### PR TITLE
feat(uploads): put the timestamp after the filename, not before

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -3492,7 +3492,7 @@ describe('file upload with relativePath — POST /:id/upload-file', () => {
     const res = await postFormData(app, '/api/agents/test-agent/upload-file', formData)
     expect(res.status).toBe(200)
     const body = await res.json()
-    expect(body.path).toMatch(/\/workspace\/uploads\/\d+-test\.txt/)
+    expect(body.path).toMatch(/\/workspace\/uploads\/test-\d{13}\.txt/)
     expect(body.success).toBe(true)
   })
 

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -191,7 +191,7 @@ import { getConfiguredLlmClient, createSummarizerText } from '@shared/lib/llm-pr
 import { getActiveLlmProvider, resolveActiveProviderModel } from '@shared/lib/llm-provider'
 import { revokeProxyToken } from '@shared/lib/proxy/token-store'
 import { getAgentWorkspaceDir } from '@shared/lib/utils/file-storage'
-import { isPathWithinDir, isRealPathWithinDir, sanitizeUploadFilename } from '@shared/lib/utils/path-safety'
+import { isPathWithinDir, isRealPathWithinDir, sanitizeUploadFilename, withUploadTimestamp } from '@shared/lib/utils/path-safety'
 import { AGENT_PACKAGE_EXTENSION, SKILL_PACKAGE_EXTENSION } from '@shared/lib/utils/package-extensions'
 import { readAgentPreferences, updateAgentPreferences } from '@shared/lib/services/agent-preferences-service'
 import { agentPreferencesUpdateSchema } from '@shared/lib/types/agent-preferences'
@@ -5934,7 +5934,7 @@ function resolveUploadDestPath(agentSlug: string, filename: string, relativePath
     // Single-file upload: collapse the untrusted name to a safe basename
     // (shared with the chat-attachment write path). isPathWithinDir below is
     // the defense-in-depth backstop.
-    uploadPath = `uploads/${Date.now()}-${sanitizeUploadFilename(filename)}`
+    uploadPath = `uploads/${withUploadTimestamp(sanitizeUploadFilename(filename))}`
   }
 
   const workspaceDir = getAgentWorkspaceDir(agentSlug)

--- a/src/shared/lib/chat-integrations/chat-integration-manager.sup231.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.sup231.test.ts
@@ -67,7 +67,7 @@ describe('SUP-231 writeToWorkspace path containment', () => {
 
     // The (sanitized) file must land strictly under uploads.
     const inUploads = fs.existsSync(uploadsDir)
-      ? fs.readdirSync(uploadsDir).filter((f) => f.endsWith('oauth-token.txt'))
+      ? fs.readdirSync(uploadsDir).filter((f) => /^oauth-token-\d{13}\.txt$/.test(f))
       : []
     expect(inUploads.length).toBe(1)
   })
@@ -88,14 +88,14 @@ describe('SUP-231 writeToWorkspace path containment', () => {
     expect(path.isAbsolute(rel)).toBe(false)
   })
 
