### PR TITLE
fix(transcript): keep following through WebKit viewport moves off our own clicks and commits

### DIFF
--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -3255,6 +3255,190 @@ describe('MessageList', () => {
       expect(geometry.scrollTop).toBe(150)
     })
 
+    it('puts the viewport back when a transcript commit moves it, before any scroll event', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
+      // A long transcript: the reply under the click is thousands of px tall.
+      geometry.setNaturalScrollHeight(4000)
+      geometry.setScrollTop(3400)
+      fireEvent.scroll(el) // baseline at the live edge
+
+      // The engine goes quiet: no writes for longer than any rollback window.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 600))
+      })
+
+      // A commit lands in the transcript (a reply re-rendered on a click) and
+      // WebKit moves the viewport to that reply's top during the commit: by
+      // the time the MutationObserver runs, scrollTop has moved and the
+      // geometry is back to what it was. No input anywhere. The observer
+      // must put it back right there, and following must survive.
+      geometry.setScrollTop(1100)
+      await act(async () => {
+        contentWrapper.appendChild(document.createElement('span'))
+        await Promise.resolve() // MutationObserver delivery
+      })
+      expect(geometry.scrollTop).toBe(3399)
+      fireEvent.scroll(el) // the browser's echo of the write
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 40))
+      })
+      expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
+      expect(geometry.scrollTop).toBe(3399)
+    })
+
+    it('leaves an outside scroll alone even while the transcript is churning', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 600))
+      })
+
+      // A commit that moves nothing (a working indicator ticking), then a
+      // programmatic scroll from outside in its own task — a test's
+      // scrollIntoView, find-in-page. The commit is no reason to eat it:
+      // following releases and nothing yanks the reader back.
+      await act(async () => {
+        contentWrapper.appendChild(document.createElement('span'))
+        await Promise.resolve()
+      })
+      expect(geometry.scrollTop).toBe(700)
+      geometry.setScrollTop(150)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      })
+      expect(screen.getByText('Scroll to bottom')).toBeInTheDocument()
+      expect(geometry.scrollTop).toBe(150)
+    })
+
+    it('does not fight a held drag when a commit lands under it', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
+      fireEvent.scroll(el)
+
+      // The reader is dragging (press + motion) and has pulled the viewport
+      // up when a commit lands. The observer sees an upward displacement
+      // with stable geometry — and a held pointer behind it. Hands off.
+      fireEvent.pointerDown(el, { button: 0, clientX: 10, clientY: 10 })
+      fireEvent(window, new MouseEvent('pointermove', { clientX: 10, clientY: 60 }))
+      geometry.setScrollTop(400)
+      await act(async () => {
+        contentWrapper.appendChild(document.createElement('span'))
+        await Promise.resolve()
+      })
+      expect(geometry.scrollTop).toBe(400)
+    })
+
+    it('does not let a bare click on the transcript turn a rollback into an escape', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
+      fireEvent.scroll(el) // 699 joins the trail
+
+      geometry.setNaturalScrollHeight(1500)
+      await act(async () => {
+        fireContentResize(contentWrapper, 1500)
+      })
+      await waitFor(() => expect(geometry.scrollTop).toBe(899))
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 600))
+      })
+
+      // Press + release on the content, no motion: a click on a button under
+      // a reply. It cannot scroll anything, so it is not input evidence — the
+      // compositor rollback that follows (an on-trail, size-stable upward
+      // landing) is still the engine's own motion coming back.
+      fireEvent.pointerDown(el, { button: 0, clientX: 10, clientY: 10 })
+      fireEvent(window, new MouseEvent('pointerup', { clientX: 10, clientY: 10 }))
+      geometry.setScrollTop(699)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      })
+      expect(screen.queryByText('Scroll to bottom')).not.toBeInTheDocument()
+      expect(geometry.scrollTop).toBe(899)
+    })
+
+    it('still honors the same upward landing as an escape under a content drag', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
+      fireEvent.scroll(el)
+
+      geometry.setNaturalScrollHeight(1500)
+      await act(async () => {
+        fireContentResize(contentWrapper, 1500)
+      })
+      await waitFor(() => expect(geometry.scrollTop).toBe(899))
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 600))
+      })
+
+      // The press travels: a drag. The upward landing under it is the reader's.
+      fireEvent.pointerDown(el, { button: 0, clientX: 10, clientY: 10 })
+      fireEvent(window, new MouseEvent('pointermove', { clientX: 10, clientY: 60 }))
+      geometry.setScrollTop(699)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      })
+      expect(screen.getByText('Scroll to bottom')).toBeInTheDocument()
+      expect(geometry.scrollTop).toBe(699)
+    })
+
+    it('keeps a scrollbar gutter press as input evidence past its release', async () => {
+      installFakeResizeObserver()
+      mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]
+      renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+      const el = screen.getByTestId('message-list')
+      const geometry = mockTurnGeometry(el)
+      const contentWrapper = screen.getByTestId('turn-anchor-spacer').parentElement!
+      Object.defineProperty(el, 'clientWidth', { configurable: true, get: () => 800 })
+      fireEvent.scroll(el)
+
+      geometry.setNaturalScrollHeight(1500)
+      await act(async () => {
+        fireContentResize(contentWrapper, 1500)
+      })
+      await waitFor(() => expect(geometry.scrollTop).toBe(899))
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 600))
+      })
+
+      // A track click pages the viewport with no pointer motion, and the
+      // scroll event can trail the release. The gutter press itself is the
+      // evidence that makes the on-trail upward landing the reader's.
+      fireEvent.pointerDown(el, { button: 0, clientX: 810, clientY: 10 })
+      fireEvent(window, new MouseEvent('pointerup', { clientX: 810, clientY: 10 }))
+      geometry.setScrollTop(699)
+      fireEvent.scroll(el)
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 250))
+      })
+      expect(screen.getByText('Scroll to bottom')).toBeInTheDocument()
+      expect(geometry.scrollTop).toBe(699)
+    })
+
     it('ignores a bounce-back settling inside the live-edge band after a downward wheel', async () => {
       installFakeResizeObserver()
       mockMessagesData.data = [createAssistantMessage({ content: { text: 'Previous response' } })]

--- a/src/renderer/components/messages/use-message-list-scroll.ts
+++ b/src/renderer/components/messages/use-message-list-scroll.ts
@@ -39,10 +39,14 @@ const TURN_ANCHOR_TOP = 100
 //     touch momentum) classifies a scroll event as the user's only when the
 //     geometry was stable AND some input recently touched the scroller: our
 //     own writes always update the baseline in the same statement, a browser
-//     clamp only ever fires in a frame where scrollHeight or clientHeight
+//     clamp normally fires in a frame where scrollHeight or clientHeight
 //     changed, and WebKit's async scrolling can roll a write back with no
 //     input at all — upward + stable + fresh input is the reader leaving;
 //     upward + stable + no input is the engine, and following converges back.
+//     WebKit can also move the viewport off one of OUR OWN DOM commits with
+//     the geometry already back in place by the time the event fires; that
+//     one is caught and undone at the commit itself, before it paints (see
+//     the MutationObserver below).
 //   - FOLLOWING is convergent: while engaged, every content or viewport
 //     resize re-pins the live edge with a single instant write. A missed or
 //     misread event can cost one frame, never a dead latch.
@@ -265,8 +269,18 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
   const pointerDownPosRef = useRef<{ x: number; y: number } | null>(null)
   const pointerOnScrollbarRef = useRef(false)
   // Any input that reached the scroller — wheel (either direction), scroll
-  // key, pointer press, touch. The backstop's release requires this to be
-  // fresh; see INPUT_EVIDENCE_WINDOW_MS.
+  // key, scrollbar press, content drag, touch. The backstop's release
+  // requires this to be fresh; see INPUT_EVIDENCE_WINDOW_MS. A bare click on
+  // the content (press + release, no motion) is deliberately NOT evidence:
+  // it cannot scroll, but it can change the transcript (a toggle, a button
+  // under a reply), and WebKit re-clamps the scroller mid-commit when the
+  // changed row sits at the live edge — a size-stable upward scroll event a
+  // few ms after the release. With the click counted as input, that clamp
+  // read as the reader escaping and killed following (reproduced with the
+  // read-aloud speaker button, WebKit only). The held press itself still
+  // counts while it lasts: a thumb drag on an overlay scrollbar and a
+  // selection autoscroll deliver scroll events under a held button with no
+  // pointer motion of their own.
   const lastInputAtRef = useRef(0)
   const touchActiveRef = useRef(false)
   const touchSettleTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
@@ -880,6 +894,50 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
     return () => observer.disconnect()
   }, [pinToLiveEdge, isLoading, error])
 
