### PR TITLE
fix(stt): capture the microphone through an AudioWorklet

### DIFF
--- a/src/renderer/hooks/use-voice-agent.ts
+++ b/src/renderer/hooks/use-voice-agent.ts
@@ -7,7 +7,7 @@ import {
   type VoiceAgentEvent,
   type VoiceProvider,
 } from '@renderer/lib/voice-agent'
-import { acquireMicStream, float32ToInt16, pcm16ToFloat32 } from '@renderer/lib/stt'
+import { acquireMicStream, pcm16ToFloat32, startAudioCapture, type AudioCaptureHandle } from '@renderer/lib/stt'
 
 export type VoiceAgentState = 'idle' | 'connecting' | 'active' | 'error'
 export type SpeakingState = 'none' | 'user' | 'agent'
@@ -39,7 +39,7 @@ export function useVoiceAgent({ config, onFunctionCall, onError }: UseVoiceAgent
   const adapterRef = useRef<VoiceAgentAdapter | null>(null)
   const streamRef = useRef<MediaStream | null>(null)
   const audioContextRef = useRef<AudioContext | null>(null)
-  const processorRef = useRef<ScriptProcessorNode | null>(null)
+  const captureRef = useRef<AudioCaptureHandle | null>(null)
   const playbackContextRef = useRef<AudioContext | null>(null)
   const playbackAnalyserRef = useRef<AnalyserNode | null>(null)
   const nextPlaybackTimeRef = useRef(0)
@@ -60,10 +60,9 @@ export function useVoiceAgent({ config, onFunctionCall, onError }: UseVoiceAgent
   onErrorRef.current = onError
 
   const cleanupAudio = useCallback(() => {
-    processorRef.current?.disconnect()
-    processorRef.current = null
-
-    audioContextRef.current?.close()
+    // The capture owns its context and closes it.
+    captureRef.current?.cleanup()
+    captureRef.current = null
     audioContextRef.current = null
 
     streamRef.current?.getTracks().forEach(t => t.stop())
@@ -241,35 +240,24 @@ export function useVoiceAgent({ config, onFunctionCall, onError }: UseVoiceAgent
 
       // 4. Set up audio capture (AudioContext resamples to the provider rate;
       // the getUserMedia sampleRate constraint is a no-op — see acquireMicStream)
-      const sampleRate = adapter.inputSampleRate
       const stream = await acquireMicStream()
       streamRef.current = stream
 
-      const audioContext = new AudioContext({ sampleRate })
-      if (audioContext.state === 'suspended') {
-        await audioContext.resume()
-      }
-      audioContextRef.current = audioContext
-
-      const source = audioContext.createMediaStreamSource(stream)
-
-      // Set up analyser for visualization
-      const analyser = audioContext.createAnalyser()
-      analyser.fftSize = 256
-      analyser.smoothingTimeConstant = 0.6
-      source.connect(analyser)
-      analyserRef.current = analyser
-
-      // Set up processor to pipe audio to adapter
-      const processor = audioContext.createScriptProcessor(2048, 1, 1)
-      processor.onaudioprocess = (e) => {
-        if (mutedRef.current) return
-        const float32 = e.inputBuffer.getChannelData(0)
-        adapter.sendAudio(float32ToInt16(float32).buffer as ArrayBuffer)
-      }
-      processorRef.current = processor
-      source.connect(processor)
-      processor.connect(audioContext.destination)
+      // Captured at the provider's input rate. Muting drops chunks here
+      // rather than pausing the graph, so unmuting is instant.
+      const capture = await startAudioCapture(
+        {
+          sampleRate: adapter.inputSampleRate,
+          sendAudio: (chunk) => {
+            if (!mutedRef.current) adapter.sendAudio(chunk)
+          },
+        },
+        stream,
+        { withAnalyser: true },
+      )
+      captureRef.current = capture
+      audioContextRef.current = capture.audioContext
+      analyserRef.current = capture.analyser
 
       // 5. Set up audio playback context with an analyser for visualization
       const playbackCtx = new AudioContext({ sampleRate: adapter.outputSampleRate })
@@ -279,9 +267,9 @@ export function useVoiceAgent({ config, onFunctionCall, onError }: UseVoiceAgent
       // Guard against race condition: if stop() was called while we were
       // awaiting, clean up everything we just created to avoid leaked resources
       if ((stateRef.current as VoiceAgentState) !== 'connecting') {
-        processor.disconnect()
-        audioContext.close()
-        stream.getTracks().forEach(t => t.stop())
+        capture.cleanup()
+        captureRef.current = null
+        audioContextRef.current = null
         playbackContextRef.current?.close()
         playbackContextRef.current = null
         playbackAnalyserRef.current = null

--- a/src/renderer/lib/stt.test.ts
+++ b/src/renderer/lib/stt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { createSttAdapter, type TranscriptEvent } from './stt'
+import { createSttAdapter, type TranscriptEvent, startAudioCapture } from './stt'
 import { MockWebSocket } from '@shared/test/mock-websocket'
 
 // float32ToInt16 and arrayBufferToBase64 are not exported, so we test them
@@ -162,6 +162,113 @@ describe('createSttAdapter', () => {
 
   it('throws for unknown provider', () => {
     expect(() => createSttAdapter('unknown' as any)).toThrow('Unknown voice provider: unknown')
+  })
+})
+
+// ============================================================================
+// Microphone capture
+// ============================================================================
+
+describe('startAudioCapture', () => {
+  class FakeNode {
+    connections: unknown[] = []
+    connect(target: unknown) { this.connections.push(target) }
+    disconnect = vi.fn()
+  }
+  class FakeWorkletNode extends FakeNode {
+    port: { onmessage: ((e: { data: Float32Array }) => void) | null } = { onmessage: null }
+    static instances: FakeWorkletNode[] = []
+    constructor(public ctx: unknown, public name: string) {
+      super()
+      FakeWorkletNode.instances.push(this)
+    }
+  }
+  class FakeProcessor extends FakeNode {
+    onaudioprocess: ((e: { inputBuffer: { getChannelData: () => Float32Array } }) => void) | null = null
+  }
+  function fakeContext(options: { worklet?: 'ok' | 'fails' | 'absent' } = {}) {
+    const processors: FakeProcessor[] = []
+    const ctx = {
+      sampleRate: 16000,
+      state: 'running',
+      destination: { id: 'destination' },
+      resume: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      createMediaStreamSource: () => new FakeNode(),
+      createAnalyser: () => ({ fftSize: 0, smoothingTimeConstant: 0 }),
+      createScriptProcessor: () => {
+        const p = new FakeProcessor()
+        processors.push(p)
+        return p
+      },
+      audioWorklet: options.worklet === 'absent' ? undefined : {
+        addModule: vi.fn(async () => {
+          if (options.worklet === 'fails') throw new Error('no worklets here')
+        }),
+      },
+    }
+    return { ctx, processors }
+  }
+  const stream = { getTracks: () => [{ stop: vi.fn() }] } as unknown as MediaStream
+  const sink = () => ({ sendAudio: vi.fn() })
+
+  beforeEach(() => {
+    FakeWorkletNode.instances = []
+    vi.stubGlobal('AudioWorkletNode', FakeWorkletNode)
+    vi.stubGlobal('URL', { ...URL, createObjectURL: vi.fn(() => 'blob:worklet') })
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('captures through an AudioWorklet, handing each chunk to the sink as 16-bit PCM', async () => {
+    const { ctx, processors } = fakeContext({ worklet: 'ok' })
+    vi.stubGlobal('AudioContext', function FakeAudioContext() { return ctx } as unknown as typeof AudioContext)
+    const a = sink()
+    const handle = await startAudioCapture(a, stream)
+    expect(processors).toHaveLength(0)
+    const node = FakeWorkletNode.instances[0]
+    expect(node.name).toBe('pcm-capture')
+    expect(node.connections).toContain(ctx.destination)
+    node.port.onmessage?.({ data: Float32Array.from([0, 0.5, -0.5, 1]) })
+    expect(a.sendAudio).toHaveBeenCalledTimes(1)
+    const pcm = new Int16Array(a.sendAudio.mock.calls[0][0] as ArrayBuffer)
+    expect(Array.from(pcm)).toEqual([0, 16383, -16384, 32767])
+
+    // A reconnected adapter takes over the same mic; null drops the audio.
+    const b = sink()
+    handle.setSink(b)
+    node.port.onmessage?.({ data: Float32Array.from([0.25]) })
+    expect(a.sendAudio).toHaveBeenCalledTimes(1)
+    expect(b.sendAudio).toHaveBeenCalledTimes(1)
+    handle.setSink(null)
+    node.port.onmessage?.({ data: Float32Array.from([0.25]) })
+    expect(b.sendAudio).toHaveBeenCalledTimes(1)
+
+    handle.cleanup()
+    expect(node.disconnect).toHaveBeenCalled()
+    expect(ctx.close).toHaveBeenCalled()
+  })
+
+  it('falls back to a ScriptProcessor where the worklet cannot be loaded', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { ctx, processors } = fakeContext({ worklet: 'fails' })
+    vi.stubGlobal('AudioContext', function FakeAudioContext() { return ctx } as unknown as typeof AudioContext)
+    const a = sink()
+    await startAudioCapture(a, stream)
+    expect(FakeWorkletNode.instances).toHaveLength(0)
+    expect(processors).toHaveLength(1)
+    processors[0].onaudioprocess?.({ inputBuffer: { getChannelData: () => Float32Array.from([1]) } })
+    expect(a.sendAudio).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('falls back to a ScriptProcessor where there is no worklet API at all', async () => {
+    const { ctx, processors } = fakeContext({ worklet: 'absent' })
+    vi.stubGlobal('AudioContext', function FakeAudioContext() { return ctx } as unknown as typeof AudioContext)
+    await startAudioCapture(sink(), stream)
+    expect(processors).toHaveLength(1)
   })
 })
 

--- a/src/renderer/lib/stt.ts
+++ b/src/renderer/lib/stt.ts
@@ -477,12 +477,92 @@ export function pcm16ToFloat32(buffer: ArrayBuffer): Float32Array {
   return float32
 }
 
+/** Where captured audio goes: an STT or voice-agent adapter. */
+export interface AudioSink {
+  sendAudio(chunk: ArrayBuffer): void
+}
+
 export interface AudioCaptureHandle {
   stream: MediaStream
   audioContext: AudioContext
-  processor: ScriptProcessorNode
   analyser: AnalyserNode
+  /** Redirect the captured audio (a reconnected adapter), or drop it (null). */
+  setSink: (sink: AudioSink | null) => void
   cleanup: () => void
+}
+
+/** Samples per chunk handed to the sink: 128 ms at 16 kHz, as the ScriptProcessor always sent. */
+const CAPTURE_CHUNK_SAMPLES = 2048
+
+/**
+ * The capture worklet: gathers the 128-frame render quanta into chunks and
+ * posts each one. Runs on the audio thread, so it keeps up where a
+ * ScriptProcessor (main thread) does not: Safari starves the latter down to
+ * a fifth of its callbacks, and the transcript comes out as fragments.
+ */
+const CAPTURE_WORKLET_SOURCE = `
+class PcmCaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super()
+    this.buffer = new Float32Array(${CAPTURE_CHUNK_SAMPLES})
+    this.filled = 0
+  }
+  process(inputs) {
+    const channel = inputs[0] && inputs[0][0]
+    if (channel) {
+      for (let i = 0; i < channel.length; i++) {
+        this.buffer[this.filled++] = channel[i]
+        if (this.filled === this.buffer.length) {
+          const chunk = this.buffer
+          this.buffer = new Float32Array(chunk.length)
+          this.filled = 0
+          this.port.postMessage(chunk, [chunk.buffer])
+        }
+      }
+    }
+    return true
+  }
+}
+registerProcessor('pcm-capture', PcmCaptureProcessor)
+`
+let captureWorkletUrl: string | null = null
+
+interface CaptureNode {
+  node: AudioNode
+  disconnect: () => void
+}
+
+/**
+ * The node that hands captured samples to `onChunk`: an AudioWorklet where
+ * the browser has one, else the deprecated ScriptProcessor.
+ */
+async function createCaptureNode(audioContext: AudioContext, onChunk: (samples: Float32Array) => void): Promise<CaptureNode> {
+  if (audioContext.audioWorklet && typeof AudioWorkletNode !== 'undefined') {
+    try {
+      captureWorkletUrl ??= URL.createObjectURL(new Blob([CAPTURE_WORKLET_SOURCE], { type: 'application/javascript' }))
+      await audioContext.audioWorklet.addModule(captureWorkletUrl)
+      const node = new AudioWorkletNode(audioContext, 'pcm-capture', { numberOfInputs: 1, numberOfOutputs: 1, channelCount: 1 })
+      node.port.onmessage = (event: MessageEvent<Float32Array>) => onChunk(event.data)
+      return {
+        node,
+        disconnect: () => {
+          node.port.onmessage = null
+          node.disconnect()
+        },
+      }
+    } catch (err) {
+      console.warn('Audio capture worklet unavailable, falling back to ScriptProcessor:', err)
+    }
+  }
+  const processor = audioContext.createScriptProcessor(CAPTURE_CHUNK_SAMPLES, 1, 1)
+  processor.onaudioprocess = (e) => onChunk(e.inputBuffer.getChannelData(0))
+  return {
+    node: processor,
+    disconnect: () => {
+      processor.onaudioprocess = null
+      processor.disconnect()
+    },
+  }
 }
 
 /**
@@ -504,19 +584,19 @@ export async function acquireMicStream(): Promise<MediaStream> {
 }
 
 /**
- * Set up microphone capture and pipe PCM audio chunks to an SttAdapter.
- * Returns handles for the resources and a cleanup function. The caller owns
- * the passed-in stream (acquire via acquireMicStream) and is responsible for
- * releasing it if this rejects; on success the returned cleanup() stops it.
- *
- * TODO: Migrate from deprecated createScriptProcessor to AudioWorkletNode.
+ * Set up microphone capture and pipe 16-bit PCM chunks to `sink` (an STT or
+ * voice-agent adapter), at the sink's sample rate (16 kHz unless it says
+ * otherwise). Returns handles for the resources and a cleanup function. The
+ * caller owns the passed-in stream (acquire via acquireMicStream) and is
+ * responsible for releasing it if this rejects; on success the returned
+ * cleanup() stops it.
  */
 export async function startAudioCapture(
-  adapter: SttAdapter,
+  sink: AudioSink & { readonly sampleRate?: number },
   stream: MediaStream,
   options?: { withAnalyser?: boolean },
 ): Promise<AudioCaptureHandle> {
-  const sampleRate = adapter.sampleRate ?? 16000
+  const sampleRate = sink.sampleRate ?? 16000
 
   const audioContext = new AudioContext({ sampleRate })
   // The context may start suspended if created outside a synchronous user-gesture
@@ -533,20 +613,27 @@ export async function startAudioCapture(
     source.connect(analyser)
   }
 
-  const processor = audioContext.createScriptProcessor(2048, 1, 1)
-  processor.onaudioprocess = (e) => {
-    const float32 = e.inputBuffer.getChannelData(0)
-    adapter.sendAudio(float32ToInt16(float32).buffer as ArrayBuffer)
-  }
-
-  source.connect(processor)
-  processor.connect(audioContext.destination)
+  let currentSink: AudioSink | null = sink
+  const capture = await createCaptureNode(audioContext, (samples) => {
+    currentSink?.sendAudio(float32ToInt16(samples).buffer as ArrayBuffer)
+  })
+  source.connect(capture.node)
+  capture.node.connect(audioContext.destination)
 
   const cleanup = () => {
-    processor.disconnect()
+    currentSink = null
+    capture.disconnect()
     audioContext.close()
     stream.getTracks().forEach(t => t.stop())
   }
 
-  return { stream, audioContext, processor, analyser, cleanup }
+  return {
+    stream,
+    audioContext,
+    analyser,
+    setSink: (next) => {
+      currentSink = next
+    },
+    cleanup,
+  }
 }

--- a/src/renderer/lib/voice-listener.test.ts
+++ b/src/renderer/lib/voice-listener.test.ts
@@ -16,7 +16,7 @@ interface FakeAdapter {
 
 const stt = vi.hoisted(() => {
   const adapters: FakeAdapter[] = []
-  const captures: Array<{ cleanup: ReturnType<typeof vi.fn>; processor: { onaudioprocess: unknown }; analyser: object }> = []
+  const captures: Array<{ cleanup: ReturnType<typeof vi.fn>; setSink: ReturnType<typeof vi.fn>; analyser: object }> = []
   const tracks: Array<{ stop: ReturnType<typeof vi.fn> }> = []
   return {
     adapters,
@@ -50,7 +50,7 @@ const stt = vi.hoisted(() => {
       return { getTracks: () => [track] }
     }),
     startAudioCapture: vi.fn(async () => {
-      const capture = { cleanup: vi.fn(), processor: { onaudioprocess: null as unknown }, analyser: { fftSize: 256 } }
+      const capture = { cleanup: vi.fn(), setSink: vi.fn(), analyser: { fftSize: 256 } }
       captures.push(capture)
       return capture
     }),
@@ -171,6 +171,8 @@ describe('VoiceListener', () => {
     expect(ev.onError).not.toHaveBeenCalled()
     expect(listener.utterance).toBe('so far')
     expect(stt.captures).toHaveLength(1)
+    // The same mic now feeds the new socket.
+    expect(stt.captures[0].setSink).toHaveBeenCalledWith(stt.adapters[1])
     expect(listener.isRunning).toBe(true)
 
     // The new socket carries the transcript on.

--- a/src/renderer/lib/voice-listener.ts
+++ b/src/renderer/lib/voice-listener.ts
@@ -2,7 +2,6 @@ import { apiFetch } from '@renderer/lib/api'
 import {
   acquireMicStream,
   createSttAdapter,
-  float32ToInt16,
   startAudioCapture,
   type AudioCaptureHandle,
   type SttAdapter,
@@ -235,13 +234,7 @@ export class VoiceListener {
       }
       this.adapter = adapter
       // Re-point the running capture at the new adapter.
-      const capture = this.capture
-      if (capture) {
-        capture.processor.onaudioprocess = (e) => {
-          const float32 = e.inputBuffer.getChannelData(0)
-          adapter.sendAudio(float32ToInt16(float32).buffer as ArrayBuffer)
-        }
-      }
+      this.capture?.setSink(adapter)
     } catch (err) {
       if (generation !== this.generation) return
       this.stop()


### PR DESCRIPTION
## Safari transcription heard a word here and there

Dictation, voice mode, and the voice agent all captured the microphone through a `ScriptProcessorNode`, which runs on the main thread. On Safari that node is starved: a harness page reproducing the app's exact capture chain against a real Deepgram token showed 1.5 to 2 processor callbacks per second where 7.8 are expected, so about 80% of the audio never reached the socket. Playing back what was sent gave mangled fragments, and Deepgram transcribed fragments to match. Chromium and Electron were unaffected. The same harness with an `AudioWorkletNode`, which runs on the audio thread, captured cleanly and transcribed normally in Safari.

## Change

`startAudioCapture` now captures through an AudioWorklet. The worklet gathers the 128-frame render quanta into the same 2048-sample chunks the ScriptProcessor always sent, posts each to the main thread, and the main thread converts to 16-bit PCM for the adapter as before. The worklet module is an inline source loaded from a blob URL, so nothing changes in the build or the packaged app. Where the worklet API is missing or the module fails to load, the ScriptProcessor remains as the fallback with a warning.

The capture handle no longer exposes the processor node. It exposes `setSink`, which the voice-mode listener uses to point a running microphone at a reconnected socket, and which the voice agent uses to drop chunks while muted. The voice agent, which had its own copy of the ScriptProcessor setup, now shares this capture.

## Tests

- `stt`: captures through the worklet and hands the sink 16-bit PCM; a reconnected sink takes over and null drops the audio; falls back to the ScriptProcessor when the worklet fails to load or the API is absent.
- `voice-listener`: a reconnect points the running capture at the new socket.
- Voice-mode E2E on Chromium, which drives the real capture chain against a mocked socket.

Verified by hand in Safari: on the harness, mode A (ScriptProcessor) mangled and mode D (AudioWorklet) clean; then end to end on a web dev instance of this branch, dictation and voice mode both transcribing normally.
