### PR TITLE
fix(file-preview): allow selecting text lines

### DIFF
--- a/src/renderer/components/file-preview/renderers/text-renderer.test.tsx
+++ b/src/renderer/components/file-preview/renderers/text-renderer.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { TextRenderer } from './text-renderer'
+
+vi.mock('./use-file-content', () => ({
+  useFileContent: () => ({
+    data: { text: 'first line\nsecond line', truncated: false },
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+vi.mock('../comments/use-text-selection', () => ({
+  useTextSelection: () => ({ selection: null, clearSelection: vi.fn() }),
+}))
+
+describe('TextRenderer', () => {
+  it('makes file contents selectable without including line numbers', () => {
+    render(<TextRenderer url="/file.txt" filePath="/file.txt" agentSlug="test-agent" />)
+
+    expect(screen.getByText('first line')).toHaveClass('select-text')
+    expect(screen.getByText('1')).toHaveClass('select-none')
+  })
+})

--- a/src/renderer/components/file-preview/renderers/text-renderer.tsx
+++ b/src/renderer/components/file-preview/renderers/text-renderer.tsx
@@ -44,7 +44,7 @@ export function TextRenderer({ url, filePath, agentSlug, commentsEnabled = true 
                   <td className="pr-4 text-right text-muted-foreground/50 select-none align-top tabular-nums w-[1%] whitespace-nowrap">
                     {i + 1}
                   </td>
-                  <td className="whitespace-pre-wrap break-all">
+                  <td className="whitespace-pre-wrap break-all select-text">
                     {line || '\n'}
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary

- allow selecting one or more lines in plain-text file previews
- keep line numbers excluded from selections and copied snippets
- cover the selectable content boundary with a renderer regression test

## Testing

- `npm run typecheck`
- `npm run lint` (passes with 40 existing warnings)
- `npx vitest run src/renderer/components/file-preview/renderers/text-renderer.test.tsx`
- browser drag selection verified in light and dark modes; selected text excludes line numbers

## Screenshots

| Light | Dark |
| --- | --- |
| ![Selectable file preview (light)](https://github.com/user-attachments/assets/964124c9-9df3-4968-8d0f-829a3f0008fd) | ![Selectable file preview (dark)](https://github.com/user-attachments/assets/5c880ab5-fca7-44e6-8bd7-7bbe1180f1bb) |
