### PR TITLE
feat(platform): add gpt-6-astra to the model catalog

### DIFF
--- a/src/shared/lib/llm-provider/builtin-catalogs.ts
+++ b/src/shared/lib/llm-provider/builtin-catalogs.ts
@@ -609,6 +609,22 @@ const PLATFORM_EXTRA_MODELS: ModelDefinition[] = [
     promptHints: GPT_TOOL_USE_PROMPT_HINTS,
   },
   {
+    // Not isLatest: the bare `gpt` alias stays on Sol so alias users don't jump 2x in price.
+    id: 'gpt-6-astra',
+    label: 'GPT-6 Astra',
+    blurb: 'OpenAI frontier, served via Platform',
+    family: 'gpt',
+    icon: 'openai',
+    supportedEfforts: NON_CLAUDE_EFFORTS,
+    supportedSpeeds: FLEX_AND_PRIORITY_SPEEDS,
+    ...PLATFORM_RESPONSES_WEB,
+    pricing: { inputPerMtok: 10, outputPerMtok: 50, speedMultipliers: GPT_SPEED_MULTIPLIERS },
+    // OpenAI API context window (developers.openai.com/api/docs/models/gpt-6-astra).
+    contextWindow: 1_050_000,
+    longContextPriceCliff: GPT_LONG_CONTEXT_CLIFF,
+    promptHints: GPT_TOOL_USE_PROMPT_HINTS,
+  },
+  {
     // Bare id matches the platform proxy's grok-* → xai-responses route.
     id: 'grok-4.6',
     label: 'Grok 4.6',

--- a/src/shared/lib/llm-provider/model-catalog.test.ts
+++ b/src/shared/lib/llm-provider/model-catalog.test.ts
@@ -219,6 +219,15 @@ describe('getProviderCatalog', () => {
       supportsWebFetch: false,
       pricing: { inputPerMtok: 5, outputPerMtok: 30 },
     })
+    // Astra is selectable but not the family default: the bare `gpt` alias stays on Sol.
+    expect(catalog.find((m) => m.id === 'gpt-6-astra')).toMatchObject({
+      family: 'gpt',
+      supportsWebSearch: true,
+      supportsWebFetch: false,
+      pricing: { inputPerMtok: 10, outputPerMtok: 50 },
+      contextWindow: 1_050_000,
+    })
+    expect(catalog.find((m) => m.id === 'gpt-6-astra')!.isLatest).toBeFalsy()
     const gptLatest = catalog.filter((m) => m.family === 'gpt' && m.isLatest)
     expect(gptLatest.map((m) => m.id)).toEqual(['gpt-5.6-sol'])
     // Grok rides the same Responses wire (xai-responses upstream); bare id only.

--- a/src/shared/lib/services/model-pricing.json
+++ b/src/shared/lib/services/model-pricing.json
@@ -267,6 +267,23 @@
       "cacheRead": 0.5
     }
   },
+  "gpt-6-astra": {
+    "input": 10,
+    "output": 50,
+    "cacheCreation": 12.5,
+    "cacheRead": 1,
+    "speedMultipliers": {
+      "slow": 0.5,
+      "fast": 2
+    },
+    "longContext": {
+      "thresholdTokens": 272000,
+      "input": 20,
+      "output": 75,
+      "cacheCreation": 25,
+      "cacheRead": 2
+    }
+  },
   "grok-4.5": {
     "input": 2,
     "output": 6,


### PR DESCRIPTION
## Why

OpenAI released GPT-6 Astra (`gpt-6-astra`) on Sep 3, 2026. The platform proxy is gaining support in [platform#400](https://github.com/SkillfulAgents/platform/pull/400); this makes it selectable in SuperAgent when the provider is Platform.

## What changed

- `PLATFORM_EXTRA_MODELS` (`builtin-catalogs.ts`): new `gpt-6-astra` entry — label "GPT-6 Astra", `family: 'gpt'`, flex/priority speeds, $10/$50 per Mtok, 1.05M context, 272K long-context cliff, same prompt hints as the other GPT entries.
- `model-pricing.json` (local usage tab): `gpt-6-astra` at $10 in / $1 cached / $12.50 cache write / $50 out; >272K reprices to $20 / $2 / $25 / $75; flex 0.5x, priority 2x.
- `model-catalog.test.ts`: asserts the entry's shape and that `gpt-5.6-sol` remains the only `isLatest` in the `gpt` family.

## Default / latest

Astra is **not** `isLatest`/`isDefault`. The bare `gpt` family alias resolves to the `isLatest` id, so flipping it would move every alias user from $5/$30 to $10/$50 without them choosing it. Flip it in a follow-up if that's the intent.

## Verification

- `vitest run` on `llm-provider`, `usage-service`, `model-pricing-refresh`, `model-family-list` → 362 passed.
- `eslint` on changed files → clean.
- `tsc --noEmit` → only 2 pre-existing errors in `file-type-icon.tsx` (`lucide-react` install drift, unrelated).

## Depends on

- [platform#400](https://github.com/SkillfulAgents/platform/pull/400) must be deployed before the proxy accepts `gpt-6-astra`; until then selecting it returns the proxy's unsupported-model error.

Made with [Cursor](https://cursor.com)