### PR TITLE
feat(workflows): real agent labels and per-agent model in the workflow tab

### DIFF
--- a/src/renderer/components/messages/subagent-block.tsx
+++ b/src/renderer/components/messages/subagent-block.tsx
@@ -9,6 +9,8 @@ import { parseToolResult } from '@renderer/lib/parse-tool-result'
 import type { ApiToolCall, ApiMessage } from '@shared/lib/types/api'
 import type { SubagentInfo } from '@renderer/hooks/use-message-stream'
 import { formatElapsed } from '@renderer/hooks/use-elapsed-timer'
+import { formatModelSlug } from '@renderer/lib/model-label'
+import { modelSlugFromAgentType } from '@shared/lib/workflows/workflow-schemas'
 
 const SUBAGENT_LABEL_CLASS =
   'font-sans font-normal shrink-0 text-sm text-foreground/65 group-hover:text-foreground leading-none transition-colors'
@@ -31,24 +33,8 @@ function formatTokens(tokens: number): string {
 }
 
 export function displaySubagentType(subagentType: string): string {
-  const modelType = /^model-(.+)-[a-z0-9]{7}$/.exec(subagentType)
-  if (!modelType) return subagentType
-
-  const parts = modelType[1]
-    .split('-')
-    .map((part) => {
-      if (!/^[a-z]+$/.test(part)) return part
-      return part.length <= 4
-        ? part.toUpperCase()
-        : `${part[0].toUpperCase()}${part.slice(1)}`
-    })
-
-  return parts.reduce((label, part, index) => {
-    const separator = index > 0 && /^\d+$/.test(part) && /^\d+$/.test(parts[index - 1])
-      ? '.'
-      : index > 0 ? ' ' : ''
-    return `${label}${separator}${part}`
-  }, '')
+  const slug = modelSlugFromAgentType(subagentType)
+  return slug ? formatModelSlug(slug) : subagentType
 }
 
 export function SubAgentBlock({

--- a/src/renderer/components/workflow/workflow-tray-content.test.ts
+++ b/src/renderer/components/workflow/workflow-tray-content.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { overlayLiveStatus, progressSummary, workflowProgressSegments } from './workflow-tray-content'
+import { overlayLiveStatus, phaseModels, progressSummary, workflowProgressSegments } from './workflow-tray-content'
 import type { WorkflowAgentNode } from '@shared/lib/workflows/workflow-schemas'
 
 function node(over: Partial<WorkflowAgentNode>): WorkflowAgentNode {
@@ -14,6 +14,7 @@ function node(over: Partial<WorkflowAgentNode>): WorkflowAgentNode {
     toolCount: 0,
     tokens: 0,
     durationMs: null,
+    model: null,
     ...over,
   }
 }
@@ -72,6 +73,36 @@ describe('overlayLiveStatus', () => {
       a: { status: 'running', result: null, tokens: 500, toolCount: 3, lastTool: 'Bash sleep 40' },
     })
     expect(out[0]).toMatchObject({ tokens: 500, toolCount: 3, lastTool: 'Bash sleep 40' })
+  })
+})
+
+describe('overlayLiveStatus — labels', () => {
+  it('prefers the wire label over the disk re-join (which can degrade to "agent N")', () => {
+    const out = overlayLiveStatus([node({ label: 'agent 1' })], {
+      a: { status: 'running', result: null, label: 'qualify:closera' },
+    })
+    expect(out[0].label).toBe('qualify:closera')
+  })
+
+  it('keeps the disk label when the wire carries none (reload of a finished run)', () => {
+    const out = overlayLiveStatus([node({ label: 'qualify:moda' })], { a: { status: 'done', result: null } })
+    expect(out[0].label).toBe('qualify:moda')
+  })
+})
+
+describe('phaseModels', () => {
+  it('lists distinct model labels in first-seen order, skipping unknowns', () => {
+    const agents = [
+      node({ model: 'claude-haiku-4-5-20251001' }),
+      node({ model: null }),
+      node({ model: 'haiku-4-5' }), // meta.json slug form of the same model
+      node({ model: 'claude-sonnet-5' }),
+    ]
+    expect(phaseModels(agents)).toEqual(['Haiku 4.5', 'Sonnet 5'])
+  })
+
+  it('is empty when no agent has a known model', () => {
+    expect(phaseModels([node({}), node({})])).toEqual([])
   })
 })
 

