### PR TITLE
fix(voice): survive a request card, align the composer, recover a stalled reader, read aloud from the menu

### DIFF
--- a/e2e/specs/read-aloud-follow.spec.ts
+++ b/e2e/specs/read-aloud-follow.spec.ts
@@ -66,9 +66,6 @@ function installPillRecorder(page: Page) {
   })
 }
 
-/** The read-aloud controls row that appears under a reply once it is read: its height plus spacing. */
-const CONTROLS_ROW_PX = 32
-
 function distanceFromBottom(page: Page) {
   return page.evaluate(() => {
     const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')!
@@ -103,8 +100,10 @@ test.describe('read-aloud at the live edge', () => {
       }),
     )
     await page.route('**/api/voice/tts-token', async (route) => {
-      // Long enough for the connecting render to paint and settle on its own.
-      await new Promise((resolve) => setTimeout(resolve, 600))
+      // Long enough for the connecting render to paint and settle on its own,
+      // and for the menu-item click to return (WebKit takes most of a second
+      // to close the menu) before the connecting state is asserted.
+      await new Promise((resolve) => setTimeout(resolve, 1500))
       return route.fulfill({
         status: 500,
         contentType: 'application/json',
@@ -179,17 +178,12 @@ test.describe('read-aloud at the live edge', () => {
     // only a sanity check; the scroll events are the frame-independent record.
     expect(rec.frames).toBeGreaterThan(0)
     expect(rec.pillFrames).toBe(0)
-    // The press adds the controls row under the reply, so the content grows
-    // by that row at the live edge and the engine puts the viewport back.
-    // Every scroll event recorded is that put-back: never further from the
-    // edge than the row it is catching up with, and never moving away.
-    let last = Infinity
-    for (const s of rec.scrolls) {
-      const distance = s.sh - s.ch - s.top
-      expect(distance).toBeLessThan(24 + CONTROLS_ROW_PX)
-      expect(distance).toBeLessThanOrEqual(last)
-      last = distance
-    }
+    // WebKit reports the engine's put-back as a scroll event already at the
+    // live edge; Chromium never moves at all and reports nothing. (The
+    // controls overlay the reply rather than adding a row to it: a row
+    // appearing at the live edge would grow the content, and WebKit answers
+    // that by jumping the transcript to its top.)
+    for (const s of rec.scrolls) expect(s.sh - s.ch - s.top).toBeLessThan(24)
     await expect(page.getByRole('button', { name: 'Scroll to bottom' })).toBeHidden()
   })
 })

--- a/e2e/specs/read-aloud-follow.spec.ts
+++ b/e2e/specs/read-aloud-follow.spec.ts
@@ -66,6 +66,9 @@ function installPillRecorder(page: Page) {
   })
 }
 
+/** The read-aloud controls row that appears under a reply once it is read: its height plus spacing. */
+const CONTROLS_ROW_PX = 32
+
 function distanceFromBottom(page: Page) {
   return page.evaluate(() => {
     const el = document.querySelector<HTMLElement>('[data-testid="message-list"]')!
@@ -135,18 +138,21 @@ test.describe('read-aloud at the live edge', () => {
     await expect.poll(() => distanceFromBottom(page), { timeout: 10000 }).toBeLessThan(24)
     await expect(page.getByRole('button', { name: 'Scroll to bottom' })).toBeHidden()
 
-    // Hover the button, not the reply: WebKit scrolls a hovered element's top
-    // into view when it is taller than the viewport, and that programmatic
-    // jump (rightly) releases following before the press under test.
+    // Open the message menu at a point near the reply's bottom edge, which is
+    // on screen: a point nearer its top would make Playwright scroll it into
+    // view, and that programmatic jump (rightly) releases following before
+    // the press under test.
     const reply = page.getByTestId('message-assistant').last()
-    const speaker = reply.getByTestId('read-aloud-button')
-    await speaker.hover()
-    await expect(speaker).toBeVisible()
+    const box = await reply.boundingBox()
+    if (!box) throw new Error('the reply has no box')
+    await reply.click({ button: 'right', position: { x: 24, y: box.height - 12 } })
+    const readAloudItem = page.getByRole('menuitem', { name: 'Read aloud' })
+    await expect(readAloudItem).toBeVisible()
     await expect.poll(() => distanceFromBottom(page)).toBeLessThan(24)
     await expect(page.getByRole('button', { name: 'Scroll to bottom' })).toBeHidden()
     await installPillRecorder(page)
 
-    await speaker.click()
+    await readAloudItem.click()
 
     // Controls in, spans in — the first re-render.
     const controls = reply.getByTestId('read-aloud-controls')
@@ -157,7 +163,8 @@ test.describe('read-aloud at the live edge', () => {
     // Controls out, spans out — the second re-render, on the refused token.
     await expect(reply.getByTestId('read-aloud-error')).toHaveText('No speech in tests', { timeout: 10000 })
     await expect(reply.locator('[data-spoken-word]')).toHaveCount(0)
-    await expect(speaker).toBeVisible()
+    // The failed read leaves a speaker to try again.
+    await expect(reply.getByTestId('read-aloud-button')).toBeVisible()
 
     // Following held the whole way: the pill was never painted, the viewport
     // is back on the live edge, and nothing is left dangling above it.
@@ -172,9 +179,17 @@ test.describe('read-aloud at the live edge', () => {
     // only a sanity check; the scroll events are the frame-independent record.
     expect(rec.frames).toBeGreaterThan(0)
     expect(rec.pillFrames).toBe(0)
-    // WebKit reports the engine's put-back as a scroll event already at the
-    // live edge; Chromium never moves at all and reports nothing.
-    for (const s of rec.scrolls) expect(s.sh - s.ch - s.top).toBeLessThan(24)
+    // The press adds the controls row under the reply, so the content grows
+    // by that row at the live edge and the engine puts the viewport back.
+    // Every scroll event recorded is that put-back: never further from the
+    // edge than the row it is catching up with, and never moving away.
+    let last = Infinity
+    for (const s of rec.scrolls) {
+      const distance = s.sh - s.ch - s.top
+      expect(distance).toBeLessThan(24 + CONTROLS_ROW_PX)
+      expect(distance).toBeLessThanOrEqual(last)
+      last = distance
+    }
     await expect(page.getByRole('button', { name: 'Scroll to bottom' })).toBeHidden()
   })
 })

--- a/e2e/specs/user-input-requests.spec.ts
+++ b/e2e/specs/user-input-requests.spec.ts
@@ -83,7 +83,7 @@ test.describe('User Input Requests', () => {
     await sessionPage.waitForInputEnabled(15000)
   })
 
-  test('composer is replaced by the request card while a question is pending', async ({ page }) => {
+  test('composer is hidden behind the request card while a question is pending', async ({ page }) => {
     // Composer should be visible before the request arrives
     await expect(sessionPage.getMessageInput()).toBeVisible()
     await expect(page.locator('[data-testid="pending-request-slot"]')).toHaveCount(0)
@@ -91,9 +91,10 @@ test.describe('User Input Requests', () => {
     await sessionPage.sendMessage('ask question')
     await sessionPage.waitForQuestionRequest()
 
-    // While the question is pending, the composer is unmounted and the
-    // pending-request slot occupies its position.
-    await expect(sessionPage.getMessageInput()).toHaveCount(0)
+    // While the question is pending, the composer stays mounted (so a draft,
+    // or voice mode, survives the card) but hidden, and the pending-request
+    // slot occupies its position.
+    await expect(sessionPage.getMessageInput()).toBeHidden()
     await expect(page.locator('[data-testid="pending-request-slot"]')).toBeVisible()
 
     // Answer the question and verify the composer returns and the slot is gone.

--- a/src/renderer/components/layout/session-chat-column.test.tsx
+++ b/src/renderer/components/layout/session-chat-column.test.tsx
@@ -12,7 +12,7 @@ vi.mock('@renderer/components/messages/message-list', () => ({
   ),
 }))
 vi.mock('@renderer/components/messages/message-input', () => ({
-  MessageInput: () => <div data-testid="message-input-mock" />,
+  MessageInput: ({ suspended }: { suspended?: boolean }) => <div data-testid="message-input-mock" data-suspended={String(!!suspended)} />,
 }))
 vi.mock('@renderer/components/messages/agent-activity-indicator', () => ({
   AgentActivityIndicator: () => null,
@@ -83,18 +83,21 @@ describe('SessionChatColumn composer swap', () => {
 
   it('renders MessageInput when there are no pending requests', () => {
     renderWithProviders(<SessionChatColumn {...baseProps} />)
-    expect(screen.getByTestId('message-input-mock')).toBeInTheDocument()
+    expect(screen.getByTestId('message-input-mock')).toBeVisible()
+    expect(screen.getByTestId('message-input-mock')).toHaveAttribute('data-suspended', 'false')
     expect(screen.queryByTestId('pending-request-stack')).not.toBeInTheDocument()
     expect(screen.queryByTestId('pending-request-slot')).not.toBeInTheDocument()
   })
 
-  it('replaces MessageInput with PendingRequestStack when a request is pending', () => {
+  it('hides MessageInput behind the PendingRequestStack while a request is pending, keeping it mounted and paused', () => {
     mockPendingResult.items = [secretDescriptor]
     mockPendingResult.count = 1
 
     renderWithProviders(<SessionChatColumn {...baseProps} />)
 
-    expect(screen.queryByTestId('message-input-mock')).not.toBeInTheDocument()
+    // Mounted, so a draft or voice mode survives the request; paused and out of sight meanwhile.
+    expect(screen.getByTestId('message-input-mock')).not.toBeVisible()
+    expect(screen.getByTestId('message-input-mock')).toHaveAttribute('data-suspended', 'true')
     expect(screen.getByTestId('pending-request-slot')).toBeInTheDocument()
     expect(screen.getByTestId('pending-request-stack')).toBeInTheDocument()
     expect(screen.getByTestId('pending-secret')).toBeInTheDocument()
@@ -135,8 +138,9 @@ describe('SessionChatColumn composer swap', () => {
 
     renderWithProviders(<SessionChatColumn {...baseProps} />)
 
-    expect(screen.queryByText('Send')).not.toBeInTheDocument()
-    expect(screen.queryByText('New line')).not.toBeInTheDocument()
+    // Mounted behind the card with the composer, but out of sight.
+    expect(screen.getByText('Send')).not.toBeVisible()
+    expect(screen.getByText('New line')).not.toBeVisible()
   })
 
   it('shows the new-conversation notice for an old session with a large context', () => {

--- a/src/renderer/components/layout/session-chat-column.tsx
+++ b/src/renderer/components/layout/session-chat-column.tsx
@@ -97,107 +97,114 @@ export function SessionChatColumn({
       overlayFooter
       footerClassName="max-w-[740px] mx-auto w-full"
       footer={
-        pendingRequestCount > 0 ? (
-          <div className="px-4 pb-4" data-testid="pending-request-slot">
-            <PendingRequestStack>
-              {pendingRequestItems.map((d) => (
-                <PendingRequestErrorBoundary
-                  key={d.key}
+        <>
+          {pendingRequestCount > 0 && (
+            <div className="px-4 pb-4" data-testid="pending-request-slot">
+              <PendingRequestStack>
+                {pendingRequestItems.map((d) => (
+                  <PendingRequestErrorBoundary
+                    key={d.key}
+                    sessionId={sessionId}
+                    agentSlug={agentSlug}
+                    onDismiss={d.onComplete}
+                    itemId={d.key}
+                    kind={d.kind}
+                  >
+                    {renderPendingRequest(d, renderCtx)}
+                  </PendingRequestErrorBoundary>
+                ))}
+              </PendingRequestStack>
+            </div>
+          )}
+          {/* Kept mounted behind a request card, just hidden: what it holds (a
+              draft, voice mode) survives the request. Voice mode pauses for it
+              and picks the agent's turn back up once the card is answered. */}
+          <div hidden={pendingRequestCount > 0}>
+            <ProviderErrorPlacement placement="composer" sessionId={sessionId} agentSlug={agentSlug}>
+              {pendingWakeAt && pendingWakeTaskId && !isActive && (
+                <PendingWakeBanner
                   sessionId={sessionId}
                   agentSlug={agentSlug}
-                  onDismiss={d.onComplete}
-                  itemId={d.key}
-                  kind={d.kind}
-                >
-                  {renderPendingRequest(d, renderCtx)}
-                </PendingRequestErrorBoundary>
-              ))}
-            </PendingRequestStack>
-          </div>
-        ) : (
-          <ProviderErrorPlacement placement="composer" sessionId={sessionId} agentSlug={agentSlug}>
-            {pendingWakeAt && pendingWakeTaskId && !isActive && (
-              <PendingWakeBanner
+                  wakeAt={pendingWakeAt}
+                  taskId={pendingWakeTaskId}
+                  note={pendingWakeNote}
+                  readOnly={isViewOnly}
+                />
+              )}
+              {staleSession.showNotice && (
+                <StaleSessionNotice
+                  onIgnore={staleSession.ignore}
+                  onStartFresh={staleSession.startFresh}
+                  onLearnMoreOpenChange={staleSession.setLearnMoreOpen}
+                />
+              )}
+              <MessageInput
+                key={sessionId}
                 sessionId={sessionId}
                 agentSlug={agentSlug}
-                wakeAt={pendingWakeAt}
-                taskId={pendingWakeTaskId}
-                note={pendingWakeNote}
-                readOnly={isViewOnly}
+                onMessageSent={onMessageSent}
+                onMessageUuidAssigned={onMessageUuidAssigned}
+                onMessageFailed={onMessageFailed}
+                initialEffort={effort}
+                initialSpeed={speed}
+                initialModel={model}
+                registerSnapshot={staleSession.registerSnapshot}
+                suspended={pendingRequestCount > 0}
               />
-            )}
-            {staleSession.showNotice && (
-              <StaleSessionNotice
-                onIgnore={staleSession.ignore}
-                onStartFresh={staleSession.startFresh}
-                onLearnMoreOpenChange={staleSession.setLearnMoreOpen}
-              />
-            )}
-            <MessageInput
-              key={sessionId}
-              sessionId={sessionId}
-              agentSlug={agentSlug}
-              onMessageSent={onMessageSent}
-              onMessageUuidAssigned={onMessageUuidAssigned}
-              onMessageFailed={onMessageFailed}
-              initialEffort={effort}
-              initialSpeed={speed}
-              initialModel={model}
-              registerSnapshot={staleSession.registerSnapshot}
-            />
-            <div className="relative isolate flex items-center justify-between gap-1.5 overflow-hidden px-6 py-3">
-              <div
-                aria-hidden="true"
-                className="pointer-events-none absolute inset-y-0 left-0 z-0 w-[52%] bg-gradient-to-r from-background via-background/75 to-transparent backdrop-blur-[2px]"
-                style={{
-                  maskImage: 'linear-gradient(to right, black 0%, black 55%, transparent 100%)',
-                  WebkitMaskImage: 'linear-gradient(to right, black 0%, black 55%, transparent 100%)',
-                }}
-              />
-              <div
-                aria-hidden="true"
-                className="pointer-events-none absolute inset-y-0 right-0 z-0 w-[52%] bg-gradient-to-l from-background via-background/75 to-transparent backdrop-blur-[2px]"
-                style={{
-                  maskImage: 'linear-gradient(to left, black 0%, black 55%, transparent 100%)',
-                  WebkitMaskImage: 'linear-gradient(to left, black 0%, black 55%, transparent 100%)',
-                }}
-              />
-              {contextPercent != null ? (
-                <TooltipProvider delayDuration={0}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div className="relative z-10 flex cursor-default items-center gap-1.5">
-                        <span className="text-xs text-muted-foreground">Context Usage</span>
-                        <DonutChart
-                          percent={contextPercent}
-                          animated={isActive}
-                          size="sm"
-                          showLabel={false}
-                        />
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>{contextPercent}%</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              ) : (
-                <span className="relative z-10" />
-              )}
-              {voiceModeActive ? (
-                <span className="relative z-10" />
-              ) : (
-                <span className="relative z-10 flex items-center gap-1 text-xs text-muted-foreground">
-                  <kbd className="inline-flex items-center justify-center rounded-sm bg-muted border border-border/50 px-1 h-4 text-xs font-sans leading-none">↵</kbd>
-                  <span>Send</span>
-                  <span className="mx-1">·</span>
-                  <kbd className="inline-flex items-center justify-center rounded-sm bg-muted border border-border/50 px-1 h-4 text-xs font-sans leading-none">⇧↵</kbd>
-                  <span>New line</span>
-                </span>
-              )}
-            </div>
-          </ProviderErrorPlacement>
-        )
+              <div className="relative isolate flex items-center justify-between gap-1.5 overflow-hidden px-6 py-3">
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute inset-y-0 left-0 z-0 w-[52%] bg-gradient-to-r from-background via-background/75 to-transparent backdrop-blur-[2px]"
+                  style={{
+                    maskImage: 'linear-gradient(to right, black 0%, black 55%, transparent 100%)',
+                    WebkitMaskImage: 'linear-gradient(to right, black 0%, black 55%, transparent 100%)',
+                  }}
+                />
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute inset-y-0 right-0 z-0 w-[52%] bg-gradient-to-l from-background via-background/75 to-transparent backdrop-blur-[2px]"
+                  style={{
+                    maskImage: 'linear-gradient(to left, black 0%, black 55%, transparent 100%)',
+                    WebkitMaskImage: 'linear-gradient(to left, black 0%, black 55%, transparent 100%)',
+                  }}
+                />
+                {contextPercent != null ? (
+                  <TooltipProvider delayDuration={0}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div className="relative z-10 flex cursor-default items-center gap-1.5">
+                          <span className="text-xs text-muted-foreground">Context Usage</span>
+                          <DonutChart
+                            percent={contextPercent}
+                            animated={isActive}
+                            size="sm"
+                            showLabel={false}
+                          />
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>{contextPercent}%</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                ) : (
+                  <span className="relative z-10" />
+                )}
+                {voiceModeActive ? (
+                  <span className="relative z-10" />
+                ) : (
+                  <span className="relative z-10 flex items-center gap-1 text-xs text-muted-foreground">
+                    <kbd className="inline-flex items-center justify-center rounded-sm bg-muted border border-border/50 px-1 h-4 text-xs font-sans leading-none">↵</kbd>
+                    <span>Send</span>
+                    <span className="mx-1">·</span>
+                    <kbd className="inline-flex items-center justify-center rounded-sm bg-muted border border-border/50 px-1 h-4 text-xs font-sans leading-none">⇧↵</kbd>
+                    <span>New line</span>
+                  </span>
+                )}
+              </div>
+            </ProviderErrorPlacement>
+          </div>
+        </>
       }
     />
   )

--- a/src/renderer/components/messages/message-context-menu.tsx
+++ b/src/renderer/components/messages/message-context-menu.tsx
@@ -1,5 +1,5 @@
 
-import { Copy, Trash2 } from 'lucide-react'
+import { Copy, Square, Trash2, Volume2 } from 'lucide-react'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -12,9 +12,11 @@ interface MessageContextMenuProps {
   text: string
   children: React.ReactNode
   onRemove?: () => void
+  /** Offered on a reply that can be read aloud: start it, or stop the reading in progress. */
+  readAloud?: { active: boolean; onToggle: () => void }
 }
 
-export function MessageContextMenu({ text, children, onRemove }: MessageContextMenuProps) {
+export function MessageContextMenu({ text, children, onRemove, readAloud }: MessageContextMenuProps) {
   const handleCopy = async () => {
     try {
       const selection = window.getSelection()?.toString()
@@ -34,6 +36,12 @@ export function MessageContextMenu({ text, children, onRemove }: MessageContextM
           <Copy className="h-4 w-4 mr-2" />
           Copy
         </ContextMenuItem>
+        {readAloud && (
+          <ContextMenuItem onClick={readAloud.onToggle} data-testid="context-read-aloud">
+            {readAloud.active ? <Square className="h-4 w-4 mr-2 fill-current" /> : <Volume2 className="h-4 w-4 mr-2" />}
+            {readAloud.active ? 'Stop reading' : 'Read aloud'}
+          </ContextMenuItem>
+        )}
         {onRemove && (
           <>
             <ContextMenuSeparator />

--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -170,14 +170,14 @@ describe('MessageInput', () => {
 
       // The agent asks for something: the column hides the composer behind the card.
       rerender(<MessageInput sessionId="s-1" agentSlug="agent-1" suspended />)
-      expect(mockUseVoiceMode).toHaveBeenLastCalledWith(expect.objectContaining({ active: false }))
+      expect(mockUseVoiceMode).toHaveBeenLastCalledWith(expect.objectContaining({ active: true, paused: true }))
       expect(mockUseHoldSound).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: false }))
       expect(screen.getByTestId('voice-mode-composer')).toBeInTheDocument()
       // No "exited" notice: the person did not leave.
       expect(mockSendMessage.mutate).toHaveBeenCalledTimes(1)
 
       rerender(<MessageInput sessionId="s-1" agentSlug="agent-1" />)
-      expect(mockUseVoiceMode).toHaveBeenLastCalledWith(expect.objectContaining({ active: true }))
+      expect(mockUseVoiceMode).toHaveBeenLastCalledWith(expect.objectContaining({ active: true, paused: false }))
       expect(mockSendMessage.mutate).toHaveBeenCalledTimes(1)
 
       // Leave properly, so the deferred exit notice lands here and not in the next test.

--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -56,8 +56,9 @@ vi.mock('@renderer/hooks/use-voice-input', async (importOriginal) => {
   }
 })
 const mockVoice = { phase: 'listening' as 'listening' | 'thinking' | 'speaking', working: false }
+const mockUseVoiceMode = vi.fn()
 vi.mock('@renderer/hooks/use-voice-mode', () => ({
-  useVoiceMode: () => ({
+  useVoiceMode: (args: unknown) => mockUseVoiceMode(args) ?? ({
     phase: mockVoice.phase,
     working: mockVoice.working,
     utterance: '',
@@ -158,6 +159,30 @@ describe('MessageInput', () => {
       mockCanUseVoiceMode = true
       renderWithProviders(<MessageInput sessionId="s-1" agentSlug="agent-1" />)
       expect(screen.getByTestId('voice-mode-button')).toBeInTheDocument()
+    })
+
+    it('pauses behind a request card rather than ending, and resumes after it', async () => {
+      mockCanUseVoiceMode = true
+      const { rerender } = renderWithProviders(<MessageInput sessionId="s-1" agentSlug="agent-1" />)
+      await userEvent.click(screen.getByTestId('voice-mode-button'))
+      expect(mockUseVoiceMode).toHaveBeenLastCalledWith(expect.objectContaining({ active: true }))
+      expect(mockSendMessage.mutate).toHaveBeenCalledTimes(1)
+
+      // The agent asks for something: the column hides the composer behind the card.
+      rerender(<MessageInput sessionId="s-1" agentSlug="agent-1" suspended />)
+      expect(mockUseVoiceMode).toHaveBeenLastCalledWith(expect.objectContaining({ active: false }))
+      expect(mockUseHoldSound).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: false }))
+      expect(screen.getByTestId('voice-mode-composer')).toBeInTheDocument()
+      // No "exited" notice: the person did not leave.
+      expect(mockSendMessage.mutate).toHaveBeenCalledTimes(1)
+
+      rerender(<MessageInput sessionId="s-1" agentSlug="agent-1" />)
+      expect(mockUseVoiceMode).toHaveBeenLastCalledWith(expect.objectContaining({ active: true }))
+      expect(mockSendMessage.mutate).toHaveBeenCalledTimes(1)
+
+      // Leave properly, so the deferred exit notice lands here and not in the next test.
+      await userEvent.click(screen.getByTestId('voice-mode-exit'))
+      await waitFor(() => expect(mockSendMessage.mutate).toHaveBeenCalledTimes(2))
     })
 
     it('cannot be entered while a dictation is still recording', () => {

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -48,9 +48,15 @@ interface MessageInputProps {
   initialModel?: string
   /** Registers a getter so the stale-session prompt can move the live draft. */
   registerSnapshot?: (getSnapshot: (() => ComposerSnapshot) | null) => void
+  /**
+   * Hidden behind a request card the agent is waiting on. Voice mode pauses
+   * (mic and reader off, no hold sound) and resumes when the card is gone,
+   * rather than ending, so the agent is not told the person left.
+   */
+  suspended?: boolean
 }
 
-export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUuidAssigned, onMessageFailed, initialEffort, initialSpeed, initialModel, registerSnapshot }: MessageInputProps) {
+export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUuidAssigned, onMessageFailed, initialEffort, initialSpeed, initialModel, registerSnapshot, suspended = false }: MessageInputProps) {
   useRenderTracker('MessageInput')
   const { canUseAgent, isAuthMode } = useUser()
   const isViewOnly = !canUseAgent(agentSlug)
@@ -310,14 +316,14 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
   const voice = useVoiceMode({
     sessionId,
     agentSlug,
-    active: voiceModeOn && !isViewOnly,
+    active: voiceModeOn && !isViewOnly && !suspended,
     send: submitMessage,
     startWithAgentTurn: openedByVoice,
   })
   // Something to hear while the agent works, unless the person muted it.
   const holdSoundWanted = useHoldSoundPreference()
   useHoldSound({
-    enabled: voiceModeOn && !isViewOnly && holdSoundWanted,
+    enabled: voiceModeOn && !isViewOnly && !suspended && holdSoundWanted,
     agentTurn: voice.phase !== 'listening',
     working: voice.working,
   })

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -50,8 +50,9 @@ interface MessageInputProps {
   registerSnapshot?: (getSnapshot: (() => ComposerSnapshot) | null) => void
   /**
    * Hidden behind a request card the agent is waiting on. Voice mode pauses
-   * (mic and reader off, no hold sound) and resumes when the card is gone,
-   * rather than ending, so the agent is not told the person left.
+   * (mic closed, the reply being read finishes, no hold sound) and resumes
+   * when the card is gone, rather than ending, so the agent is not told the
+   * person left.
    */
   suspended?: boolean
 }
@@ -316,7 +317,8 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
   const voice = useVoiceMode({
     sessionId,
     agentSlug,
-    active: voiceModeOn && !isViewOnly && !suspended,
+    active: voiceModeOn && !isViewOnly,
+    paused: suspended,
     send: submitMessage,
     startWithAgentTurn: openedByVoice,
   })

--- a/src/renderer/components/messages/message-item.test.tsx
+++ b/src/renderer/components/messages/message-item.test.tsx
@@ -44,9 +44,18 @@ vi.mock('./sent-attachment-chip', async (importOriginal) => ({
   ),
 }))
 
-// Mock MessageContextMenu to just render children
+// Mock MessageContextMenu to render children, plus its read-aloud item as a plain button
 vi.mock('./message-context-menu', () => ({
-  MessageContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  MessageContextMenu: ({ children, readAloud }: { children: React.ReactNode; readAloud?: { active: boolean; onToggle: () => void } }) => (
+    <>
+      {children}
+      {readAloud && (
+        <button type="button" data-testid="context-read-aloud" data-active={String(readAloud.active)} onClick={readAloud.onToggle}>
+          {readAloud.active ? 'Stop reading' : 'Read aloud'}
+        </button>
+      )}
+    </>
+  ),
 }))
 
 // Mock tooltip to render inline (avoids Radix portal issues in tests)
@@ -74,6 +83,8 @@ const readAloudState = {
   toggle: vi.fn(),
   pause: vi.fn(),
   resume: vi.fn(),
+  speak: vi.fn(),
+  stop: vi.fn(),
 }
 
 vi.mock('@renderer/hooks/use-voice-input', () => ({
@@ -92,7 +103,13 @@ vi.mock('@renderer/hooks/use-read-aloud', () => ({
   }),
   useSpokenWordHighlight: () => {},
   useIsVoiceReading: () => false,
-  readAloud: { restart: vi.fn(), getPlayer: () => null, getStreamWordCursor: () => -1 },
+  readAloud: {
+    restart: vi.fn(),
+    getPlayer: () => null,
+    getStreamWordCursor: () => -1,
+    speak: (...args: unknown[]) => readAloudState.speak(...args),
+    stop: () => readAloudState.stop(),
+  },
 }))
 
 // The speed picker inside the controls reads user settings (react-query).
@@ -261,35 +278,51 @@ describe('MessageItem', () => {
   })
 
   describe('read aloud', () => {
-    it('offers a speaker button under a settled assistant reply when speech is configured', () => {
+    it('offers "Read aloud" in the message menu when speech is configured, and nothing under the reply', () => {
       readAloudState.configured = true
+      readAloudState.speak.mockClear()
       const msg = createAssistantMessage({ content: { text: 'Hello **there**.' } })
       render(<MessageItem message={msg} />)
-      const button = screen.getByTestId('read-aloud-button')
-      expect(button).toHaveAttribute('aria-label', 'Read aloud')
-      expect(button).toHaveAttribute('data-status', 'idle')
-      button.click()
-      expect(readAloudState.toggle).toHaveBeenCalledTimes(1)
+      expect(screen.queryByTestId('read-aloud-controls')).toBeNull()
+      expect(screen.queryByTestId('read-aloud-button')).toBeNull()
+      const item = screen.getByTestId('context-read-aloud')
+      expect(item).toHaveTextContent('Read aloud')
+      expect(item).toHaveAttribute('data-active', 'false')
+      item.click()
+      expect(readAloudState.speak).toHaveBeenCalledWith(msg.id, 'Hello **there**.')
+    })
+
+    it('offers "Stop reading" in the menu while this reply is being read', () => {
+      readAloudState.configured = true
+      readAloudState.stop.mockClear()
+      const msg = createAssistantMessage({ content: { text: 'Hello there world' } })
+      readAloudState.activeId = msg.id
+      render(<MessageItem message={msg} />)
+      const item = screen.getByTestId('context-read-aloud')
+      expect(item).toHaveTextContent('Stop reading')
+      item.click()
+      expect(readAloudState.stop).toHaveBeenCalledTimes(1)
     })
 
     it('shows nothing when the voice provider cannot speak', () => {
       const msg = createAssistantMessage({ content: { text: 'Hello there.' } })
       render(<MessageItem message={msg} />)
-      expect(screen.queryByTestId('read-aloud-button')).toBeNull()
+      expect(screen.queryByTestId('context-read-aloud')).toBeNull()
+      expect(screen.queryByTestId('read-aloud-controls')).toBeNull()
     })
 
     it('never offers it on user messages, streaming text, or provider errors', () => {
       readAloudState.configured = true
       const { unmount } = render(<MessageItem message={createUserMessage({ content: { text: 'hi' } })} />)
-      expect(screen.queryByTestId('read-aloud-button')).toBeNull()
+      expect(screen.queryByTestId('context-read-aloud')).toBeNull()
       unmount()
 
       const streaming = render(<MessageItem message={createAssistantMessage({ content: { text: 'partial' } })} isStreaming />)
-      expect(screen.queryByTestId('read-aloud-button')).toBeNull()
+      expect(screen.queryByTestId('context-read-aloud')).toBeNull()
       streaming.unmount()
 
       render(<MessageItem message={createAssistantMessage({ content: { text: 'boom' }, apiError: 'rate_limit' })} />)
-      expect(screen.queryByTestId('read-aloud-button')).toBeNull()
+      expect(screen.queryByTestId('context-read-aloud')).toBeNull()
     })
 
     it('renders the word spans and dims the prose only for the reply being read', () => {
@@ -344,11 +377,10 @@ describe('MessageItem', () => {
       expect(screen.getByTestId('read-aloud-button')).toBeInTheDocument()
     })
 
-    it('mounts only the speaker while idle', () => {
+    it('mounts nothing under the reply while idle', () => {
       readAloudState.configured = true
       render(<MessageItem message={createAssistantMessage({ content: { text: 'Hello there world' } })} />)
-      expect(screen.getByTestId('read-aloud-button')).toBeInTheDocument()
-      for (const id of ['read-aloud-pause', 'read-aloud-resume', 'read-aloud-stop', 'read-aloud-speed']) {
+      for (const id of ['read-aloud-controls', 'read-aloud-button', 'read-aloud-pause', 'read-aloud-resume', 'read-aloud-stop', 'read-aloud-speed']) {
         expect(screen.queryByTestId(id)).toBeNull()
       }
     })

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -27,6 +27,7 @@ import type { EmbeddedImageAliases } from '@renderer/lib/parse-tool-result'
 import { rehypeStreamingWordReveal } from './streaming-word-reveal'
 import { countSpokenWords, rehypeSpokenWords } from '@renderer/lib/speech/spoken-words'
 import { readAloud, useIsBeingRead, useSpokenWordHighlight } from '@renderer/hooks/use-read-aloud'
+import { useIsTtsConfigured } from '@renderer/hooks/use-voice-input'
 import { ReadAloudControls } from './read-aloud-controls'
 
 // Re-export for use by other components
@@ -416,7 +417,20 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
   // is one, then the persisted message it becomes. Its cursor counts words
   // per message, so the highlight follows across that swap.
   const isVoiceRead = !!voiceReading && isAssistant && !!hasText && !isProviderErrorMessage && (!!isStreaming || !!isLatestAssistant)
-  const isBeingRead = (useIsBeingRead(message.id) && canReadAloud) || isVoiceRead
+  const isThisBeingRead = useIsBeingRead(message.id) && canReadAloud
+  const isBeingRead = isThisBeingRead || isVoiceRead
+  // "Read aloud" lives in the message's context menu, so an idle reply
+  // carries no row for it; the controls appear under it only while it reads.
+  const ttsConfigured = useIsTtsConfigured()
+  const readAloudMenu = canReadAloud && ttsConfigured
+    ? {
+        active: isThisBeingRead,
+        onToggle: () => {
+          if (isThisBeingRead) readAloud.stop()
+          else void readAloud.speak(message.id, text)
+        },
+      }
+    : undefined
   const proseRef = useRef<HTMLDivElement>(null)
   const getSpokenCursor = useCallback(
     () => (isVoiceRead ? readAloud.getStreamWordCursor() : (readAloud.getPlayer()?.getWordCursor() ?? -1)),
@@ -500,7 +514,7 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
 
         {/* Message bubble - only show if there's text content */}
         {showMessageBubble && !bareUserRender && (
-          <MessageContextMenu text={text || ''} onRemove={onRemoveMessage ? () => onRemoveMessage(message.id) : undefined}>
+          <MessageContextMenu text={text || ''} onRemove={onRemoveMessage ? () => onRemoveMessage(message.id) : undefined} readAloud={readAloudMenu}>
             <div
               dir="auto"
               // Assistant bubbles opt into table breakout and must not clip it.
@@ -570,18 +584,8 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
           </MessageContextMenu>
         )}
 
-        {/* Read-aloud controls: revealed on hover, pinned while reading */}
-        {canReadAloud && (
-          <div
-            className={cn(
-              'flex items-center -mt-1 transition-opacity',
-              'opacity-0 group-hover/message:opacity-100 focus-within:opacity-100 touch:opacity-100',
-              isBeingRead && 'opacity-100',
-            )}
-          >
-            <ReadAloudControls messageId={message.id} markdown={text} />
-          </div>
-        )}
+        {/* Read-aloud controls: only while this reply is being read (or failed to be) */}
+        {canReadAloud && <ReadAloudControls messageId={message.id} markdown={text} className="-mt-1" />}
 
         {/* Attached file chips for user messages */}
         {isUser && attachedFiles.length > 0 && agentSlug && (() => {

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -523,7 +523,9 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
                 'rounded-lg max-w-full text-foreground',
                 !isAssistant && 'overflow-hidden',
                 isUser && 'bg-zinc-100 dark:bg-zinc-800/70 px-4 py-2',
-                isAssistant && 'py-1'
+                // Relative for the read-aloud controls, which overlay the
+                // gap under the bubble rather than adding a row to it.
+                isAssistant && 'relative py-1'
               )}
             >
               {/* Kind-specific user bubble (e.g. slash command) */}
@@ -580,12 +582,17 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
               {!hasText && isStreaming && (
                 <span className="inline-block w-2 h-4 bg-current animate-pulse" />
               )}
+
+              {/* Read-aloud controls, only while this reply is being read (or
+                  failed to be). Overlaid on the gap under the bubble: adding a
+                  row to the last reply at the live edge makes WebKit jump the
+                  transcript to its top. */}
+              {canReadAloud && (
+                <ReadAloudControls messageId={message.id} markdown={text} className="absolute left-0 top-full z-10 -mt-1" />
+              )}
             </div>
           </MessageContextMenu>
         )}
-
-        {/* Read-aloud controls: only while this reply is being read (or failed to be) */}
-        {canReadAloud && <ReadAloudControls messageId={message.id} markdown={text} className="-mt-1" />}
 
         {/* Attached file chips for user messages */}
         {isUser && attachedFiles.length > 0 && agentSlug && (() => {

--- a/src/renderer/components/messages/read-aloud-controls.tsx
+++ b/src/renderer/components/messages/read-aloud-controls.tsx
@@ -91,15 +91,19 @@ export function ReadAloudSpeedSelect({ testId = 'read-aloud-speed', align = 'sta
 }
 
 /**
- * Playback controls under an assistant reply. Idle: one speaker button.
- * While reading: pause/resume, stop, and the speed picker. Hidden entirely
- * when the voice provider can't synthesize speech.
+ * Playback controls under an assistant reply, only while it is being read:
+ * pause/resume, stop, and the speed picker. Nothing while idle (reading is
+ * started from the message's context menu, so the reply carries no extra
+ * row), except a failed read, which shows what went wrong next to a
+ * speaker to try again. Hidden entirely when the voice provider can't
+ * synthesize speech.
  */
 export function ReadAloudControls({ messageId, markdown, className }: ReadAloudControlsProps) {
   const configured = useIsTtsConfigured()
   const { status, toggle, pause, resume, error } = useReadAloud(messageId, markdown)
   if (!configured) return null
   const active = status !== 'idle'
+  if (!active && !error) return null
 
   return (
     <TooltipProvider>

--- a/src/renderer/components/messages/voice-mode-composer.tsx
+++ b/src/renderer/components/messages/voice-mode-composer.tsx
@@ -70,24 +70,26 @@ export function VoiceModeComposer({
           <AttachmentPreview attachments={attachments} onRemove={onRemoveAttachment} onRetry={onRetryAttachment} />
         </div>
       )}
+      {/* The transcript line and the indicator's margin above it add up to
+          the gap under the mic, so the mic sits midway between the working
+          indicator and the row of controls. */}
       <div
-        className="mx-auto mb-2 min-h-[1.25rem] max-w-md px-2 text-center text-sm italic text-muted-foreground"
+        className="mx-auto min-h-[1.25rem] max-w-md px-2 text-center text-sm italic text-muted-foreground"
         data-testid="voice-mode-transcript"
         aria-live="polite"
       >
         {phase === 'listening' ? utterance : ''}
       </div>
-      <div className="flex items-end justify-between gap-4">
-        <div className="pb-1">{attachmentPicker}</div>
-        <div className="flex flex-col items-center gap-3">
-          <VoiceMicButton phase={phase} getAnalyser={getAnalyser} onClick={onPressMic} />
+      <div className="flex flex-col items-center gap-7">
+        <VoiceMicButton phase={phase} getAnalyser={getAnalyser} onClick={onPressMic} />
+        <div className="grid w-full grid-cols-[1fr_auto_1fr] items-center gap-4">
+          <div className="justify-self-start">{attachmentPicker}</div>
           <div className="flex items-center gap-1">
             {composerOptions}
             {voiceControls}
           </div>
-        </div>
-        <div className="pb-1">
-          <Button
+          <div className="justify-self-end">
+            <Button
             type="button"
             size="icon"
             variant="outline"
@@ -97,8 +99,9 @@ export function VoiceModeComposer({
             title="Exit voice mode"
             data-testid="voice-mode-exit"
           >
-            <X className="h-4 w-4" />
-          </Button>
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
       </div>
       <VoiceInputError error={error} onDismiss={onClearError} className="mt-3 justify-center" />

--- a/src/renderer/hooks/use-voice-mode.test.tsx
+++ b/src/renderer/hooks/use-voice-mode.test.tsx
@@ -98,17 +98,24 @@ const STREAM_ID = 'voice:s1'
 
 function setup(options: { startWithAgentTurn?: boolean } = {}) {
   const send = vi.fn(async (_text: string) => true)
+  const props = { active: true, paused: false }
   const hook = renderHook(
-    ({ active }: { active: boolean }) => useVoiceMode({ sessionId: 's1', agentSlug: 'agent', active, send, ...options }),
-    { initialProps: { active: true } },
+    ({ active, paused }: { active: boolean; paused: boolean }) =>
+      useVoiceMode({ sessionId: 's1', agentSlug: 'agent', active, paused, send, ...options }),
+    { initialProps: { ...props } },
   )
   const listener = h.listeners[h.listeners.length - 1]
+  const rerender = (next: Partial<typeof props>) =>
+    act(() => {
+      Object.assign(props, next)
+      hook.rerender({ ...props })
+    })
   const setStream = (next: Partial<typeof stream.state>) =>
     act(() => {
       stream.state = { ...stream.state, ...next }
-      hook.rerender({ active: true })
+      hook.rerender({ ...props })
     })
-  return { ...hook, send, listener, setStream }
+  return { ...hook, rerender, send, listener, setStream }
 }
 
 async function flush() {
@@ -482,15 +489,17 @@ describe('useVoiceMode', () => {
     setStream({ isActive: true, streamingMessage: 'Which account? ' })
     expect(reader.pushStream).toHaveBeenLastCalledWith(STREAM_ID, 'Which account? ')
 
-    // The request card is up: voice mode pauses.
-    rerender({ active: false })
+    // The request card is up: the mic closes, the question is read to its end.
+    rerender({ paused: true })
     expect(listener.stop).toHaveBeenCalledTimes(1)
-    expect(reader.stop).toHaveBeenCalled()
+    expect(reader.endStream).toHaveBeenCalledWith(STREAM_ID)
+    expect(reader.stop).not.toHaveBeenCalled()
     reader.beginStream.mockClear()
     reader.pushStream.mockClear()
 
     // Answered; the turn carries on. The question is not read again.
-    rerender({ active: true })
+    rerender({ paused: false })
+    expect(h.listeners).toHaveLength(2)
     expect(result.current.phase).toBe('thinking')
     expect(reader.beginStream).not.toHaveBeenCalled()
     setStream({ streamingMessage: 'Connected. Anything else? ' })
@@ -499,6 +508,28 @@ describe('useVoiceMode', () => {
     setStream({ isActive: false })
     act(() => reader.set({ activeId: null, status: 'idle' }))
     expect(result.current.phase).toBe('listening')
+  })
+
+  it('resumed after the card with the agent gone quiet, it waits for the turn to show up again, bounded', async () => {
+    vi.useFakeTimers()
+    try {
+      const { result, rerender, listener, setStream } = setup()
+      act(() => listener.hear('connect my calendar'))
+      act(() => listener.events.onSpeechEnded())
+      await flush()
+      setStream({ isActive: true, streamingMessage: 'Which account? ' })
+      rerender({ paused: true })
+      // The stream reports idle while the card is up (the turn is between steps).
+      setStream({ isActive: false, streamingMessage: null })
+      act(() => reader.set({ activeId: null, status: 'idle' }))
+      rerender({ paused: false })
+      expect(result.current.phase).toBe('thinking')
+      // It comes back: read as the agent's reply.
+      setStream({ isActive: true, streamingMessage: 'Connected. ' })
+      expect(reader.pushStream).toHaveBeenLastCalledWith(STREAM_ID, 'Connected. ')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('entered while the agent is already replying, it reads what follows', () => {

--- a/src/renderer/hooks/use-voice-mode.test.tsx
+++ b/src/renderer/hooks/use-voice-mode.test.tsx
@@ -474,6 +474,42 @@ describe('useVoiceMode', () => {
     expect(reader.pushStream).toHaveBeenLastCalledWith(STREAM_ID, 'Hi, I am listening. ')
   })
 
+  it('paused for a request card mid-turn, then resumed: the agent keeps the floor and the rest of its reply is read', async () => {
+    const { result, rerender, listener, setStream } = setup()
+    act(() => listener.hear('connect my calendar'))
+    act(() => listener.events.onSpeechEnded())
+    await flush()
+    setStream({ isActive: true, streamingMessage: 'Which account? ' })
+    expect(reader.pushStream).toHaveBeenLastCalledWith(STREAM_ID, 'Which account? ')
+
+    // The request card is up: voice mode pauses.
+    rerender({ active: false })
+    expect(listener.stop).toHaveBeenCalledTimes(1)
+    expect(reader.stop).toHaveBeenCalled()
+    reader.beginStream.mockClear()
+    reader.pushStream.mockClear()
+
+    // Answered; the turn carries on. The question is not read again.
+    rerender({ active: true })
+    expect(result.current.phase).toBe('thinking')
+    expect(reader.beginStream).not.toHaveBeenCalled()
+    setStream({ streamingMessage: 'Connected. Anything else? ' })
+    expect(reader.beginStream).toHaveBeenCalledWith(STREAM_ID)
+    expect(reader.pushStream).toHaveBeenLastCalledWith(STREAM_ID, 'Connected. Anything else? ')
+    setStream({ isActive: false })
+    act(() => reader.set({ activeId: null, status: 'idle' }))
+    expect(result.current.phase).toBe('listening')
+  })
+
+  it('entered while the agent is already replying, it reads what follows', () => {
+    stream.state = { streamingToolUses: [], isActive: true, streamingMessage: 'Half way through. ' }
+    const { result, setStream } = setup()
+    expect(result.current.phase).toBe('thinking')
+    expect(reader.beginStream).not.toHaveBeenCalled()
+    setStream({ streamingMessage: 'Half way through. And the rest. ' })
+    expect(reader.pushStream).toHaveBeenLastCalledWith(STREAM_ID, 'Half way through. And the rest. ')
+  })
+
   it('turning voice mode off releases the mic and silences the reader', () => {
     const { rerender, listener } = setup()
     rerender({ active: false })

--- a/src/renderer/hooks/use-voice-mode.ts
+++ b/src/renderer/hooks/use-voice-mode.ts
@@ -47,6 +47,13 @@ interface UseVoiceModeArgs {
    * so the reply is read rather than waited out.
    */
   startWithAgentTurn?: boolean
+  /**
+   * The person is answering a request card the agent put up. The mic
+   * closes (the card takes the answer), the reply being read finishes
+   * rather than stopping mid-sentence, and when the card is gone the floor
+   * is the agent's again for whatever it says next.
+   */
+  paused?: boolean
 }
 
 /**
@@ -54,7 +61,8 @@ interface UseVoiceModeArgs {
  * utterances are sent on silence, and a reader that speaks each reply as it
  * streams in. Talking over the agent (or pressing the mic) interrupts it.
  */
-export function useVoiceMode({ sessionId, agentSlug, active, send, startWithAgentTurn = false }: UseVoiceModeArgs) {
+export function useVoiceMode({ sessionId, agentSlug, active, send, startWithAgentTurn = false, paused = false }: UseVoiceModeArgs) {
+  const listening = active && !paused
   const { isActive, streamingMessage, streamingToolUses } = useMessageStream(active ? sessionId : null, active ? agentSlug : null)
   const toolsRunning = (streamingToolUses?.length ?? 0) > 0
   const interruptSession = useInterruptSession()
@@ -82,6 +90,9 @@ export function useVoiceMode({ sessionId, agentSlug, active, send, startWithAgen
   const interruptRef = useRef<() => void>(() => {})
   const userTurnRef = useRef(userTurn)
   userTurnRef.current = userTurn
+  // Set alongside the state where an effect in the same commit must see it.
+  const awaitingTurnRef = useRef(awaitingTurn)
+  awaitingTurnRef.current = awaitingTurn
   const isActiveRef = useRef(isActive)
   isActiveRef.current = isActive
   // A send is confirmed by the stream reporting a turn that began after it.
@@ -170,10 +181,11 @@ export function useVoiceMode({ sessionId, agentSlug, active, send, startWithAgen
     else interrupt()
   }, [sendUtterance, interrupt])
 
-  // Open the mic for as long as voice mode is on. A mic that dies (its
-  // socket gone for good) is reopened after a pause, longer each time.
+  // Open the mic for as long as voice mode is on and not paused for a
+  // request card. A mic that dies (its socket gone for good) is reopened
+  // after a pause, longer each time.
   useEffect(() => {
-    if (!active) return
+    if (!listening) return
     let restartTimer: ReturnType<typeof setTimeout> | null = null
     const scheduleRestart = () => {
       if (restartTimer) return
@@ -244,11 +256,10 @@ export function useVoiceMode({ sessionId, agentSlug, active, send, startWithAgen
       }
       listener.stop()
       if (listenerRef.current === listener) listenerRef.current = null
-      readAloud.stop()
-      readerStartedRef.current = false
-      fedRef.current = ''
     }
-  }, [active, sessionId, sendUtterance, streamId, listenerEpoch])
+  }, [listening, sessionId, sendUtterance, streamId, listenerEpoch])
+  // Whatever is being read stops with the hook (the session view is gone).
+  useEffect(() => () => readAloud.stop(), [])
   interruptRef.current = interrupt
 
   useEffect(() => {
@@ -256,27 +267,51 @@ export function useVoiceMode({ sessionId, agentSlug, active, send, startWithAgen
     else if (toolsRunning) setToolCalled(true)
   }, [userTurn, toolsRunning])
 
-  // Voice mode off: the floor is nobody's. (Not in the cleanup above — a
-  // development-mode remount re-runs that with the mode still on, and would
-  // hand the floor to the person while the agent is mid-reply.)
+  // Voice mode off: the floor is nobody's and the reader is silent. (Not
+  // in the mic's cleanup above — a development-mode remount re-runs that
+  // with the mode still on, and would hand the floor to the person while
+  // the agent is mid-reply.) Paused for a request card: the reply being
+  // read finishes. Back from the card, or coming on while the agent's turn
+  // is running: the floor is the agent's, and what it said before is not
+  // read again, only what follows.
+  const wasPausedRef = useRef(false)
   useEffect(() => {
-    if (active) {
-      // Coming on (or back on, after a request card) while the agent's turn
-      // is running: the floor is the agent's, and what it said before is
-      // not read again, only what follows.
-      if (isActiveRef.current) {
-        staleTextRef.current = streamingRef.current ?? ''
-        setUserTurn(false)
-        setAwaitingTurn(false)
+    if (!active) {
+      readAloud.stop()
+      readerStartedRef.current = false
+      fedRef.current = ''
+      setUtterance('')
+      setUserTurn(true)
+      setAwaitingTurn(false)
+      listenerRestartsRef.current = 0
+      interruptPendingRef.current = null
+      wasPausedRef.current = false
+      return
+    }
+    if (paused) {
+      wasPausedRef.current = true
+      if (readerStartedRef.current) {
+        readAloud.endStream(streamId)
+        readerStartedRef.current = false
+        fedRef.current = ''
       }
       return
     }
-    setUtterance('')
-    setUserTurn(true)
-    setAwaitingTurn(false)
-    listenerRestartsRef.current = 0
-    interruptPendingRef.current = null
-  }, [active])
+    const resumed = wasPausedRef.current
+    wasPausedRef.current = false
+    if (isActiveRef.current) {
+      staleTextRef.current = streamingRef.current ?? ''
+      setUserTurn(false)
+      setAwaitingTurn(false)
+    } else if (resumed && !userTurnRef.current) {
+      // The agent had the floor when the card went up and its turn has not
+      // shown up again yet: wait for it as after a send (bounded).
+      staleTextRef.current = streamingRef.current ?? ''
+      turnStartArmedRef.current = true
+      awaitingTurnRef.current = true
+      setAwaitingTurn(true)
+    }
+  }, [active, paused, streamId])
 
   // The stream confirms the turn started: it reports active after having
   // been idle since the send (an interrupted turn still winding down does
@@ -300,7 +335,7 @@ export function useVoiceMode({ sessionId, agentSlug, active, send, startWithAgen
   // Feed the reply to the reader as it streams in. Tool calls are not text
   // and never reach here; each assistant message of the turn is a segment.
   useEffect(() => {
-    if (!active || userTurn) return
+    if (!listening || userTurn) return
     const text = streamingMessage ?? ''
     if (text && text === staleTextRef.current) return
     staleTextRef.current = null
@@ -320,7 +355,7 @@ export function useVoiceMode({ sessionId, agentSlug, active, send, startWithAgen
     }
     fedRef.current = text
     readAloud.pushStream(streamId, text)
-  }, [active, userTurn, streamingMessage, streamId])
+  }, [listening, userTurn, streamingMessage, streamId])
 
   // The turn ended: let the reader finish what it has.
   useEffect(() => {
@@ -336,11 +371,12 @@ export function useVoiceMode({ sessionId, agentSlug, active, send, startWithAgen
   // tail of the reply, and are kept; anything older was noise while the
   // agent spoke.
   useEffect(() => {
-    if (!active || userTurn || awaitingTurn || isActive || readerActive) return
+    // (The ref covers the commit in which resuming from a pause set the wait.)
+    if (!listening || userTurn || awaitingTurn || awaitingTurnRef.current || isActive || readerActive) return
     setUserTurn(true)
     const listener = listenerRef.current
     if (listener?.utterance.trim() && Date.now() - lastHeardAtRef.current > KEEP_RECENT_WORDS_MS) void listener.discard()
-  }, [active, userTurn, awaitingTurn, isActive, readerActive])
+  }, [listening, userTurn, awaitingTurn, isActive, readerActive])
 
   const phase: VoiceModePhase = userTurn ? 'listening' : readerSpeaking ? 'speaking' : 'thinking'
   const getAnalyser = useCallback(() => listenerRef.current?.analyser ?? null, [])

--- a/src/renderer/hooks/use-voice-mode.ts
+++ b/src/renderer/hooks/use-voice-mode.ts
@@ -260,7 +260,17 @@ export function useVoiceMode({ sessionId, agentSlug, active, send, startWithAgen
   // development-mode remount re-runs that with the mode still on, and would
   // hand the floor to the person while the agent is mid-reply.)
   useEffect(() => {
-    if (active) return
+    if (active) {
+      // Coming on (or back on, after a request card) while the agent's turn
+      // is running: the floor is the agent's, and what it said before is
+      // not read again, only what follows.
+      if (isActiveRef.current) {
+        staleTextRef.current = streamingRef.current ?? ''
+        setUserTurn(false)
+        setAwaitingTurn(false)
+      }
+      return
+    }
     setUtterance('')
     setUserTurn(true)
     setAwaitingTurn(false)

--- a/src/renderer/lib/speech/speech-player.test.ts
+++ b/src/renderer/lib/speech/speech-player.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { SpeechPlayer, type SpeechPlayerStatus } from './speech-player'
+import { SpeechPlayer, SYNTHESIS_STALL_MS, CLOCK_STALL_MS, type SpeechPlayerStatus } from './speech-player'
 import type { TtsAdapter, TtsAudioCallback, TtsEventCallback } from '@renderer/lib/tts'
 import type { SpokenWord } from './spoken-words'
 
@@ -100,6 +100,54 @@ function setup() {
 describe('SpeechPlayer', () => {
   beforeEach(() => { vi.useFakeTimers() })
   afterEach(() => { vi.useRealTimers() })
+
+  it('a sentence the synthesizer never answers fails the player, so the reader can retry it', () => {
+    const { adapter, player, errors } = setup()
+    player.start()
+    player.append(words('One two three.'))
+    expect(adapter.sent).toEqual(['speak:One two three.', 'flush'])
+    vi.advanceTimersByTime(SYNTHESIS_STALL_MS - 1000)
+    expect(player.status).toBe('connecting')
+    vi.advanceTimersByTime(2000)
+    expect(player.status).toBe('error')
+    expect(errors.at(-1)?.message).toMatch(/stalled/)
+    expect(adapter.closed).toBe(true)
+  })
+
+  it('a synthesizer that keeps answering, however slowly, is not a stall', () => {
+    const { adapter, ctx, player } = setup()
+    player.start()
+    player.append(words('One two three. Four five six.'))
+    expect(adapter.sent).toHaveLength(4)
+    vi.advanceTimersByTime(SYNTHESIS_STALL_MS - 2000)
+    adapter.pushAudio(2)
+    adapter.pushFlushed()
+    for (let i = 0; i < 3; i++) {
+      ctx.currentTime += 1
+      vi.advanceTimersByTime(1000)
+    }
+    expect(player.status).toBe('speaking')
+    vi.advanceTimersByTime(SYNTHESIS_STALL_MS - 4000)
+    adapter.pushAudio(2)
+    expect(player.status).toBe('speaking')
+  })
+
+  it('an audio clock that stops with audio scheduled is resumed, then given up on', () => {
+    const { adapter, ctx, player, errors } = setup()
+    player.start()
+    player.append(words('One two three.'))
+    adapter.pushAudio(3)
+    adapter.pushFlushed()
+    expect(player.status).toBe('speaking')
+    // The output device went away: the browser suspends the context and the clock freezes.
+    ctx.state = 'suspended'
+    vi.advanceTimersByTime(2500)
+    expect(ctx.resume).toHaveBeenCalled()
+    expect(player.status).toBe('speaking')
+    vi.advanceTimersByTime(CLOCK_STALL_MS + 1000)
+    expect(player.status).toBe('error')
+    expect(errors.at(-1)?.message).toMatch(/Audio output stalled/)
+  })
 
   it('sends each sentence as its own speak+flush batch as words arrive', () => {
     const { adapter, player } = setup()

--- a/src/renderer/lib/speech/speech-player.ts
+++ b/src/renderer/lib/speech/speech-player.ts
@@ -51,6 +51,20 @@ interface ScheduledSegment extends SpeechSegment {
 const LEAD_S = 0.05
 /** Slack after the last scheduled sample before declaring playback done. */
 const DONE_GRACE_MS = 80
+/** How often the watchdog looks at the synthesizer and the audio clock. */
+const WATCHDOG_MS = 1_000
+/**
+ * A sentence handed to the synthesizer with nothing back (no audio, no
+ * flush) for this long: the connection is dead, whatever the socket says.
+ * Its first audio normally arrives well under a second.
+ */
+export const SYNTHESIS_STALL_MS = 10_000
+/**
+ * Audio scheduled ahead but the clock not moving for this long: the output
+ * device went away (headphones off, a Bluetooth switch) and the browser did
+ * not say so. A resume is tried first.
+ */
+export const CLOCK_STALL_MS = 4_000
 /**
  * How far ahead of playback to keep audio scheduled. Segments are sent only
  * as this runs down (plus a couple in flight so the synthesizer's latency is
@@ -123,6 +137,11 @@ export class SpeechPlayer {
   private carry: Uint8Array | null = null
   private ended = false
   private doneTimer: ReturnType<typeof setTimeout> | null = null
+  private watchdogTimer: ReturnType<typeof setInterval> | null = null
+  /** When the synthesizer last sent anything, or was last asked. */
+  private lastSynthesisAt = 0
+  private lastClock = -1
+  private clockStalledSince: number | null = null
   private _status: SpeechPlayerStatus = 'connecting'
   private wordCount = 0
   /** High-water mark of the cursor, so it never reads backwards. */
@@ -183,6 +202,34 @@ export class SpeechPlayer {
     this.adapter.connect(this.token, this.voice).catch((err: unknown) => {
       this.fail(err instanceof Error ? err : new Error('Failed to connect to text-to-speech'))
     })
+    // Neither the socket nor the audio graph promises to report its death;
+    // a player that waits on either forever is minutes of silent "speaking".
+    this.watchdogTimer = setInterval(() => this.watchdog(), WATCHDOG_MS)
+  }
+
+  private watchdog(): void {
+    if (this.isTerminal || this._status === 'paused') return
+    const ctx = this.ctx
+    const now = Date.now()
+    if (ctx && this.bufferedAhead() > 0) {
+      if (ctx.currentTime === this.lastClock) {
+        this.clockStalledSince ??= now
+        if (ctx.state === 'suspended') ctx.resume().catch(() => {})
+        if (now - this.clockStalledSince >= CLOCK_STALL_MS) {
+          this.fail(new Error('Audio output stalled'))
+          return
+        }
+      } else {
+        this.clockStalledSince = null
+      }
+      this.lastClock = ctx.currentTime
+    } else {
+      this.clockStalledSince = null
+      if (ctx) this.lastClock = ctx.currentTime
+    }
+    if (this.sent > this.receiving && now - this.lastSynthesisAt >= SYNTHESIS_STALL_MS) {
+      this.fail(new Error('Text-to-speech stalled: nothing came back for the last sentence'))
+    }
   }
 
   /**
@@ -247,6 +294,8 @@ export class SpeechPlayer {
   resume(): void {
     if (this._status !== 'paused' || !this.ctx) return
     void this.ctx.resume()
+    // The pause is not the synthesizer's silence.
+    this.lastSynthesisAt = Date.now()
     this.setStatus('speaking')
     this.pump()
     this.maybeFinish()
@@ -325,6 +374,7 @@ export class SpeechPlayer {
       const segment = this.segments[this.sent++]
       this.adapter.speak(segment.text)
       this.adapter.flush()
+      this.lastSynthesisAt = Date.now()
     }
     if (this.sent < this.segments.length && this.sent - this.receiving < MAX_IN_FLIGHT) {
       const delayMs = Math.max(100, (this.bufferedAhead() - AHEAD_S) * 1000)
@@ -335,6 +385,7 @@ export class SpeechPlayer {
   private handleAudio(chunk: ArrayBuffer): void {
     const ctx = this.ctx
     if (!ctx || this.isTerminal) return
+    this.lastSynthesisAt = Date.now()
 
     let bytes = new Uint8Array(chunk)
     if (this.carry) {
@@ -440,6 +491,7 @@ export class SpeechPlayer {
     if (this.isTerminal) return
     switch (event.type) {
       case 'flushed': {
+        this.lastSynthesisAt = Date.now()
         const segment = this.segments[this.receiving]
         if (segment) {
           // A short segment may never reach the measuring threshold: level
@@ -512,6 +564,10 @@ export class SpeechPlayer {
     if (this.doneTimer) {
       clearTimeout(this.doneTimer)
       this.doneTimer = null
+    }
+    if (this.watchdogTimer) {
+      clearInterval(this.watchdogTimer)
+      this.watchdogTimer = null
     }
     if (this.pumpTimer) {
       clearTimeout(this.pumpTimer)


### PR DESCRIPTION
Four follow-ups to voice mode (#991).

## Voice mode survives a request card

When the agent asked for anything (a connected account, a secret, a question), voice mode ended on its own: the chat column swaps the composer out for the request card, so the composer unmounted, its unmount cleanup sent the "user left voice mode" notice, and the mode's state went with it. Answering the card brought back a text composer.

Now the composer stays mounted behind the card, hidden, with a new `suspended` prop. While suspended, voice mode pauses rather than ends: the mic closes (the card takes the answer), the reply being read finishes instead of stopping mid-sentence, the hold sound is off, and no notice is sent. When the card is answered the composer comes back and the floor is the agent's again: what it said before the pause is not read again, only what follows. If its turn has not shown up again yet, the mode waits for it as it does after a send, bounded by the same grace period. Entering voice mode while the agent is already replying works the same way.

A side effect for text mode: a draft typed before a request card no longer disappears behind it.

## Composer alignment

The attachment picker and the exit button sat higher than the model selector, and the mic sat much closer to the row of controls than to the working indicator above it. The bottom row is now a three-column grid with its items vertically centred, and the gap under the mic matches the transcript line plus the indicator's margin above it, so the mic sits midway between the two.

## A stalled reader fails and retries, instead of "speaking" silently for good

Seen in the field: narration stopped part-way, the highlight frozen on the first word of a sentence, the mic in its speaking state, for over a minute while a tool call ran. The player waits on two things that do not promise to report their death: the speak socket (a sentence sent with nothing back, no close frame) and the audio graph (a clock that stops with audio scheduled, as when the output device goes away).

A watchdog in the player now fails it after ten seconds without a reply from the synthesizer for a sentence it was given, or four seconds of a frozen clock, after trying to resume the context. A failure goes through the reader's existing retry: fresh credentials, a fresh player, and the unspoken words requeued from the cursor, so the stuck sentence is said again rather than lost. Two stalls in a row surface as an error.

## "Read aloud" moves into the message menu

The hover-revealed speaker under every assistant reply reserved a row of space whether or not anyone used it. It now lives in the message's context menu next to Copy, as "Read aloud" or "Stop reading" while that reply is being read. The controls (pause, stop, speed) appear under a reply only while it is being read, or after a failed read, where they keep a speaker to try again. They overlay the gap under the bubble rather than adding a row: growing the last reply by a row at the live edge made WebKit jump the transcript to its top (caught by the WebKit E2E job on the first cut of this change). Idle replies carry nothing extra.

## Screenshots

Mock instance. Voice mode with the agent working: mic centred between the indicator and the controls, picker, selector and exit on one line. And a reply's context menu with "Read aloud" in it, no row under the reply.

| Light | Dark |
| --- | --- |
| ![Read aloud in the message menu (light)](https://github.com/user-attachments/assets/b4d18ec2-ef27-4960-88e2-f6ff620b163a) | ![Read aloud in the message menu (dark)](https://github.com/user-attachments/assets/9f229514-8213-4514-a1dd-4096a9711d80) |
| ![Voice mode, agent working (light)](https://github.com/user-attachments/assets/584ce89f-7af6-49a3-80a5-e3bd85f2946d) | ![Voice mode, agent working (dark)](https://github.com/user-attachments/assets/ae5ffbd0-0c97-41da-a621-2622f67d5506) |

## Tests

- `session-chat-column`: the composer is hidden and suspended behind a pending request, not unmounted.
- `message-input`: voice mode pauses while suspended and resumes after, with no exit notice in between.
- `use-voice-mode`: paused for a request card mid-turn, the mic closes and the reply being read finishes; resumed, the agent keeps the floor and the rest of its reply is read; resumed with the agent gone quiet, it waits for the turn to show up again; entered while the agent is already replying, what follows is read.
- `speech-player`: a sentence the synthesizer never answers fails the player; a slow synthesizer that keeps answering is not a stall; a stopped audio clock is resumed, then given up on.
- `message-item`: "Read aloud" / "Stop reading" in the menu, nothing under an idle reply, the controls only while reading.
- `read-aloud-follow` E2E (Chromium and WebKit): starts the read from the menu; still asserts nothing moves, since the overlaid controls change no layout.
- Voice-mode E2E spec: 4 of 4 passing.
- `user-input-requests` E2E: the "composer is replaced" case now asserts hidden rather than unmounted, which is the new behaviour.

https://claude.ai/code/session_01LSocDkQvRLodzzz6durSoM
