### PR TITLE
feat(voice): render read-aloud spans and controls only for the reply being read

### DIFF
--- a/e2e/specs/read-aloud-follow.spec.ts
+++ b/e2e/specs/read-aloud-follow.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect, type Page } from '@playwright/test'
+import { AppPage } from '../pages/app.page'
+import { AgentPage } from '../pages/agent.page'
+import { SessionPage } from '../pages/session.page'
+
+// Runs under web-webkit (where the failure reproduces) and web-chromium (as
+// the control that never moved).
+//
+// Pressing the speaker under the LAST reply re-renders that reply at the live
+// edge: the action row swaps its children and every prose word gains a span.
+// WebKit answers that commit by moving the viewport a row's worth up, with
+// scrollHeight and clientHeight already back at their old values by the time
+// the scroll event fires — by geometry alone, a reader escaping. The follow
+// engine attributes the move to the commit (COMMIT_ROLLBACK_WINDOW_MS in
+// use-message-list-scroll.ts) and puts the viewport straight back: the
+// scroll-to-bottom pill must never show, in any frame, and the live edge must
+// hold through both re-renders (controls in, controls out).
+
+declare global {
+  interface Window {
+    __pillRec?: {
+      frames: number
+      pillFrames: number
+      maxDistance: number
+      scrolls: Array<Record<string, number>>
+      pill: Array<Record<string, number>>
+    }
+  }
+}
+
+function installPillRecorder(page: Page) {
+  return page.evaluate(() => {
+    const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')!
+    const rec: NonNullable<Window['__pillRec']> = { frames: 0, pillFrames: 0, maxDistance: 0, scrolls: [], pill: [] }
+    window.__pillRec = rec
+    const t0 = performance.now()
+    el.addEventListener(
+      'scroll',
+      () => {
+        rec.scrolls.push({
+          t: Math.round(performance.now() - t0),
+          top: Math.round(el.scrollTop),
+          sh: el.scrollHeight,
+          ch: el.clientHeight,
+        })
+      },
+      { passive: true },
+    )
+    let lastPill = 0
+    const sample = () => {
+      const pill = [...document.querySelectorAll('button')].some(
+        (b) => b.textContent?.includes('Scroll to bottom') && b.offsetParent !== null,
+      )
+        ? 1
+        : 0
+      rec.frames += 1
+      if (pill) rec.pillFrames += 1
+      if (pill !== lastPill) {
+        rec.pill.push({ t: Math.round(performance.now() - t0), pill, top: Math.round(el.scrollTop) })
+        lastPill = pill
+      }
+      rec.maxDistance = Math.max(rec.maxDistance, el.scrollHeight - el.scrollTop - el.clientHeight)
+      requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+  })
+}
+
+function distanceFromBottom(page: Page) {
+  return page.evaluate(() => {
+    const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')!
+    return el.scrollHeight - el.scrollTop - el.clientHeight
+  })
+}
+
+test.describe('read-aloud at the live edge', () => {
+  let appPage: AppPage
+  let agentPage: AgentPage
+  let sessionPage: SessionPage
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    appPage = new AppPage(page)
+    agentPage = new AgentPage(page)
+    sessionPage = new SessionPage(page)
+
+    // Speech is "configured" for this page only. The token endpoint refuses,
+    // so no audio is ever fetched: the press goes connecting → error, which
+    // re-renders the reply exactly the way play → stop does.
+    await page.route('**/api/stt/configured', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          configured: true,
+          supportsVoiceAgent: false,
+          supportsTts: true,
+          defaultVoice: 'aura-2-thalia-en',
+        }),
+      }),
+    )
+    await page.route('**/api/stt/tts-token', async (route) => {
+      // Long enough for the connecting render to paint and settle on its own.
+      await new Promise((resolve) => setTimeout(resolve, 600))
+      return route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'No speech in tests' }),
+      })
+    })
+
+    await appPage.goto()
+    await appPage.waitForAgentsLoaded()
+    await agentPage.createAgent(`Read Aloud Follow ${testInfo.workerIndex}-${Date.now()}`)
+  })
+
+  test('keeps following when the speaker under the last reply is pressed', async ({ page }) => {
+    test.setTimeout(120000)
+
+    // A long transcript, so the scroller has real range and the reply under
+    // test sits at the live edge with content above it to clamp against.
+    await sessionPage.sendMessage('stream a long story please')
+    await sessionPage.waitForUserMessageCount(1)
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')
+            return el ? el.scrollHeight - el.clientHeight : 0
+          }),
+        { timeout: 60000 },
+      )
+      .toBeGreaterThan(1500)
+    await expect(sessionPage.getStopButton()).toBeHidden({ timeout: 30000 })
+    await expect.poll(() => distanceFromBottom(page), { timeout: 10000 }).toBeLessThan(24)
+    await expect(page.getByRole('button', { name: 'Scroll to bottom' })).toBeHidden()
+
+    // Hover the button, not the reply: WebKit scrolls a hovered element's top
+    // into view when it is taller than the viewport, and that programmatic
+    // jump (rightly) releases following before the press under test.
+    const reply = page.getByTestId('message-assistant').last()
+    const speaker = reply.getByTestId('read-aloud-button')
+    await speaker.hover()
+    await expect(speaker).toBeVisible()
+    await expect.poll(() => distanceFromBottom(page)).toBeLessThan(24)
+    await expect(page.getByRole('button', { name: 'Scroll to bottom' })).toBeHidden()
+    await installPillRecorder(page)
+
+    await speaker.click()
+
+    // Controls in, spans in — the first re-render.
+    const controls = reply.getByTestId('read-aloud-controls')
+    await expect(controls).toHaveAttribute('data-status', 'connecting')
+    await expect.poll(() => reply.locator('[data-spoken-word]').count()).toBeGreaterThan(0)
+    await expect(reply.getByTestId('read-aloud-stop')).toBeVisible()
+
+    // Controls out, spans out — the second re-render, on the refused token.
+    await expect(reply.getByTestId('read-aloud-error')).toHaveText('No speech in tests', { timeout: 10000 })
+    await expect(reply.locator('[data-spoken-word]')).toHaveCount(0)
+    await expect(speaker).toBeVisible()
+
+    // Following held the whole way: the pill was never painted, the viewport
+    // is back on the live edge, and nothing is left dangling above it.
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    const rec = await page.evaluate(() => window.__pillRec!)
+    console.log(
+      `[read-aloud-follow] frames=${rec.frames} pillFrames=${rec.pillFrames} maxDistance=${rec.maxDistance}` +
+        ` scrolls=${JSON.stringify(rec.scrolls)} pill=${JSON.stringify(rec.pill)}`,
+    )
+    await expect.poll(() => distanceFromBottom(page), { timeout: 5000 }).toBeLessThan(24)
+    // rAF sampling is throttled under parallel workers, so the frame count is
+    // only a sanity check; the scroll events are the frame-independent record.
+    expect(rec.frames).toBeGreaterThan(0)
+    expect(rec.pillFrames).toBe(0)
+    // WebKit reports the engine's put-back as a scroll event already at the
+    // live edge; Chromium never moves at all and reports nothing.
+    for (const s of rec.scrolls) expect(s.sh - s.ch - s.top).toBeLessThan(24)
+    await expect(page.getByRole('button', { name: 'Scroll to bottom' })).toBeHidden()
+  })
+})

