### PR TITLE
ci(mac): build the signing keychain in-workflow (CSC_KEYCHAIN)

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -32,10 +32,47 @@ jobs:
           echo "$APPLE_API_KEY_BASE64" | base64 --decode > /tmp/AuthKey.p8
           echo "APPLE_API_KEY=/tmp/AuthKey.p8" >> $GITHUB_ENV
 
-      - name: Build and sign macOS app
+      # electron-builder's temporary-keychain path passes the .p12 import password
+      # to `security set-key-partition-list -k`, which needs the *keychain* password.
+      # Older macOS builds tolerated the mismatch; the macOS 26.6 runner image
+      # (20260831+) rejects it and the build dies before signing. Upstream fix
+      # (electron-userland/electron-builder#10066, PR #10101) is not released on
+      # 26.x yet, so build the keychain here and hand it over via CSC_KEYCHAIN.
+      # electron-builder only honours CSC_KEYCHAIN when CSC_LINK is unset, so
+      # CSC_LINK/CSC_KEY_PASSWORD must NOT be passed to the build step.
+      - name: Set up signing keychain
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          CERT="$RUNNER_TEMP/signing.p12"
+          case "$CSC_LINK" in
+            https://*) curl -fsSL "$CSC_LINK" -o "$CERT" ;;
+            *) printf '%s' "$CSC_LINK" | sed -E 's/^data:[^,]*;base64,//' | base64 --decode > "$CERT" ;;
+          esac
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          # No auto-lock timeout: notarization can run for a long time.
+          security set-keychain-settings "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          rm -f "$CERT"
+          # Put the new keychain (plus electron-builder's bundled Apple root/
+          # intermediate certs, which its own keychain path also adds) on the
+          # search list so codesign can build the certificate chain.
+          security list-keychains -d user -s "$KEYCHAIN" \
+            "$PWD/node_modules/app-builder-lib/certs/root_certs.keychain" \
+            $(security list-keychains -d user | tr -d '"')
+          security find-identity -v -p codesigning "$KEYCHAIN"
+          echo "CSC_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+
+      - name: Build and sign macOS app
+        env:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -58,3 +95,9 @@ jobs:
           name: Superagent-macOS-ZIP-${{ github.ref_name }}
           path: release/*.zip
           retention-days: 30
+
+      - name: Remove signing keychain
+        if: always()
+        run: |
+          # create-keychain writes <name>-db on modern macOS, so don't test the path.
+          [ -z "${CSC_KEYCHAIN:-}" ] || security delete-keychain "$CSC_KEYCHAIN" || true

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -37,11 +37,48 @@ jobs:
           echo "$APPLE_API_KEY_BASE64" | base64 --decode > /tmp/AuthKey.p8
           echo "APPLE_API_KEY=/tmp/AuthKey.p8" >> $GITHUB_ENV
 
+      # electron-builder's temporary-keychain path passes the .p12 import password
+      # to `security set-key-partition-list -k`, which needs the *keychain* password.
+      # Older macOS builds tolerated the mismatch; the macOS 26.6 runner image
+      # (20260831+) rejects it and the build dies before signing. Upstream fix
+      # (electron-userland/electron-builder#10066, PR #10101) is not released on
+      # 26.x yet, so build the keychain here and hand it over via CSC_KEYCHAIN.
+      # electron-builder only honours CSC_KEYCHAIN when CSC_LINK is unset, so
+      # CSC_LINK/CSC_KEY_PASSWORD must NOT be passed to the build step.
+      - name: Set up signing keychain
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          CERT="$RUNNER_TEMP/signing.p12"
+          case "$CSC_LINK" in
+            https://*) curl -fsSL "$CSC_LINK" -o "$CERT" ;;
+            *) printf '%s' "$CSC_LINK" | sed -E 's/^data:[^,]*;base64,//' | base64 --decode > "$CERT" ;;
+          esac
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          # No auto-lock timeout: notarization can run for a long time.
+          security set-keychain-settings "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          rm -f "$CERT"
+          # Put the new keychain (plus electron-builder's bundled Apple root/
+          # intermediate certs, which its own keychain path also adds) on the
+          # search list so codesign can build the certificate chain.
+          security list-keychains -d user -s "$KEYCHAIN" \
+            "$PWD/node_modules/app-builder-lib/certs/root_certs.keychain" \
+            $(security list-keychains -d user | tr -d '"')
+          security find-identity -v -p codesigning "$KEYCHAIN"
+          echo "CSC_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+
       - name: Build and sign macOS app
         env:
           CSC_FOR_PULL_REQUEST: true
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -64,6 +101,12 @@ jobs:
           name: Superagent-macOS-ZIP
           path: release/*.zip
           retention-days: 14
+
+      - name: Remove signing keychain
+        if: always()
+        run: |
+          # create-keychain writes <name>-db on modern macOS, so don't test the path.
+          [ -z "${CSC_KEYCHAIN:-}" ] || security delete-keychain "$CSC_KEYCHAIN" || true
 
   build-win:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,10 +194,47 @@ jobs:
           node -e "const fs=require('fs'),p=require('./package.json');p.build.publish.channel=process.env.UPDATE_CHANNEL;fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
           echo "build.publish.channel set to $UPDATE_CHANNEL"
 
-      - name: Build and sign macOS app
+      # electron-builder's temporary-keychain path passes the .p12 import password
+      # to `security set-key-partition-list -k`, which needs the *keychain* password.
+      # Older macOS builds tolerated the mismatch; the macOS 26.6 runner image
+      # (20260831+) rejects it and the build dies before signing. Upstream fix
+      # (electron-userland/electron-builder#10066, PR #10101) is not released on
+      # 26.x yet, so build the keychain here and hand it over via CSC_KEYCHAIN.
+      # electron-builder only honours CSC_KEYCHAIN when CSC_LINK is unset, so
+      # CSC_LINK/CSC_KEY_PASSWORD must NOT be passed to the build step.
+      - name: Set up signing keychain
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          CERT="$RUNNER_TEMP/signing.p12"
+          case "$CSC_LINK" in
+            https://*) curl -fsSL "$CSC_LINK" -o "$CERT" ;;
+            *) printf '%s' "$CSC_LINK" | sed -E 's/^data:[^,]*;base64,//' | base64 --decode > "$CERT" ;;
+          esac
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          # No auto-lock timeout: notarization can run for a long time.
+          security set-keychain-settings "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          rm -f "$CERT"
+          # Put the new keychain (plus electron-builder's bundled Apple root/
+          # intermediate certs, which its own keychain path also adds) on the
+          # search list so codesign can build the certificate chain.
+          security list-keychains -d user -s "$KEYCHAIN" \
+            "$PWD/node_modules/app-builder-lib/certs/root_certs.keychain" \
+            $(security list-keychains -d user | tr -d '"')
+          security find-identity -v -p codesigning "$KEYCHAIN"
+          echo "CSC_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+
+      - name: Build and sign macOS app
+        env:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -218,6 +255,12 @@ jobs:
             release/*.yaml
             release/*.blockmap
           retention-days: 5
+
+      - name: Remove signing keychain
+        if: always()
+        run: |
+          # create-keychain writes <name>-db on modern macOS, so don't test the path.
+          [ -z "${CSC_KEYCHAIN:-}" ] || security delete-keychain "$CSC_KEYCHAIN" || true
 
   # Build Windows Electron app
   build-win:


### PR DESCRIPTION
## Why

Every `build-mac` job on the `macos-26` runner has failed since GitHub rolled the image to 20260831 (macOS 26.6), including the v0.5.18 release run:

```
⨯ /usr/bin/security process failed 1
Command failed: /usr/bin/security set-key-partition-list -S apple-tool:,apple: -s -k *** <tmp>.keychain
```

electron-builder passes the `.p12` import password to `set-key-partition-list -k`, which needs the keychain's own password. The newer `security` binary rejects the mismatch. Upstream: electron-userland/electron-builder#10066, fixed in PR #10101 but not yet released on 26.x (#10167).

| Runner image | build-mac |
|---|---|
| 20260728.0273.1 | pass |
| 20260831.0337.3 | fail |

## What

A "Set up signing keychain" step creates a keychain with a random password, imports the cert, runs `set-key-partition-list` with the right password, adds it (plus electron-builder's bundled Apple root certs) to the search list, and exports `CSC_KEYCHAIN`. `CSC_LINK` / `CSC_KEY_PASSWORD` are removed from the build step because electron-builder only honours `CSC_KEYCHAIN` when `CSC_LINK` is unset. A final `if: always()` step deletes the keychain.

Applied to `pr-build.yml`, `release.yml`, and `build-mac.yml` (Blacksmith is still on the older image; same failure once it refreshes).

No UI change.

https://claude.ai/code/session_01EHEbpzgt78jh2zBJzrzpfB