+  // WebKit moves the viewport off our OWN DOM commits. Re-rendering the reply
+  // at the live edge (its speaker button swapped for the playback strip, its
+  // prose words wrapped in spans) has been recorded landing the scroller on
+  // that reply's TOP — 143px up for a short reply, 2280px for a long one —
+  // with scrollHeight and clientHeight unchanged, no input anywhere, no JS
+  // scroll call or focus change behind it (traced), and the engine quiet.
+  // Chromium never moves. By the time the scroll event fires that is the
+  // exact shape of an outside programmatic jump, and classifying it there
+  // (a "commit happened recently" window) also swallowed genuine outside
+  // scrolls racing transcript churn — a test's scrollIntoView on a request
+  // card while the working indicator ticked. So it is caught where it can
+  // be told apart: the MutationObserver microtask runs right after the
+  // mutating task, before anything else can scroll, and at that point the
+  // move is already visible (traced: scrollTop had moved, scrollHeight had
+  // not). A size-stable upward displacement seen there, while following
+  // with no input behind it, is the browser's reaction to our render: put
+  // the viewport straight back before it paints. Attributes are left out on
+  // purpose — a class flip that changes layout does so with a size change
+  // the pin already covers, and the ones that don't (a word lighting up as
+  // it is read) would only churn the callback.
+  useEffect(() => {
+    const content = contentRef.current
+    if (!content || typeof MutationObserver === 'undefined') return
+    const observer = new MutationObserver(() => {
+      const el = scrollRef.current
+      const baseline = baselineRef.current
+      if (!el || !baseline || !followingRef.current || glideRef.current) return
+      if (
+        pointerDownRef.current ||
+        touchActiveRef.current ||
+        performance.now() - lastInputAtRef.current < INPUT_EVIDENCE_WINDOW_MS
+      ) {
+        return
+      }
+      const sizeStable =
+        baseline.scrollHeight === el.scrollHeight && baseline.clientHeight === el.clientHeight
+      if (!sizeStable || el.scrollTop >= baseline.scrollTop - 1) return
+      writeScrollTop(el, Math.min(baseline.scrollTop, liveEdgeTarget(el)))
+      rememberPosition()
+    })
+    observer.observe(content, { subtree: true, childList: true, characterData: true })
+    return () => observer.disconnect()
+  }, [isLoading, error, writeScrollTop, rememberPosition])
+
   // Markdown, images, and expanded tool cards can change height without a
   // message-state update — and the spacer math depends on the viewport's
   // clientHeight, so window resizes matter too. Feed both through the same