--- a/src/renderer/components/workflow/workflow-tray-content.tsx
+++ b/src/renderer/components/workflow/workflow-tray-content.tsx
@@ -6,6 +6,7 @@ import { useMessageStream, type WorkflowAgentLive } from '@renderer/hooks/use-me
 import { useWorkflowTree, useWorkflowAgentMessages } from '@renderer/hooks/use-messages'
 import { StatusIndicator } from '@renderer/components/messages/tool-call-item'
 import { formatElapsed } from '@renderer/hooks/use-elapsed-timer'
+import { formatModelId } from '@renderer/lib/model-label'
 import { WorkflowAgentTranscript } from './workflow-agent-transcript'
 import type { WorkflowAgentNode } from '@shared/lib/workflows/workflow-schemas'
 
@@ -77,12 +78,30 @@ export function overlayLiveStatus(
       ...a,
       status,
       result: a.result ?? live.result ?? null,
+      // The wire label is the one the script actually passed to agent(); the disk
+      // label is a heuristic re-join of prompt ↔ call site that degrades to "agent N"
+      // when a label variable can't be recovered from the prompt text. Prefer the
+      // wire while it's flowing; disk covers reloads of finished runs.
+      label: live.label ?? a.label,
       // Live tokens/tools are fresher than the ~2s disk poll; fall back to disk on reload.
       tokens: live.tokens ?? a.tokens,
       toolCount: live.toolCount ?? a.toolCount,
       lastTool: live.lastTool ?? null,
     }
   })
+}
+
+/**
+ * Distinct model labels across a phase's agents, in first-seen order — the
+ * phase header shows "Haiku 4.5" for a uniform fan-out, or "Haiku 4.5 · Sonnet 5"
+ * when a phase mixes models (e.g. a cheap pass plus a critic).
+ */
+export function phaseModels(agents: Pick<WorkflowAgentNode, 'model'>[]): string[] {
+  const seen = new Set<string>()
+  for (const a of agents) {
+    if (a.model) seen.add(formatModelId(a.model))
+  }
+  return [...seen]
 }
 
 export type ProgressSegment = 'done' | 'running' | 'failed' | 'pending'
