### PR TITLE
fix(e2e): expect timestamped upload names

### DIFF
--- a/e2e/helpers/upload-filename.ts
+++ b/e2e/helpers/upload-filename.ts
@@ -1,0 +1,13 @@
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/** Match the storage name returned for an uploaded file. */
+export function timestampedUploadNamePattern(fileName: string): RegExp {
+  const dot = fileName.lastIndexOf('.')
+  if (dot <= 0) return new RegExp(`${escapeRegExp(fileName)}-\\d{13}`)
+
+  const stem = fileName.slice(0, dot)
+  const extension = fileName.slice(dot)
+  return new RegExp(`${escapeRegExp(stem)}-\\d{13}${escapeRegExp(extension)}`)
+}

--- a/e2e/specs/composer-failure-recovery.spec.ts
+++ b/e2e/specs/composer-failure-recovery.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
+import { timestampedUploadNamePattern } from '../helpers/upload-filename'
 import * as path from 'path'
 import * as fs from 'fs'
 import * as os from 'os'
@@ -130,7 +131,9 @@ test.describe('Composer failure recovery', () => {
 
     await sessionPage.waitForUserMessageCount(2, 15000)
     await sessionPage.expectUserMessage(text, 1)
-    await expect(page.getByTestId('file-pill').filter({ hasText: 'guarded.txt' }).first()).toBeVisible({ timeout: 5000 })
+    await expect(
+      page.getByTestId('file-pill').filter({ hasText: timestampedUploadNamePattern('guarded.txt') }).first(),
+    ).toBeVisible({ timeout: 5000 })
     await expect(sessionPage.getMessageInput()).toHaveText('')
   })
 

--- a/e2e/specs/file-upload.spec.ts
+++ b/e2e/specs/file-upload.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
+import { timestampedUploadNamePattern } from '../helpers/upload-filename'
 import * as path from 'path'
 import * as fs from 'fs'
 import * as os from 'os'
@@ -11,7 +12,7 @@ function attachmentPreview(page: import('@playwright/test').Page, fileName: stri
 }
 
 function filePill(page: import('@playwright/test').Page, fileName: string) {
-  return page.getByTestId('file-pill').filter({ hasText: fileName })
+  return page.getByTestId('file-pill').filter({ hasText: timestampedUploadNamePattern(fileName) })
 }
 
 test.describe('File & Folder Upload', () => {
@@ -144,6 +145,6 @@ test.describe('File & Folder Upload', () => {
     await pill.click()
     const tabBar = page.getByTestId('file-tab-bar')
     await expect(tabBar).toBeVisible({ timeout: 5000 })
-    await expect(tabBar).toContainText('report.pdf')
+    await expect(tabBar).toContainText(timestampedUploadNamePattern('report.pdf'))
   })
 })


### PR DESCRIPTION
## Summary

- match sent upload pills using the intended stem-13-digit-timestamp-extension storage format
- reuse the matcher in file upload and composer recovery coverage
- update the preview tab assertion hidden behind the original pill lookup failure

## Why

PR #976 moved upload timestamps from a filename prefix to immediately before the extension. The e2e selectors still searched for the original contiguous filename, so four upload tests could not find pills that were present.

## Verification

- npm run typecheck
- npx eslint e2e/helpers/upload-filename.ts e2e/specs/file-upload.spec.ts e2e/specs/composer-failure-recovery.spec.ts
- the four previously failing Playwright cases: 4 passed