### PR TITLE
Restyle the webhook spark chart onto the shared track

### DIFF
--- a/src/renderer/components/activity/activity-spark-chart.test.tsx
+++ b/src/renderer/components/activity/activity-spark-chart.test.tsx
@@ -27,6 +27,36 @@ describe('activity spark charts', () => {
     expect(tip).toHaveTextContent('1 Failed')
   })
 
+  it('draws a track per day so an empty window still reads as 14 days', () => {
+    render(<ActivitySparkChart
+      label="GitHub activity"
+      data={Array.from({ length: 14 }, (_, i) => ({
+        date: `2026-07-${String(i + 1).padStart(2, '0')}`, succeeded: 0, failed: 0,
+      }))}
+    />)
+
+    expect(screen.getAllByTestId('activity-day-track')).toHaveLength(14)
+    // Nothing ran, so no segment has height.
+    for (const bar of screen.getAllByTestId('activity-success-bar')) {
+      expect(bar).toHaveAttribute('height', '0')
+    }
+  })
+
+  it('floors a lone call so it cannot render as a sub-pixel sliver', () => {
+    render(<ActivitySparkChart
+      label="GitHub activity"
+      data={[
+        { date: '2026-07-08', succeeded: 500, failed: 0 },
+        { date: '2026-07-09', succeeded: 1, failed: 0 },
+      ]}
+    />)
+
+    const [tall, lone] = screen.getAllByTestId('activity-success-bar')
+    expect(Number(tall.getAttribute('height'))).toBeGreaterThan(10)
+    // 1/500 of the track would be ~0.04px; the floor keeps it visible.
+    expect(Number(lone.getAttribute('height'))).toBeGreaterThanOrEqual(1.5)
+  })
+
   it('keeps an all-zero series visible and truthful', () => {
     render(<ActivitySparkChart
       label="Slack activity"

--- a/src/renderer/components/activity/activity-spark-chart.test.tsx
+++ b/src/renderer/components/activity/activity-spark-chart.test.tsx
@@ -57,6 +57,28 @@ describe('activity spark charts', () => {
     expect(Number(lone.getAttribute('height'))).toBeGreaterThanOrEqual(1.5)
   })
 
+  it('keeps a floored minority segment from pushing the stack above the track', () => {
+    render(<ActivitySparkChart
+      label="GitHub activity"
+      data={[{ date: '2026-07-08', succeeded: 499, failed: 1 }]}
+    />)
+
+    const [ok] = screen.getAllByTestId('activity-success-bar')
+    const [fail] = screen.getAllByTestId('activity-failure-bar')
+    // The tallest day fills the track exactly, so a floored 1.5px failure cap
+    // would otherwise poke ~1.5px above it. Read every y in each path.
+    const ys = (el: Element) =>
+      [...el.getAttribute('d')!.matchAll(/[\d.]+,([\d.]+)/g)].map((m) => Number(m[1]))
+    const capTop = Math.min(...ys(fail))
+    const capBottom = Math.max(...ys(fail))
+    // Track spans y=1..19: the cap tops out at the track's edge, not above it.
+    expect(capTop).toBeCloseTo(1, 5)
+    expect(Math.max(...ys(ok))).toBeCloseTo(19, 5)
+    // The cap keeps its floor; the success segment gave up the excess.
+    expect(capBottom - capTop).toBeCloseTo(1.5, 5)
+    expect(Math.min(...ys(ok))).toBeCloseTo(capBottom, 5)
+  })
+
   it('squares the edge where a day\'s success and failure segments meet', () => {
     render(<ActivitySparkChart
       label="GitHub activity"

--- a/src/renderer/components/activity/activity-spark-chart.test.tsx
+++ b/src/renderer/components/activity/activity-spark-chart.test.tsx
@@ -57,6 +57,36 @@ describe('activity spark charts', () => {
     expect(Number(lone.getAttribute('height'))).toBeGreaterThanOrEqual(1.5)
   })
 
+  it('squares the edge where a day\'s success and failure segments meet', () => {
+    render(<ActivitySparkChart
+      label="GitHub activity"
+      data={[
+        { date: '2026-07-08', succeeded: 6, failed: 3 },
+        { date: '2026-07-09', succeeded: 6, failed: 0 },
+      ]}
+    />)
+
+    const [stackedOk, loneOk] = screen.getAllByTestId('activity-success-bar')
+    const [stackedFail] = screen.getAllByTestId('activity-failure-bar')
+
+    // Stacked: paths, so only the outer edge of each segment is rounded.
+    expect(stackedOk.tagName).toBe('path')
+    expect(stackedFail.tagName).toBe('path')
+    // A day with no failures keeps the plain fully-rounded rect.
+    expect(loneOk.tagName).toBe('rect')
+    expect(loneOk).toHaveAttribute('rx')
+
+    // Both paths begin at the join with a straight move, so the success
+    // segment's top and the failure segment's bottom are one flat line.
+    const startY = (el: Element) =>
+      Number(el.getAttribute('d')!.match(/^M[\d.]+,([\d.]+) /)![1])
+    expect(startY(stackedOk)).toBeCloseTo(startY(stackedFail), 5)
+
+    // And each keeps exactly one rounded end: two quadratic curves, not four.
+    expect(stackedOk.getAttribute('d')!.match(/Q/g)).toHaveLength(2)
+    expect(stackedFail.getAttribute('d')!.match(/Q/g)).toHaveLength(2)
+  })
+
   it('keeps an all-zero series visible and truthful', () => {
     render(<ActivitySparkChart
       label="Slack activity"

--- a/src/renderer/components/activity/activity-spark-chart.tsx
+++ b/src/renderer/components/activity/activity-spark-chart.tsx
@@ -53,6 +53,24 @@ const TRACK_CLASS = 'fill-muted-foreground/10'
 const MIN_SEGMENT = 1.5
 
 /**
+ * Heights of a day's success and failure segments, in track units. A non-zero
+ * count never drops below MIN_SEGMENT; when both floors together exceed the
+ * track (the tallest day with a one-call minority), the larger segment gives
+ * up the excess so the stack still ends at the track's top edge.
+ */
+function stackedHeights(succeeded: number, failed: number, max: number) {
+  const floored = (count: number) => (count > 0 ? Math.max(MIN_SEGMENT, (count / max) * TRACK_HEIGHT) : 0)
+  let success = floored(succeeded)
+  let failure = floored(failed)
+  const excess = success + failure - TRACK_HEIGHT
+  if (excess > 0) {
+    if (success >= failure) success -= excess
+    else failure -= excess
+  }
+  return { success, failure }
+}
+
+/**
  * A rect's rx rounds all four corners, so a stacked segment needs a path to
  * keep the edge where it meets its neighbour square — otherwise the successes
  * and failures of one day read as two separate bars with a pinch between them.
@@ -332,12 +350,7 @@ export function ActivitySparkChart({ label, data, className }: ActivitySparkChar
     >
       {data.map((point, index) => {
         const x = barX(index)
-        const successHeight = point.succeeded > 0
-          ? Math.max(MIN_SEGMENT, (point.succeeded / max) * TRACK_HEIGHT)
-          : 0
-        const failureHeight = point.failed > 0
-          ? Math.max(MIN_SEGMENT, (point.failed / max) * TRACK_HEIGHT)
-          : 0
+        const { success: successHeight, failure: failureHeight } = stackedHeights(point.succeeded, point.failed, max)
         return (
           <g key={point.date}>
             <rect

--- a/src/renderer/components/activity/activity-spark-chart.tsx
+++ b/src/renderer/components/activity/activity-spark-chart.tsx
@@ -52,6 +52,71 @@ const TRACK_CLASS = 'fill-muted-foreground/10'
 /** Keeps a lone call in a tall series from rendering as a sub-pixel sliver. */
 const MIN_SEGMENT = 1.5
 
+/**
+ * A rect's rx rounds all four corners, so a stacked segment needs a path to
+ * keep the edge where it meets its neighbour square — otherwise the successes
+ * and failures of one day read as two separate bars with a pinch between them.
+ */
+function segmentPath(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  radius: number,
+  round: 'top' | 'bottom',
+): string {
+  // Only one side is rounded, so the radius may use the segment's full height.
+  const r = Math.min(radius, w / 2, h)
+  return round === 'top'
+    ? `M${x},${y + h} L${x},${y + r} Q${x},${y} ${x + r},${y} `
+      + `L${x + w - r},${y} Q${x + w},${y} ${x + w},${y + r} L${x + w},${y + h} Z`
+    : `M${x},${y} L${x},${y + h - r} Q${x},${y + h} ${x + r},${y + h} `
+      + `L${x + w - r},${y + h} Q${x + w},${y + h} ${x + w},${y + h - r} L${x + w},${y} Z`
+}
+
+/** A day's success or failure segment: fully rounded alone, squared where stacked. */
+function ActivitySegment({
+  testId,
+  x,
+  y,
+  width,
+  height,
+  radius,
+  round,
+  className,
+}: {
+  testId: string
+  x: number
+  y: number
+  width: number
+  height: number
+  radius: number
+  /** 'all' when this segment stands alone; otherwise the side to keep rounded. */
+  round: 'all' | 'top' | 'bottom'
+  className: string
+}) {
+  if (round === 'all' || height <= 0) {
+    return (
+      <rect
+        data-testid={testId}
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        rx={radius}
+        className={className}
+      />
+    )
+  }
+  return (
+    <path
+      data-testid={testId}
+      d={segmentPath(x, y, width, height, radius, round)}
+      className={className}
+    />
+  )
+}
+
 interface SparkTooltipRow {
   /** Tailwind background class for the legend swatch. */
   swatch: string
@@ -285,22 +350,24 @@ export function ActivitySparkChart({ label, data, className }: ActivitySparkChar
               rx={radius}
               className={TRACK_CLASS}
             />
-            <rect
-              data-testid="activity-success-bar"
+            <ActivitySegment
+              testId="activity-success-bar"
               x={x}
               y={TRACK_BASELINE - successHeight}
               width={barWidth}
               height={successHeight}
-              rx={radius}
+              radius={radius}
+              round={failureHeight > 0 ? 'bottom' : 'all'}
               className="fill-emerald-500"
             />
-            <rect
-              data-testid="activity-failure-bar"
+            <ActivitySegment
+              testId="activity-failure-bar"
               x={x}
               y={TRACK_BASELINE - successHeight - failureHeight}
               width={barWidth}
               height={failureHeight}
-              rx={radius}
+              radius={radius}
+              round={successHeight > 0 ? 'top' : 'all'}
               className="fill-red-500"
             />
           </g>

--- a/src/renderer/components/activity/activity-spark-chart.tsx
+++ b/src/renderer/components/activity/activity-spark-chart.tsx
@@ -49,6 +49,9 @@ const TRACK_HEIGHT = HEIGHT - TRACK_INSET * 2
 const TRACK_BASELINE = HEIGHT - TRACK_INSET
 const TRACK_CLASS = 'fill-muted-foreground/10'
 
+/** Keeps a lone call in a tall series from rendering as a sub-pixel sliver. */
+const MIN_SEGMENT = 1.5
+
 interface SparkTooltipRow {
   /** Tailwind background class for the legend swatch. */
   swatch: string
@@ -264,19 +267,32 @@ export function ActivitySparkChart({ label, data, className }: ActivitySparkChar
     >
       {data.map((point, index) => {
         const x = barX(index)
-        const successHeight = (point.succeeded / max) * TRACK_HEIGHT
-        const failureHeight = (point.failed / max) * TRACK_HEIGHT
-        const zeroHeight = point.succeeded === 0 && point.failed === 0 ? 1 : 0
+        const successHeight = point.succeeded > 0
+          ? Math.max(MIN_SEGMENT, (point.succeeded / max) * TRACK_HEIGHT)
+          : 0
+        const failureHeight = point.failed > 0
+          ? Math.max(MIN_SEGMENT, (point.failed / max) * TRACK_HEIGHT)
+          : 0
         return (
           <g key={point.date}>
             <rect
+              data-testid="activity-day-track"
+              aria-hidden="true"
+              x={x}
+              y={TRACK_INSET}
+              width={barWidth}
+              height={TRACK_HEIGHT}
+              rx={radius}
+              className={TRACK_CLASS}
+            />
+            <rect
               data-testid="activity-success-bar"
               x={x}
-              y={TRACK_BASELINE - successHeight - zeroHeight}
+              y={TRACK_BASELINE - successHeight}
               width={barWidth}
-              height={successHeight + zeroHeight}
+              height={successHeight}
               rx={radius}
-              className={point.succeeded === 0 ? 'fill-muted' : 'fill-emerald-500'}
+              className="fill-emerald-500"
             />
             <rect
               data-testid="activity-failure-bar"


### PR DESCRIPTION
Moves the webhook daily chart onto the track system #972 introduces, so the two charts read as one component rather than two.

## What changed

- **A faint track per day.** The full 14-day window now reads even when most days are empty — a trigger with one busy day no longer looks like a one-day chart. This replaces the 1px stub that stood in for a zero day; the track already says the day exists.
- **Non-zero segments get a 1.5px floor.** A single call in a 500-call week was ~0.04px of track and rendered as nothing, which read as "no calls" rather than "one call".

Both charts now share `slotGeometry`, so a cron strip and a daily chart in the same row are geometrically identical: same bar width, same gap, same track positions.

- **Stacked segments meet on a flat seam.** A rect's `rx` rounds all four corners, so a day with both successes and failures drew two pill ends meeting in the middle — one day's bar read as two. A segment with a neighbour is drawn as a path keeping only its outer end rounded; a segment standing alone keeps the plain rect.

## Tests

Three added: a 14-day empty window still draws 14 tracks with zero-height segments, a lone call against a 500-call day clears the sub-pixel floor, and a stacked day's two segments start at the same y with one rounded end each.

Stacked on #972 — merge that first.

## Screenshots

| Before (#972) | After |
| --- | --- |
| ![Webhook charts before (light)](https://github.com/user-attachments/assets/a728f3df-7712-4f09-814a-5c5f92076fab) | ![Webhook charts after (light)](https://github.com/user-attachments/assets/92a46b1b-962d-43b5-b03e-e886d5ca9364) |

Look at the two webhook rows. `Deploy Notifications` and `GitHub Push` gain a track per day, so the 14-day window reads even where days are empty, and their green/red segments now meet on a flat seam instead of two pill ends. `Slack Mentions` (never fired) goes from a bare hairline to a legible empty window. The cron rows are unchanged.

![Webhook charts after (dark)](https://github.com/user-attachments/assets/99d627f5-c58a-4d1e-ab68-d75d17c719ea)


## Review follow-up

- **Floored segments no longer overshoot the track.** Each segment took the 1.5px floor independently, so on the tallest day a one-call minority pushed the stack past the track: 499 succeeded + 1 failed gave 17.96 + 1.5 = 19.46 against 18px, drawing the failure cap above the SVG. The larger segment now gives up the excess so the stack ends exactly at the track's top. Test added.

The `GitHub Push` row below is that case (a 499/1 day, fourth from the right), with the hover card from #972 on the Sep 4 column:

![Webhook row hover (light)](https://github.com/user-attachments/assets/153e4c1c-ca38-4f9b-8d5a-4eacd96e6b65)
![Webhook row hover (dark)](https://github.com/user-attachments/assets/a48af476-0999-491c-a391-de848a33d4ad)