--- a/e2e/specs/read-aloud-follow.spec.ts
+++ b/e2e/specs/read-aloud-follow.spec.ts
@@ -94,6 +94,7 @@ test.describe('read-aloud at the live edge', () => {
           configured: true,
           supportsVoiceAgent: false,
           supportsTts: true,
+          voices: [{ id: 'aura-2-thalia-en', label: 'Thalia', description: 'Clear, confident, energetic' }],
           defaultVoice: 'aura-2-thalia-en',
         }),
       }),

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -102,7 +102,7 @@ export default defineConfig({
     // explicitly with --project=web-webkit (needs `npx playwright install webkit`).
     {
       name: 'web-webkit',
-      testMatch: ['**/safari-follow.spec.ts', '**/thinking-collapse-reading-line.spec.ts'],
+      testMatch: ['**/safari-follow.spec.ts', '**/thinking-collapse-reading-line.spec.ts', '**/read-aloud-follow.spec.ts'],
       use: { ...devices['Desktop Safari'] },
     },
     // Home connections graph — canvas mouse gestures (hover-fade, edge draw,

--- a/src/renderer/components/messages/message-item.test.tsx
+++ b/src/renderer/components/messages/message-item.test.tsx
@@ -291,23 +291,23 @@ describe('MessageItem', () => {
       expect(screen.queryByTestId('read-aloud-button')).toBeNull()
     })
 
-    it('renders readable replies word-addressable up front, and dims only the one being read', () => {
+    it('renders the word spans and dims the prose only for the reply being read', () => {
       readAloudState.configured = true
       const msg = createAssistantMessage({ content: { text: 'Hello **bright** world' } })
-      // Idle: spans are already there (so play never changes the DOM shape), no dimming.
+      // Idle: plain prose, nothing addressable, no dimming.
       const idle = render(<MessageItem message={msg} />)
-      const idleWords = Array.from(idle.container.querySelectorAll<HTMLElement>('[data-spoken-word]'))
-      expect(idleWords.map((w) => w.textContent)).toEqual(['Hello', 'bright', 'world'])
-      expect(idleWords.map((w) => w.dataset.spokenWord)).toEqual(['0', '1', '2'])
+      expect(idle.container.querySelector('[data-spoken-word]')).toBeNull()
       expect(idle.container.querySelector('.read-aloud-prose')).toBeNull()
       idle.unmount()
 
       readAloudState.activeId = msg.id
       const { container } = render(<MessageItem message={msg} />)
       expect(container.querySelector('.read-aloud-prose')).not.toBeNull()
-      expect(container.querySelectorAll('[data-spoken-word]')).toHaveLength(3)
-      expect(screen.getByTestId('read-aloud-button')).toHaveClass('hidden')
-      expect(screen.getByTestId('read-aloud-stop')).not.toHaveClass('hidden')
+      const words = Array.from(container.querySelectorAll<HTMLElement>('[data-spoken-word]'))
+      expect(words.map((w) => w.textContent)).toEqual(['Hello', 'bright', 'world'])
+      expect(words.map((w) => w.dataset.spokenWord)).toEqual(['0', '1', '2'])
+      expect(screen.queryByTestId('read-aloud-button')).toBeNull()
+      expect(screen.getByTestId('read-aloud-stop')).toBeInTheDocument()
     })
 
     it('while reading, offers pause, stop, and the speed picker; paused offers resume', () => {
@@ -315,23 +315,18 @@ describe('MessageItem', () => {
       const msg = createAssistantMessage({ content: { text: 'Hello there world' } })
       readAloudState.activeId = msg.id
       const speaking = render(<MessageItem message={msg} />)
-      const pause = screen.getByTestId('read-aloud-pause')
-      expect(pause).not.toHaveClass('hidden')
-      expect(screen.getByTestId('read-aloud-resume')).toHaveClass('hidden')
-      pause.click()
+      expect(screen.queryByTestId('read-aloud-resume')).toBeNull()
+      screen.getByTestId('read-aloud-pause').click()
       expect(readAloudState.pause).toHaveBeenCalledTimes(1)
       expect(screen.getByTestId('read-aloud-speed')).toHaveTextContent('1.2×')
-      expect(screen.getByTestId('read-aloud-speed')).not.toHaveClass('hidden')
       screen.getByTestId('read-aloud-stop').click()
       expect(readAloudState.toggle).toHaveBeenCalledTimes(1)
       speaking.unmount()
 
       readAloudState.status = 'paused'
       render(<MessageItem message={msg} />)
-      expect(screen.getByTestId('read-aloud-pause')).toHaveClass('hidden')
-      const resume = screen.getByTestId('read-aloud-resume')
-      expect(resume).not.toHaveClass('hidden')
-      resume.click()
+      expect(screen.queryByTestId('read-aloud-pause')).toBeNull()
+      screen.getByTestId('read-aloud-resume').click()
       expect(readAloudState.resume).toHaveBeenCalledTimes(1)
     })
 
@@ -339,33 +334,31 @@ describe('MessageItem', () => {
       readAloudState.configured = true
       const msg = createAssistantMessage({ content: { text: 'Hello there world' } })
       const quiet = render(<MessageItem message={msg} />)
-      expect(screen.getByTestId('read-aloud-error')).toHaveClass('hidden')
+      expect(screen.queryByTestId('read-aloud-error')).toBeNull()
       quiet.unmount()
 
       readAloudState.error = 'Deepgram key revoked'
       render(<MessageItem message={msg} />)
-      const error = screen.getByTestId('read-aloud-error')
-      expect(error).not.toHaveClass('hidden')
-      expect(error).toHaveTextContent('Deepgram key revoked')
-      expect(screen.getByTestId('read-aloud-button')).not.toHaveClass('hidden')
+      expect(screen.getByTestId('read-aloud-error')).toHaveTextContent('Deepgram key revoked')
+      expect(screen.getByTestId('read-aloud-button')).toBeInTheDocument()
     })
 
-    it('keeps every control mounted while idle, only the speaker visible', () => {
+    it('mounts only the speaker while idle', () => {
       readAloudState.configured = true
       render(<MessageItem message={createAssistantMessage({ content: { text: 'Hello there world' } })} />)
-      expect(screen.getByTestId('read-aloud-button')).not.toHaveClass('hidden')
+      expect(screen.getByTestId('read-aloud-button')).toBeInTheDocument()
       for (const id of ['read-aloud-pause', 'read-aloud-resume', 'read-aloud-stop', 'read-aloud-speed']) {
-        expect(screen.getByTestId(id)).toHaveClass('hidden')
+        expect(screen.queryByTestId(id)).toBeNull()
       }
     })
 
-    it('leaves other messages undimmed while one is being read', () => {
+    it('leaves other messages plain while one is being read', () => {
       readAloudState.configured = true
       readAloudState.activeId = 'some-other-message'
       const msg = createAssistantMessage({ content: { text: 'Hello world' } })
       const { container } = render(<MessageItem message={msg} />)
       expect(container.querySelector('.read-aloud-prose')).toBeNull()
-      expect(container.querySelectorAll('[data-spoken-word]')).toHaveLength(2)
+      expect(container.querySelector('[data-spoken-word]')).toBeNull()
     })
 
     it('adds no spans when speech is not configured', () => {

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -27,7 +27,6 @@ import type { EmbeddedImageAliases } from '@renderer/lib/parse-tool-result'
 import { rehypeStreamingWordReveal } from './streaming-word-reveal'
 import { rehypeSpokenWords } from '@renderer/lib/speech/spoken-words'
 import { useIsBeingRead, useSpokenWordHighlight } from '@renderer/hooks/use-read-aloud'
-import { useIsTtsConfigured } from '@renderer/hooks/use-voice-input'
 import { ReadAloudControls } from './read-aloud-controls'
 
 // Re-export for use by other components
@@ -393,16 +392,13 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
 
   // Read-aloud: a settled assistant reply gets a speaker button, and while it
   // is the one being read its prose is dimmed and lights up as playback
-  // reaches each word. The word spans the highlight addresses are rendered
-  // for every readable reply up front, not on play: re-rendering a reply's
-  // Markdown with the spans (React edits the kept text nodes in place before
-  // inserting) makes WebKit re-clamp the scroll container when the reply
-  // sits at the live edge, throwing the viewport up by a message's worth.
-  // With the structure fixed, play and stop change only classes and
-  // attributes, which never do.
+  // reaches each word. The word spans the highlight addresses exist only for
+  // that one reply, for as long as it is being read; every other reply is
+  // plain prose. (Re-rendering the reply at the live edge makes WebKit move
+  // the viewport; the follow engine attributes that move to the commit and
+  // puts it straight back — see COMMIT_ROLLBACK_WINDOW_MS.)
   const canReadAloud = isAssistant && !!hasText && !isStreaming && !isProviderErrorMessage && !CustomUserRender
-  const spoken = useIsTtsConfigured() && canReadAloud
-  const isBeingRead = useIsBeingRead(message.id) && spoken
+  const isBeingRead = useIsBeingRead(message.id) && canReadAloud
   const proseRef = useRef<HTMLDivElement>(null)
   useSpokenWordHighlight(proseRef, isBeingRead)
 
@@ -511,7 +507,7 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
                       text={text}
                       embeddedImageAliases={embeddedImageAliases}
                       agentSlug={agentSlug}
-                      spoken={spoken}
+                      spoken={isBeingRead}
                     />
                   )}
                   {isStreaming && (

--- a/src/renderer/components/messages/read-aloud-controls.tsx
+++ b/src/renderer/components/messages/read-aloud-controls.tsx
@@ -20,12 +20,11 @@ const ICON_BUTTON = cn(
 )
 const ICON = 'h-3.5 w-3.5'
 
-function IconButton({ label, onClick, testId, status, shown, children }: {
+function IconButton({ label, onClick, testId, status, children }: {
   label: string
   onClick: () => void
   testId: string
   status: ReadAloudStatus
-  shown: boolean
   children: React.ReactNode
 }) {
   return (
@@ -37,7 +36,7 @@ function IconButton({ label, onClick, testId, status, shown, children }: {
           aria-label={label}
           data-testid={testId}
           data-status={status}
-          className={cn(ICON_BUTTON, !shown && 'hidden')}
+          className={ICON_BUTTON}
         >
           {children}
         </button>
@@ -52,7 +51,7 @@ function IconButton({ label, onClick, testId, status, shown, children }: {
  * connection is fixed to one speed, so a change mid-reply restarts playback
  * from the current word with the new one.
  */
-function SpeedSelect({ shown }: { shown: boolean }) {
+function SpeedSelect() {
   const { data: userSettings } = useUserSettings()
   const updateUserSettings = useUpdateUserSettings()
   const stored = ttsSpeedSchema.safeParse(userSettings?.voice?.ttsSpeed)
@@ -74,7 +73,6 @@ function SpeedSelect({ shown }: { shown: boolean }) {
         className={cn(
           'h-6 w-auto gap-1 border-0 bg-transparent px-1.5 text-xs text-muted-foreground shadow-none',
           'hover:bg-black/[0.06] hover:text-foreground dark:hover:bg-white/[0.1] [&>svg]:h-3 [&>svg]:w-3',
-          !shown && 'hidden',
         )}
       >
         <SelectValue>{preset?.value === 1 ? '1×' : (preset?.label ?? `${speed}×`)}</SelectValue>
@@ -92,11 +90,6 @@ function SpeedSelect({ shown }: { shown: boolean }) {
  * Playback controls under an assistant reply. Idle: one speaker button.
  * While reading: pause/resume, stop, and the speed picker. Hidden entirely
  * when the voice provider can't synthesize speech.
- *
- * Every control stays mounted and only toggles display. Swapping the row's
- * children on play makes WebKit re-clamp the scroll container when the reply
- * sits at the live edge (the viewport drops by the row's height, the same
- * failure the prose spans had); display changes never do.
  */
 export function ReadAloudControls({ messageId, markdown, className }: ReadAloudControlsProps) {
   const configured = useIsTtsConfigured()
@@ -107,29 +100,37 @@ export function ReadAloudControls({ messageId, markdown, className }: ReadAloudC
   return (
     <TooltipProvider>
       <div className={cn('flex items-center gap-0.5', className)} data-testid="read-aloud-controls" data-status={status}>
-        <IconButton label="Read aloud" onClick={toggle} testId="read-aloud-button" status={status} shown={!active}>
-          <Volume2 className={ICON} />
-        </IconButton>
-        <span
-          role="alert"
-          data-testid="read-aloud-error"
-          className={cn('text-xs text-destructive', !(error && !active) && 'hidden')}
-        >
-          {error}
-        </span>
-        <span className={cn(ICON_BUTTON, status !== 'connecting' && 'hidden')} aria-label="Connecting" data-testid="read-aloud-connecting">
-          <Loader2 className={cn(ICON, 'animate-spin')} />
-        </span>
-        <IconButton label="Pause" onClick={pause} testId="read-aloud-pause" status={status} shown={status === 'speaking'}>
-          <Pause className={cn(ICON, 'fill-current')} />
-        </IconButton>
-        <IconButton label="Resume" onClick={resume} testId="read-aloud-resume" status={status} shown={status === 'paused'}>
-          <Play className={cn(ICON, 'fill-current')} />
-        </IconButton>
-        <IconButton label="Stop reading" onClick={toggle} testId="read-aloud-stop" status={status} shown={active}>
-          <Square className={cn(ICON, 'fill-current')} />
-        </IconButton>
-        <SpeedSelect shown={active} />
+        {!active && (
+          <IconButton label="Read aloud" onClick={toggle} testId="read-aloud-button" status={status}>
+            <Volume2 className={ICON} />
+          </IconButton>
+        )}
+        {!active && error && (
+          <span role="alert" data-testid="read-aloud-error" className="text-xs text-destructive">
+            {error}
+          </span>
+        )}
+        {status === 'connecting' && (
+          <span className={ICON_BUTTON} aria-label="Connecting" data-testid="read-aloud-connecting">
+            <Loader2 className={cn(ICON, 'animate-spin')} />
+          </span>
+        )}
+        {status === 'speaking' && (
+          <IconButton label="Pause" onClick={pause} testId="read-aloud-pause" status={status}>
+            <Pause className={cn(ICON, 'fill-current')} />
+          </IconButton>
+        )}
+        {status === 'paused' && (
+          <IconButton label="Resume" onClick={resume} testId="read-aloud-resume" status={status}>
+            <Play className={cn(ICON, 'fill-current')} />
+          </IconButton>
+        )}
+        {active && (
+          <IconButton label="Stop reading" onClick={toggle} testId="read-aloud-stop" status={status}>
+            <Square className={cn(ICON, 'fill-current')} />
+          </IconButton>
+        )}
+        {active && <SpeedSelect />}
       </div>
     </TooltipProvider>
   )


### PR DESCRIPTION
Stacked on #983 (follow engine) → #980 (read-aloud).

## What changed

The read-aloud row used two workarounds for the WebKit follow loss that #983 fixes at the source:

- Every readable reply rendered its prose with a `[data-spoken-word]` span per word, up front, whenever TTS was configured (so that play never changed the DOM shape). That was a span per word across the whole transcript and a one-time full re-render when `/api/stt/configured` resolved.
- `ReadAloudControls` kept every control mounted and only toggled `display`.

Both are gone:

- `MessageItem` passes `spoken={isBeingRead}`: `MarkdownBlock` wraps words only while its reply is being read. An idle transcript is plain prose again.
- `ReadAloudControls` renders what the state needs: speaker (and the error text, when there is one) while idle; spinner / pause / resume, stop and the speed picker while active.

Behaviour is unchanged. `useSpokenWordHighlight` already queried the spans on activation, so they can appear in the same commit that activates it.

## Tests

- `message-item.test.tsx`: idle replies have no spans and no dimming; spans and the dimmed prose appear only for the active reply; the idle row mounts only the speaker; error text mounts only when there is one.
- New WebKit e2e `read-aloud-follow.spec.ts` (in the `web-webkit` project, also run under `web-chromium` as the control). It presses the speaker under a long reply at the live edge with `/api/stt/tts-token` refused, so the reply re-renders twice (controls in, controls out) with no audio, and asserts the scroll-to-bottom pill is never painted in any frame and the live edge holds. Fails on the pre-#983 engine (viewport thrown 2304px up, pill for 31 frames); passes 3/3 on #983.

## WebKit verification

- The new spec, 3 consecutive runs under WebKit: pill frames 0, max distance from the live edge 1px, scroll events already report the live edge.
- Full `--project=web-webkit` (safari-follow, thinking-collapse-reading-line, read-aloud-follow): green.
- Dev-server probes in Playwright WebKit at 1436×1684 and 1436×900: play, pause, speed change while paused, resume, stop, a refused token showing red text, a 74-word reply playing to the end at 1.5×, and a speed write after done not replaying, all with `scrollTop` constant throughout.
- Playwright's own `hover()` on an element taller than the viewport scrolls its top into view in WebKit; the spec hovers the button, not the reply, and re-checks the live edge before the press.

## Screenshots

| Light | Dark |
| --- | --- |
| ![Speaker on hover (light)](https://github.com/user-attachments/assets/43870b3e-9931-4ad2-a3ab-9127c19063c0) | ![Speaker on hover (dark)](https://github.com/user-attachments/assets/a02b7698-0120-4938-a864-688f46b1b646) |
| ![Being read (light)](https://github.com/user-attachments/assets/580f776e-58f0-4fed-82d3-0606c900f71a) | ![Being read (dark)](https://github.com/user-attachments/assets/a2a3d6a5-3889-4e8e-8029-da8523debdb0) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196tnfhLZANb3NCZJioKQhf