@@ -173,7 +192,9 @@ export function WorkflowTrayContent({ agentSlug, sessionId, onClose }: WorkflowT
     : ''
   const refetchTree = treeQuery.refetch
   useEffect(() => {
-    if (selectedRunId && liveSignal) refetchTree()
+    // Don't cancel a request already in flight: a wide fan-out transitions every
+    // few seconds, and restarting the fetch on each one could starve a slow host.
+    if (selectedRunId && liveSignal) refetchTree({ cancelRefetch: false })
   }, [liveSignal, selectedRunId, refetchTree])
 
   const groups = useMemo<PhaseGroup[]>(() => {
@@ -200,7 +221,9 @@ export function WorkflowTrayContent({ agentSlug, sessionId, onClose }: WorkflowT
     return ordered
   }, [agents, treeQuery.data])
 
-  const name = openWorkflows.find((w) => w.runId === selectedRunId)?.name ?? treeQuery.data?.name ?? 'Workflow'
+  // The script's own meta.name is authoritative; the name the drawer was opened with is
+  // whatever the launching card had (for a scriptPath run, only a generic fallback).
+  const name = treeQuery.data?.name ?? openWorkflows.find((w) => w.runId === selectedRunId)?.name ?? 'Workflow'
   // Prefer the live wire usage (cumulative, accurate); fall back to the disk rollup.
   const totals = liveRun?.usage
     ? { durationMs: liveRun.usage.durationMs, toolCount: liveRun.usage.toolUses, tokens: liveRun.usage.totalTokens }
@@ -274,6 +297,11 @@ export function WorkflowTrayContent({ agentSlug, sessionId, onClose }: WorkflowT
                 {group.detail && (
                   <span className="text-[11px] text-muted-foreground truncate">{group.detail}</span>
                 )}
+                {phaseModels(group.agents).length > 0 && (
+                  <span className="ml-auto shrink-0 text-[10px] text-muted-foreground/70 whitespace-nowrap">
+                    {phaseModels(group.agents).join(' · ')}
+                  </span>
+                )}
               </div>
             )}
             {group.agents.map((a) => (
@@ -323,6 +351,8 @@ function WorkflowAgentRow({
     <div className="border border-border/70 rounded-md overflow-hidden">
       <button
         onClick={onToggle}
+        data-testid="workflow-agent-row"
+        data-agent-label={agent.label}
         className={cn(
           'flex w-full items-center gap-2 px-2 py-1.5 group hover:bg-muted/50 transition-colors',
           expanded && 'bg-muted/50'
@@ -333,6 +363,14 @@ function WorkflowAgentRow({
         </span>
         {/* shrink-0 + cap: a long result/tool string must truncate itself, not crush the label to zero width */}
         <span className="text-xs text-foreground/80 truncate shrink-0 max-w-[70%]">{agent.label}</span>
+        {agent.model && (
+          <span
+            className="shrink-0 rounded px-1 py-px text-[10px] leading-tight bg-muted text-muted-foreground/80"
+            title={agent.model}
+          >
+            {formatModelId(agent.model)}
+          </span>
+        )}
         {/* While running, show the current tool (live from the wire). */}
         {isRunning && agent.lastTool && (
           <>
@@ -364,6 +402,13 @@ function WorkflowAgentRow({
             </div>
           )}
           <StatsLine durationMs={agent.durationMs} toolCount={agent.toolCount} tokens={agent.tokens} />
+          {agent.model && (
+            <div className="text-[11px] text-muted-foreground break-words">
+              <span className="font-medium text-foreground/70">Model: </span>
+              {formatModelId(agent.model)}
+              <span className="text-muted-foreground/60"> ({agent.model})</span>
+            </div>
+          )}
           {(agent.status === 'done' || agent.status === 'failed') && agent.result && (
             <div className="text-[11px] break-words">
               <span className="font-medium text-foreground/70">

--- a/src/renderer/hooks/use-messages.ts
+++ b/src/renderer/hooks/use-messages.ts
@@ -481,7 +481,10 @@ export function useWorkflowTree(
     queryFn: async ({ signal }) => {
       const res = await apiFetch(
         `/api/agents/${agentSlug}/sessions/${sessionId}/workflows/${runId}/tree`,
-        { signal }
+        // The route answers in milliseconds from local disk; a request that hangs
+        // (stalled connection, host busy) must fail fast so the poll below retries
+        // it instead of pinning the drawer on "Loading…".
+        { signal: AbortSignal.any([signal, AbortSignal.timeout(WORKFLOW_TREE_TIMEOUT_MS)]) }
       )
       if (!res.ok) throw new Error('Failed to fetch workflow tree')
       return res.json()
@@ -491,9 +494,15 @@ export function useWorkflowTree(
     // (the tree route 404s), and new agents/labels appear as the run progresses. Stops once
     // the workflow completes (SSE-driven refetch handles the final state).
     refetchInterval: opts?.active ? 2000 : false,
-    retry: opts?.active ? 5 : false,
+    // No built-in retries: the poll IS the retry. Query retries back off
+    // exponentially (1s, 2s, 4s, 8s, 16s) and the whole sequence renders as the
+    // initial "Loading…" state, so a launch-window 404 would hide behind a
+    // half-minute spinner instead of surfacing as "Starting workflow…" at once.
+    retry: false,
   })
 }
+
+const WORKFLOW_TREE_TIMEOUT_MS = 10_000
 
 /**
  * One workflow subagent's transcript (same shape as a regular subagent). Polls

--- a/src/renderer/lib/model-label.test.ts
+++ b/src/renderer/lib/model-label.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { formatModelId, formatModelSlug } from './model-label'
+
+describe('formatModelSlug', () => {
+  it('title-cases words, upper-cases short ones, and dots adjacent version parts', () => {
+    expect(formatModelSlug('haiku-4-5')).toBe('Haiku 4.5')
+    expect(formatModelSlug('sonnet-5')).toBe('Sonnet 5')
+    expect(formatModelSlug('gpt-5')).toBe('GPT 5')
+  })
+})
+
+describe('formatModelId', () => {
+  it('drops the claude- prefix and a trailing date stamp', () => {
+    expect(formatModelId('claude-haiku-4-5-20251001')).toBe('Haiku 4.5')
+    expect(formatModelId('claude-fable-5-1')).toBe('Fable 5.1')
+    expect(formatModelId('claude-opus-4-6')).toBe('Opus 4.6')
+  })
+
+  it('passes a bare slug (meta.json form) through unchanged in meaning', () => {
+    expect(formatModelId('haiku-4-5')).toBe('Haiku 4.5')
+  })
+})

--- a/src/renderer/lib/model-label.ts
+++ b/src/renderer/lib/model-label.ts
@@ -1,0 +1,25 @@
+/**
+ * Human labels for model identifiers as they appear on disk and on the wire:
+ *   - a full API id from a transcript (`claude-haiku-4-5-20251001`, `claude-fable-5-1`)
+ *   - the slug inside a model-only agent type (`model-haiku-4-5-1cbdtsn` → `haiku-4-5`)
+ * Both collapse to "Haiku 4.5" / "Fable 5.1": initialisms (three letters or
+ * fewer, e.g. GPT) are upper-cased, names title-cased (Opus, Grok), and adjacent
+ * numeric parts join with a dot.
+ */
+export function formatModelSlug(slug: string): string {
+  const parts = slug.split('-').filter(Boolean).map((part) => {
+    if (!/^[a-z]+$/.test(part)) return part
+    return part.length <= 3 ? part.toUpperCase() : `${part[0].toUpperCase()}${part.slice(1)}`
+  })
+  return parts.reduce((label, part, index) => {
+    const separator =
+      index > 0 && /^\d+$/.test(part) && /^\d+$/.test(parts[index - 1]) ? '.' : index > 0 ? ' ' : ''
+    return `${label}${separator}${part}`
+  }, '')
+}
+
+/** A full model id → label: drops the `claude-` vendor prefix and a trailing date stamp. */
+export function formatModelId(modelId: string): string {
+  const slug = modelId.replace(/^claude-/, '').replace(/-\d{8}$/, '')
+  return formatModelSlug(slug)
+}

--- a/src/shared/lib/workflows/workflow-schemas.ts
+++ b/src/shared/lib/workflows/workflow-schemas.ts
@@ -56,6 +56,22 @@ export const JournalLineSchema = z.discriminatedUnion('type', [
 ])
 export type JournalLine = z.infer<typeof JournalLineSchema>
 
+// --- agent-<id>.meta.json: written at spawn, before the first model turn -----
+
+export const AgentMetaSchema = z.object({
+  /** The agent definition the workflow spawned with. A model-only agent is
+   *  `model-<model slug>-<7-char hash>` (e.g. `model-haiku-4-5-1cbdtsn`). */
+  agentType: z.string().optional(),
+})
+export type AgentMeta = z.infer<typeof AgentMetaSchema>
+
+/** The model slug baked into a `model-<slug>-<hash>` agentType, or null. */
+export function modelSlugFromAgentType(agentType: string | undefined): string | null {
+  if (!agentType) return null
+  const m = /^model-(.+)-[a-z0-9]{7}$/.exec(agentType)
+  return m ? m[1] : null
+}
+
 // --- parsed workflow script (output of workflow-script-parser) -------------
 
 export const WorkflowPhaseSchema = z.object({
@@ -116,6 +132,10 @@ export const WorkflowAgentNodeSchema = z.object({
   tokens: z.number().int().nonnegative(),
   /** Wall-clock span of the agent's transcript so far, or null if not derivable. */
   durationMs: z.number().int().nonnegative().nullable(),
+  /** The model the agent runs on: the transcript's first assistant turn (a full
+   *  id like `claude-haiku-4-5-20251001`), falling back to the slug in the
+   *  meta.json agentType (`haiku-4-5`) before that turn lands; null if unknown. */
+  model: z.string().nullable(),
 })
 export type WorkflowAgentNode = z.infer<typeof WorkflowAgentNodeSchema>
 

--- a/src/shared/lib/workflows/workflow-tree.test.ts
+++ b/src/shared/lib/workflows/workflow-tree.test.ts
@@ -49,6 +49,9 @@ describe('buildWorkflowTree — real capture-probe fixture', () => {
 
     // Per-agent metadata derived from the transcript.
     expect(byId.get('ae6ffae379942dd19')!.prompt).toBe('Return ONLY the single word: alpha')
+    // The model comes from the first assistant turn; the fixture's meta.json is a
+    // named agent type (`workflow-subagent`), which carries no model on its own.
+    expect(byId.get('ae6ffae379942dd19')!.model).toBe('claude-opus-4-6')
     expect(byId.get('a7720e731ec4c42db')!.prompt).toContain('Concatenate')
     for (const a of tree!.agents) {
       expect(a.toolCount).toBeGreaterThanOrEqual(0)
@@ -111,7 +114,13 @@ afterEach(async () => {
 async function scaffold(opts: {
   script: string
   journal: Array<Record<string, unknown>>
-  agents: Array<{ agentId: string; firstPrompt: string; extraLines?: Array<Record<string, unknown>> }>
+  agents: Array<{
+    agentId: string
+    firstPrompt: string
+    extraLines?: Array<Record<string, unknown>>
+    /** Written as the agent's `.meta.json` sidecar when given. */
+    meta?: Record<string, unknown>
+  }>
 }): Promise<string> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-tree-'))
   tmpDirs.push(root)
@@ -127,6 +136,7 @@ async function scaffold(opts: {
       ...(a.extraLines ?? []),
     ]
     await fs.writeFile(path.join(runDir, `agent-${a.agentId}.jsonl`), lines.map((l) => JSON.stringify(l)).join('\n') + '\n')
+    if (a.meta) await fs.writeFile(path.join(runDir, `agent-${a.agentId}.meta.json`), JSON.stringify(a.meta))
   }
   await fs.writeFile(path.join(root, sid, 'workflows', 'scripts', `probe-${run}.js`), opts.script)
   return root
@@ -179,6 +189,73 @@ describe('buildWorkflowTree — synthetic edge cases', () => {
       result: '{"score":9}',
       resolved: 'prompt-regex',
     })
+  })
+
+  it('resolves a label var through a JSON.stringify(record) prompt hole (qualify:${c.slug})', async () => {
+    // The "here's the whole record" fan-out shape: the label reads one field of a
+    // record the prompt only embeds as pretty-printed JSON.
+    const script = [
+      "export const meta = { name: 'q', description: 'd', phases: [{ title: 'Qualify' }] }",
+      "phase('Qualify')",
+      'const r = await pipeline(args.companies, c => agent(`Evaluate this company:\\n${JSON.stringify(c, null, 1)}\\n\\nFetch ${c.website} first.`, { label: `qualify:${c.slug}`, phase: \'Qualify\' }))',
+    ].join('\n')
+    const company = { slug: 'vibeflow', website: 'https://vibeflow.ai/', team_size: 3 }
+    const root = await scaffold({
+      script,
+      journal: [{ type: 'started', key: 'v2:1', agentId: 'q1' }],
+      agents: [
+        {
+          agentId: 'q1',
+          firstPrompt: `Evaluate this company:\n${JSON.stringify(company, null, 1)}\n\nFetch https://vibeflow.ai/ first.`,
+        },
+      ],
+    })
+    const tree = await buildWorkflowTree({ sessionsDir: root, sessionId: 's1', runId: 'wf_test' })
+    expect(tree!.agents[0]).toMatchObject({ label: 'qualify:vibeflow', phase: 'Qualify', resolved: 'prompt-regex' })
+    // Sized from the invocation's args when present; here there's no invocation, so 1 call site.
+    expect(tree!.expectedAgents).toBe(1)
+  })
+
+  it('reads the model from the first assistant turn, and from meta.json before one lands', async () => {
+    const script = [
+      "export const meta = { name: 'm', description: 'd', phases: [{ title: 'P' }] }",
+      "phase('P')",
+      "const a = await agent('Do A', { label: 'a', agentType: args.agentType })",
+      "const b = await agent('Do B', { label: 'b', agentType: args.agentType })",
+      "const c = await agent('Do C', { label: 'c' })",
+    ].join('\n')
+    const root = await scaffold({
+      script,
+      journal: [
+        { type: 'started', key: 'v2:1', agentId: 'm1' },
+        { type: 'started', key: 'v2:2', agentId: 'm2' },
+        { type: 'started', key: 'v2:3', agentId: 'm3' },
+      ],
+      agents: [
+        {
+          // Has replied: the transcript's model id wins over the meta slug.
+          agentId: 'm1',
+          firstPrompt: 'Do A',
+          meta: { agentType: 'model-haiku-4-5-1cbdtsn', spawnDepth: 1 },
+          extraLines: [
+            {
+              type: 'assistant',
+              timestamp: '2026-01-01T00:00:01.000Z',
+              message: { model: 'claude-haiku-4-5-20251001', role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+            },
+          ],
+        },
+        // Just spawned: only the meta.json sidecar exists.
+        { agentId: 'm2', firstPrompt: 'Do B', meta: { agentType: 'model-haiku-4-5-1cbdtsn', spawnDepth: 1 } },
+        // A named agent type carries no model.
+        { agentId: 'm3', firstPrompt: 'Do C', meta: { agentType: 'workflow-subagent' } },
+      ],
+    })
+    const tree = await buildWorkflowTree({ sessionsDir: root, sessionId: 's1', runId: 'wf_test' })
+    const byId = new Map(tree!.agents.map((a) => [a.agentId, a]))
+    expect(byId.get('m1')!.model).toBe('claude-haiku-4-5-20251001')
+    expect(byId.get('m2')!.model).toBe('haiku-4-5')
+    expect(byId.get('m3')!.model).toBeNull()
   })
 
   it('falls back to the transcript-referenced script for scriptPath invocations', async () => {

--- a/src/shared/lib/workflows/workflow-tree.ts
+++ b/src/shared/lib/workflows/workflow-tree.ts
@@ -5,17 +5,19 @@ import { isPathWithinDir } from '../utils/path-safety'
 import { streamJsonlFile } from '../utils/file-storage'
 import { parseWorkflowScript } from './workflow-script-parser'
 import {
+  AgentMetaSchema,
   JournalLineSchema,
   WorkflowTreeSchema,
   displayAgentResult,
+  modelSlugFromAgentType,
   type ParsedScript,
   type WorkflowAgentNode,
   type WorkflowTree,
 } from './workflow-schemas'
 
 // The join produces the structural fields; per-agent transcript stats (prompt,
-// toolCount, tokens, durationMs) are layered on afterwards from readAgentStats.
-type JoinedAgent = Omit<WorkflowAgentNode, 'prompt' | 'toolCount' | 'tokens' | 'durationMs'>
+// toolCount, tokens, durationMs, model) are layered on afterwards from readAgentStats.
+type JoinedAgent = Omit<WorkflowAgentNode, 'prompt' | 'toolCount' | 'tokens' | 'durationMs' | 'model'>
 
 /**
  * How many agent transcripts readAgentStats has open concurrently. Peak memory
@@ -92,7 +94,13 @@ export async function buildWorkflowTree(opts: {
   await Promise.all(
     startedOrder.map((agentId) =>
       statsLimit(async () => {
-        stats.set(agentId, await readAgentStats(path.join(runDir, `agent-${agentId}.jsonl`)))
+        const s = await readAgentStats(path.join(runDir, `agent-${agentId}.jsonl`))
+        // The transcript names the model only once the first assistant turn lands;
+        // the meta.json sidecar is written at spawn, so it fills the gap.
+        if (s.model === null) {
+          s.model = await readAgentMetaModel(path.join(runDir, `agent-${agentId}.meta.json`))
+        }
+        stats.set(agentId, s)
       })
     )
   )
@@ -112,6 +120,7 @@ export async function buildWorkflowTree(opts: {
       toolCount: s?.toolCount ?? 0,
       tokens: s?.tokens ?? 0,
       durationMs: s && s.firstTs != null && s.lastTs != null ? Math.max(0, s.lastTs - s.firstTs) : null,
+      model: s?.model ?? null,
     }
   })
 
@@ -202,12 +211,52 @@ function resolveLabel(
   if (!label.includes('${')) return label
   let unresolved = false
   label = label.replace(/\$\{([^}]*)\}/g, (_m, expr: string) => {
-    const i = call.holeExprs.indexOf(expr.trim())
+    const e = expr.trim()
+    const i = call.holeExprs.indexOf(e)
     if (i >= 0 && i < captures.length) return captures[i]
+    const viaJson = resolveFromJsonHole(e, call.holeExprs, captures)
+    if (viaJson !== null) return viaJson
     unresolved = true
     return ''
   })
   return unresolved ? fallback : label
+}
+
+/**
+ * A label hole like `${c.slug}` whose variable never appears bare in the prompt
+ * but IS embedded whole as `${JSON.stringify(c, ...)}` (the common "here's the
+ * record" fan-out shape): parse that capture and read the property path off it.
+ * Returns null when the shape doesn't apply or the capture isn't valid JSON.
+ */
+function resolveFromJsonHole(labelExpr: string, holeExprs: string[], captures: string[]): string | null {
+  const pathMatch = /^([A-Za-z_$][\w$]*)((?:\.[A-Za-z_$][\w$]*)+)$/.exec(labelExpr)
+  if (!pathMatch) return null
+  const root = pathMatch[1]
+  const props = pathMatch[2].slice(1).split('.')
+  const rootRe = new RegExp(`^JSON\\.stringify\\(\\s*${root.replace(/\$/g, '\\$')}\\s*[,)]`)
+  const i = holeExprs.findIndex((h) => rootRe.test(h))
+  if (i < 0 || i >= captures.length) return null
+  let value: unknown
+  try {
+    value = JSON.parse(captures[i])
+  } catch {
+    return null
+  }
+  for (const p of props) {
+    if (value === null || typeof value !== 'object') return null
+    value = (value as Record<string, unknown>)[p]
+  }
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' ? String(value) : null
+}
+
+/** The model slug from an agent's spawn-time meta.json, or null if absent/unparsable. */
+async function readAgentMetaModel(metaPath: string): Promise<string | null> {
+  try {
+    const parsed = AgentMetaSchema.safeParse(JSON.parse(await fs.readFile(metaPath, 'utf8')))
+    return parsed.success ? modelSlugFromAgentType(parsed.data.agentType) : null
+  } catch {
+    return null
+  }
 }
 
 async function loadScript(
@@ -333,6 +382,8 @@ interface AgentStats {
   /** Error text when the transcript's FINAL entry is a synthetic error frame
    *  (`error` + `errorDetails` fields) — the durable marker of a dead agent. */
   trailingError: string | null
+  /** Model id from the first assistant turn (`message.model`), or null before one lands. */
+  model: string | null
 }
 
 function messageText(content: unknown): string {
@@ -359,6 +410,7 @@ async function readAgentStats(filePath: string): Promise<AgentStats> {
     firstTs: null,
     lastTs: null,
     trailingError: null,
+    model: null,
   }
   let firstPrompt = ''
   let toolCount = 0
@@ -366,6 +418,7 @@ async function readAgentStats(filePath: string): Promise<AgentStats> {
   let firstTs: number | null = null
   let lastTs: number | null = null
   let trailingError: string | null = null
+  let model: string | null = null
   try {
     // Streamed, not read whole: a single agent transcript can be tens of MB and
     // a wide run holds AGENT_STATS_CONCURRENCY of them open at once.
@@ -374,7 +427,7 @@ async function readAgentStats(filePath: string): Promise<AgentStats> {
       timestamp?: string
       error?: unknown
       errorDetails?: unknown
-      message?: { content?: unknown; usage?: { output_tokens?: number } }
+      message?: { content?: unknown; usage?: { output_tokens?: number }; model?: unknown }
     }>(filePath)
     for await (const entry of lines) {
       // Track the error marker of the LAST entry only: a mid-transcript error the
@@ -401,10 +454,13 @@ async function readAgentStats(filePath: string): Promise<AgentStats> {
           toolCount += content.filter((b) => (b as { type?: string })?.type === 'tool_use').length
         }
         tokens += entry.message?.usage?.output_tokens ?? 0
+        if (model === null && typeof entry.message?.model === 'string' && entry.message.model) {
+          model = entry.message.model
+        }
       }
     }
   } catch {
     return empty
   }
-  return { firstPrompt, toolCount, tokens, firstTs, lastTs, trailingError }
+  return { firstPrompt, toolCount, tokens, firstTs, lastTs, trailingError, model }
 }


### PR DESCRIPTION
## Why

Running a 30-agent `pipeline(args.companies, c => agent(…, { label: \`qualify:${c.slug}\` }))` fan-out, the inline card showed `qualify:closera` but the workflow tab listed `agent 1`, `agent 2`, … The tab rebuilds labels by joining each agent's first prompt back to its `agent()` call site and substituting captured `${…}` holes into the label template. The prompt embeds the record as `${JSON.stringify(c, null, 1)}`, never as a bare `${c.slug}`, so the label hole had nothing to bind to and fell back to the ordinal.

Separately, there was no way to see which model a workflow phase or agent ran on, and a transient failure of the tree route rendered as a half-minute "Loading workflow…" instead of "Starting workflow…".

## What

- **Labels.** The tab prefers the label the SDK sends on the wire (`workflow_progress`) while the run is live. The disk join can now resolve a label hole like `${c.slug}` by parsing the captured JSON of a `JSON.stringify(c…)` prompt hole, so finished runs re-open with real labels too. Against the reporting run's exported snapshot, all agents resolve to `qualify:<slug>` from disk alone.
- **Model per agent / per phase.** `WorkflowAgentNode.model` comes from the transcript's first assistant turn, falling back to the spawn-time `agent-<id>.meta.json` agent type (`model-haiku-4-5-…` → `haiku-4-5`) before that turn lands. Shown as a chip on each row, a Model line on the expanded row, and the distinct set on each phase header. The formatter is shared with the subagent block (`Opus`/`Grok` are title-cased now instead of `OPUS`).
- **Header.** Prefers the script's `meta.name` over the name the launching card passed (for a scriptPath run that was only the generic "workflow").
- **Tree query resilience.** `retry: false` (the 2s poll is the retry), a 10s abort on the request, and the live-transition refetch no longer cancels an in-flight fetch. A failing route surfaces as "Starting workflow…" after one request instead of hiding behind 31s of backoff.
- Rows carry `data-testid="workflow-agent-row"` + `data-agent-label` for e2e/screenshots.

Not changed: the inline card still says "Workflow: workflow" for scriptPath runs (the renderer gets the result text, not the structured `workflowName`).

## Tests

- `workflow-tree.test.ts`: JSON-hole label resolution; model from transcript, from meta.json, and null for a named agent type; fixture asserts the model.
- `workflow-tray-content.test.ts`: wire label preferred over disk, disk kept on reload; `phaseModels` ordering/dedupe.
- `model-label.test.ts`: id and slug formatting.

## Screenshots

Rendered from the reporting run's exported snapshot on a scratch mock instance (finished-run view, so labels and models come from disk). The dark capture rendered in light on the mock instance; the change is theme-neutral (existing muted tokens).

| Workflow tab | Agent expanded |
| --- | --- |
| ![Workflow tab (light)](https://github.com/user-attachments/assets/036d6680-15cf-41b8-b969-047f3ce1461c) | ![Workflow tab, agent expanded (light)](https://github.com/user-attachments/assets/a8679db7-0e1a-4dd9-a041-2c629232eef4) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012duuVzatW2oUeLYbziUMcA
