### PR TITLE
One metadata line per trigger row

### DIFF
--- a/src/renderer/components/agents/agent-home/home-triggers.tsx
+++ b/src/renderer/components/agents/agent-home/home-triggers.tsx
@@ -35,7 +35,6 @@ import {
   useResumeWebhookTrigger,
   type WebhookTrigger,
 } from '@renderer/hooks/use-webhook-triggers'
-import { useHumanizedCron } from '@renderer/hooks/use-humanized-cron'
 import { formatDistanceToNow } from 'date-fns'
 import { HomeCollapsible } from './home-collapsible'
 import type { ApiScheduledTask } from '@shared/lib/types/api'
@@ -213,8 +212,8 @@ export function HomeTriggers({
 
 interface TriggerRowProps {
   name: string
-  subtitleLeft: ReactNode
-  subtitleRight: ReactNode
+  /** One line: the trigger kind, then its next/last run. Nothing else. */
+  subtitle: ReactNode
   isPaused: boolean
   canTogglePause: boolean
   togglePending: boolean
@@ -234,8 +233,7 @@ interface TriggerRowProps {
 
 function TriggerRow({
   name,
-  subtitleLeft,
-  subtitleRight,
+  subtitle,
   isPaused,
   canTogglePause,
   togglePending,
@@ -272,9 +270,8 @@ function TriggerRow({
                 </span>
               )}
             </div>
-            <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground mt-0.5">
-              {subtitleLeft}
-              {subtitleRight}
+            <div className="mt-0.5 truncate text-xs text-muted-foreground">
+              {subtitle}
             </div>
           </div>
           {activityChart && <div className="shrink-0 mr-6">{activityChart}</div>}
@@ -449,7 +446,6 @@ function CronRow({
   const cancelTask = useCancelScheduledTask()
   const pauseTask = usePauseScheduledTask()
   const resumeTask = useResumeScheduledTask()
-  const humanizedCron = useHumanizedCron(task.isRecurring ? task.scheduleExpression : null)
   const isPaused = task.status === 'paused'
   const isDeleted = task.status === 'cancelled'
 
@@ -458,14 +454,13 @@ function CronRow({
       kind="cron"
       isDeleted={isDeleted}
       name={task.name ?? 'Scheduled Task'}
-      subtitleLeft={<span>cron · {humanizedCron ?? 'One-time'}</span>}
-      subtitleRight={
-        task.nextExecutionAt && !isPaused ? (
-          <span className="shrink-0">
-            <span className="text-muted-foreground">next run </span>
-            {formatDistanceToNow(new Date(task.nextExecutionAt), { addSuffix: true })}
-          </span>
-        ) : null
+      subtitle={
+        <>
+          cron
+          {task.nextExecutionAt && !isPaused ? (
+            <> · next run {formatDistanceToNow(new Date(task.nextExecutionAt), { addSuffix: true })}</>
+          ) : null}
+        </>
       }
       isPaused={isPaused}
       canTogglePause={task.isRecurring}
@@ -510,29 +505,19 @@ function WebhookRow({
   const isPaused = trigger.status === 'paused'
   const isDeleted = trigger.status === 'cancelled'
   const displayName = trigger.name ?? trigger.triggerType
-  const isCustom = trigger.kind === 'custom'
 
   return (
     <TriggerRow
       kind="webhook"
       isDeleted={isDeleted}
       name={displayName}
-      subtitleLeft={
-        <span className="truncate lowercase">
-          {isCustom ? 'webhook · custom endpoint' : `webhook · ${trigger.triggerType}`}
-        </span>
-      }
-      subtitleRight={
-        <span className="shrink-0">
-          {trigger.lastFiredAt ? (
-            <>
-              <span className="text-muted-foreground">last run </span>
-              {formatDistanceToNow(new Date(trigger.lastFiredAt), { addSuffix: true })}
-            </>
-          ) : (
-            'No runs yet'
-          )}
-        </span>
+      subtitle={
+        <>
+          webhook
+          {trigger.lastFiredAt
+            ? <> · last run {formatDistanceToNow(new Date(trigger.lastFiredAt), { addSuffix: true })}</>
+            : <> · no runs yet</>}
+        </>
       }
       isPaused={isPaused}
       canTogglePause


### PR DESCRIPTION
Fixes the trigger row metadata line, which wrapped or truncated depending on which trigger you were looking at.

## The bug

The subtitle was two competing slots in a `justify-between` row with the timestamp pinned `shrink-0`, so the left side always lost:

- **cron** — a bare `<span>` with no truncation, so a long humanized schedule wrapped to a second line and pushed the row taller.
- **webhook** — had `truncate`, so it was crushed to `webhook · custom en…`.

Either way the timestamp floated mid-row instead of aligning.

## The fix

One truncating line carrying only the trigger kind and its next/last run:

```
cron · next run in about 1 hour
webhook · last run 40 minutes ago
```

The humanized cron expression and the trigger type are gone from the row — both are still on the detail page, and `useHumanizedCron` is unchanged for the scheduled-task view and the graph.

Edge cases: a webhook that has never fired reads `webhook · no runs yet`; a paused or one-time cron with no next run reads just `cron`.

## Not included

The "Called from Other Agents" x-agent row still uses the old two-slot pattern with its own inline markup rather than going through `TriggerRow`. Its string is short today so it does not visibly break, but it is the same latent bug — happy to fold it in if you want.

Stacked on #973 — merge bottom-up.

## Screenshots

| Before (#973) | After |
| --- | --- |
| ![Trigger rows before (light)](https://github.com/user-attachments/assets/45f971b5-53ec-4d56-ab31-cd11e23974ee) | ![Trigger rows after (light)](https://github.com/user-attachments/assets/b4d46bf7-3904-4eab-b00b-8979ba764138) |

`Daily Hello` and `Hourly Sync` drop from three and two lines to one; `webhook · cust…` and `webhook · githu…` stop being crushed; the timestamps stop floating mid-row. Row heights become uniform as a result.

![Trigger rows after (dark)](https://github.com/user-attachments/assets/8c9746bd-4870-447a-9fb5-4912145e2c10)