-  it('writes a normal filename to uploads/<digits>-<name> and returns the workspace path', async () => {
+  it('writes a normal filename to uploads/<name>-<digits>.<ext> and returns the workspace path', async () => {
     const { uploadsDir } = workspacePaths()
     const result = await writeToWorkspace('report.pdf', Buffer.from('pdf-bytes'))
 
-    expect(result).toMatch(/^\/workspace\/uploads\/\d+-report\.pdf$/)
+    expect(result).toMatch(/^\/workspace\/uploads\/report-\d{13}\.pdf$/)
     const files = fs.readdirSync(uploadsDir)
     expect(files).toHaveLength(1)
-    expect(files[0]).toMatch(/^\d+-report\.pdf$/)
+    expect(files[0]).toMatch(/^report-\d{13}\.pdf$/)
     const written = fs.readFileSync(path.join(uploadsDir, files[0]), 'utf8')
     expect(written).toBe('pdf-bytes')
   })

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -40,7 +40,7 @@ import {
   resolveActiveSession,
   getLastDisplayName,
 } from '@shared/lib/services/chat-integration-session-service'
-import { assertPathWithinDir, isPathWithinDir, sanitizeUploadFilename } from '@shared/lib/utils/path-safety'
+import { assertPathWithinDir, isPathWithinDir, sanitizeUploadFilename, withUploadTimestamp } from '@shared/lib/utils/path-safety'
 import { isHostOrSubdomain, tryParseUrl } from '@shared/lib/utils/url-safety'
 import type { ContainerClient } from '@shared/lib/container/types'
 import { resolveRuntimeInherit } from '@shared/lib/container/runtime-options'
@@ -1540,7 +1540,7 @@ class ChatIntegrationManager {
     // External attachment names are attacker-controlled — sanitize to a safe
     // basename so `../` segments cannot escape the uploads directory (SUP-231).
     const safeName = sanitizeUploadFilename(filename)
-    const uploadName = `${Date.now()}-${safeName}`
+    const uploadName = withUploadTimestamp(safeName)
     const workspaceDir = getAgentWorkspaceDir(agentSlug)
     const uploadsDir = path.resolve(workspaceDir, 'uploads')
     const fullPath = path.resolve(uploadsDir, uploadName)

--- a/src/shared/lib/utils/path-safety.test.ts
+++ b/src/shared/lib/utils/path-safety.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import * as fs from 'fs'
 import * as os from 'os'
 import path from 'path'
-import { isPathWithinDir, assertPathWithinDir, isRealPathWithinDir, sanitizeUploadFilename } from './path-safety'
+import { isPathWithinDir, assertPathWithinDir, isRealPathWithinDir, sanitizeUploadFilename, withUploadTimestamp } from './path-safety'
 
 // ---------------------------------------------------------------------------
 // Path containment guard (SUP-200 generalization). The motivating bug: a bare
@@ -187,5 +187,27 @@ describe('isRealPathWithinDir', () => {
     const link = path.join(base, 'alias.jsonl')
     fs.symlinkSync(real, link)
     expect(isRealPathWithinDir(base, link)).toBe(true)
+  })
+})
+
+describe('withUploadTimestamp', () => {
+  const NOW = 1788459888315
+
+  it('puts the timestamp between the stem and the extension', () => {
+    expect(withUploadTimestamp('report.pdf', NOW)).toBe('report-1788459888315.pdf')
+    expect(withUploadTimestamp('archive.tar.gz', NOW)).toBe('archive.tar-1788459888315.gz')
+  })
+
+  it('appends the timestamp when there is no extension', () => {
+    expect(withUploadTimestamp('README', NOW)).toBe('README-1788459888315')
+    expect(withUploadTimestamp('.env', NOW)).toBe('.env-1788459888315')
+  })
+
+  it('defaults to the current time', () => {
+    const before = Date.now()
+    const name = withUploadTimestamp('a.txt')
+    const stamp = Number(name.match(/^a-(\d+)\.txt$/)?.[1])
+    expect(stamp).toBeGreaterThanOrEqual(before)
+    expect(stamp).toBeLessThanOrEqual(Date.now())
   })
 })

--- a/src/shared/lib/utils/path-safety.ts
+++ b/src/shared/lib/utils/path-safety.ts
@@ -131,3 +131,17 @@ export function sanitizeUploadFilename(filename: string): string {
   if (base === '' || base === '.' || base === '..') return 'file'
   return base
 }
+
+/**
+ * Storage name for an uploaded file: the (already sanitized) name with a
+ * millisecond timestamp between the stem and the extension —
+ * `report.pdf` → `report-1788459888315.pdf` — so repeat uploads never collide
+ * while the name stays readable and sorts by its original stem. Dotless
+ * names get the suffix at the end. Pair with `sanitizeUploadFilename`.
+ */
+export function withUploadTimestamp(safeName: string, now: number = Date.now()): string {
+  const dot = safeName.lastIndexOf('.')
+  // A leading dot is not an extension separator.
+  if (dot <= 0) return `${safeName}-${now}`
+  return `${safeName.slice(0, dot)}-${now}${safeName.slice(dot)}`
+}


### PR DESCRIPTION
## Summary

Uploaded files are now stored as `report-1788459888315.pdf` instead of `1788459888315-report.pdf`, so names stay readable and sort by their original stem.

- One helper, `withUploadTimestamp`, lives next to `sanitizeUploadFilename` in path-safety and is used by both producers: the upload route and chat-integration attachments.
- Dotless names get the suffix at the end (`README-1788459888315`); multi-dot names keep only the last extension after the stamp (`archive.tar-…​.gz`).
- Independent of the file-drawer PR stack. The display-side name cleaning in #948 is being taught the new form in a follow-up commit there.

## Test plan

- [x] `npm run typecheck`, lint on touched files
- [x] path-safety tests (new cases for the helper), chat-integration containment tests, and the API upload-route test updated to the new pattern and passing
- [ ] Manual: upload a file in a session and confirm the stored name under `/workspace/uploads/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