@@ -963,21 +1021,24 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
   // Scrollbar interactions emit no wheel/key events — track the held pointer.
   // A press in the scrollbar gutter suspends pinning outright (track clicks
   // page without any pointer motion); a content press only counts once it
-  // actually drags. A motionless press — or one whose release was swallowed
-  // by a native context menu or a focus change — must never own the viewport
-  // indefinitely.
+  // actually drags, and only a gutter press or a drag leaves input evidence
+  // behind (see lastInputAtRef: a bare click must not). A motionless press —
+  // or one whose release was swallowed by a native context menu or a focus
+  // change — must never own the viewport indefinitely.
   const handlePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return
     const el = scrollRef.current
     pointerDownRef.current = true
     pointerDragRef.current = false
     pointerDownPosRef.current = { x: event.clientX, y: event.clientY }
-    lastInputAtRef.current = performance.now()
     pointerOnScrollbarRef.current =
       !!el &&
       el.clientWidth > 0 &&
       event.clientX >= el.getBoundingClientRect().left + el.clientWidth
-    if (pointerOnScrollbarRef.current) cancelGlide()
+    if (pointerOnScrollbarRef.current) {
+      lastInputAtRef.current = performance.now()
+      cancelGlide()
+    }
   }, [cancelGlide])
   useEffect(() => {
     const release = () => {
@@ -999,6 +1060,7 @@ export function useMessageListScroll<T>(options: MessageListScrollOptions<T>) {
         return
       }
       pointerDragRef.current = true
+      lastInputAtRef.current = performance.now()
       glideRef.current?.cancel()
     }
     window.addEventListener('pointerup', release)


### PR DESCRIPTION
Stacked on #980 (read-aloud). Engine-only; the read-aloud rendering change that depends on it is #984.

## What was wrong

Pressing a button under the last reply at the live edge killed following in Safari. Two attribution mistakes in the transcript follow engine, both WebKit-only:

1. **A bare click counted as input evidence.** `handlePointerDown` stamped `lastInputAtRef` on every content press, so for 500ms after any click an upward, size-stable scroll event read as the reader escaping. A click cannot scroll, but it can change the transcript, and WebKit answers a DOM change at the live edge with exactly such an event a few ms after the release.
2. **Even with no input anywhere, the same event landed off the position trail with the engine quiet.** By geometry alone that is the shape of an outside programmatic jump (find-in-page, an extension, a test's `scrollTo`), which rightly releases follow.

Traced in WebKit against the dev server: the move happens inside the browser (no JS scroll call, no focus change, `overflow-anchor` already off) and lands the scroller on the re-rendered reply's **top**. 143px up for a short reply, 2280px up for a long one. Chromium never moves.

## What changed

`src/renderer/components/messages/use-message-list-scroll.ts`

- Only a scrollbar-gutter press or a content drag (past `POINTER_DRAG_THRESHOLD_PX`) stamps input evidence. The held press itself still counts while it lasts, so overlay-scrollbar thumb drags and selection autoscroll, which deliver scroll events under a held button with no motion, are unchanged.
- A `MutationObserver` on the transcript content (childList + characterData, not attributes) catches the WebKit move **at the commit**. Its microtask runs right after the mutating task, before anything else can scroll, and at that point the move is already visible (traced: `scrollTop` had moved, `scrollHeight` had not). A size-stable upward displacement seen there, while following with no input behind it, is put straight back before it paints. The scroll handler's classifier is untouched.

An earlier revision of this PR classified the move in the scroll handler instead (any evidence-less upward stable event within 400ms of a commit). That also swallowed genuine outside scrolls racing transcript churn: Playwright's scroll-into-view on a request card while the working indicator ticked, which broke `mixed-pending-requests.spec.ts`. Catching it at the commit has no such window.

## Tests

Unit (`message-list.test.tsx`, 6 new, 147 passing):

- a commit that moves the viewport (thousands of px, past any revert cap) is put back before any scroll event and following survives
- an outside scroll in its own task, right after a commit, still releases and is not yanked back
- a commit landing under a held drag is left alone
- a bare click does not turn an on-trail rollback into an escape
- a content drag still escapes
- a scrollbar gutter press still counts as evidence past its release

## Verification

- Dev server, Playwright WebKit, 1436×1684 and 1436×900: the read-aloud controls swapping under the last reply moved the viewport 143px up and showed the pill before; now the only scroll event already reports the live edge and the pill never shows. Chromium: no scroll events either way.
- `--project=web-webkit` twice over (safari-follow, thinking-collapse-reading-line, and #984's read-aloud-follow): green.
- Chromium: mixed-pending-requests, chat-flow, file-upload, composer-failure-recovery, settings, message-pagination (its programmatic `scrollTo`), transcript-follow, thinking-collapse-follow: 48/48.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196tnfhLZANb3NCZJioKQhf
