### PR TITLE
feat(browser): navigation commands, history state, and favicons on the stream

### DIFF
--- a/agent-container/src/browser-navigation.test.ts
+++ b/agent-container/src/browser-navigation.test.ts
@@ -61,6 +61,23 @@ describe('browser navigation', () => {
     expect(publish).toHaveBeenCalledOnce();
   });
 
+  it('publishes useful history even when iframe updates arrive before every reply', () => {
+    const { navigation, commands, publish, reply } = setup();
+    navigation.handleMessage({ method: 'Page.frameNavigated', params: { frame: { id: 'main' } } });
+    for (let cycle = 0; cycle < 3; cycle++) {
+      const requestId = commands.at(-1)!.id;
+      for (let event = 0; event < 10; event++) {
+        navigation.handleMessage({ method: 'Page.navigatedWithinDocument', params: { frameId: 'child' } });
+      }
+      reply(1, requestId);
+      expect(publish).toHaveBeenLastCalledWith({
+        type: 'history_state', targetId: 'tab-a', url: 'https://b.test/', canGoBack: true, canGoForward: true,
+      });
+    }
+    expect(commands).toHaveLength(4);
+    expect(publish).toHaveBeenCalledOnce();
+  });
+
   it('ignores subframe loads and tracks the main frame across commits', () => {
     const { navigation, commands } = setup();
     navigation.handleMessage({ result: { frameTree: { frame: { id: 'main' } } } });

--- a/agent-container/src/browser-navigation.test.ts
+++ b/agent-container/src/browser-navigation.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createBrowserNavigation } from './browser-navigation';
+
+const entries = [
+  { id: 10, url: 'https://a.test/' },
+  { id: 20, url: 'https://b.test/' },
+  { id: 30, url: 'https://c.test/' },
+];
+
+function setup() {
+  let id = 0;
+  const commands: Array<{ id: number; method: string; params?: Record<string, unknown> }> = [];
+  const publish = vi.fn();
+  const navigation = createBrowserNavigation({
+    targetId: 'tab-a', publish,
+    sendCommand(method, params) {
+      commands.push({ id: ++id, method, params });
+      return id;
+    },
+  });
+  const reply = (currentIndex: number, requestId = id) => navigation.handleMessage({ id: requestId, result: { entries, currentIndex } });
+  return { navigation, commands, publish, reply };
+}
+
+describe('browser navigation', () => {
+  it('reports the new document at commit even when resources never finish loading', () => {
+    const { navigation, publish, reply, commands } = setup();
+    navigation.refresh();
+    reply(0);
+    navigation.handleMessage({ method: 'Page.frameNavigated', params: { frame: { id: 'main' } } });
+    expect(commands.at(-1)?.method).toBe('Page.getNavigationHistory');
+    reply(1);
+    expect(publish).toHaveBeenLastCalledWith({
+      type: 'history_state', targetId: 'tab-a', url: 'https://b.test/', canGoBack: true, canGoForward: true,
+    });
+  });
+
+  it('coalesces lifecycle events and discards the reply from before a document change', () => {
+    const { navigation, publish, commands, reply } = setup();
+    navigation.refresh();
+    navigation.handleMessage({ method: 'Page.frameNavigated', params: { frame: { id: 'main' } } });
+    navigation.handleMessage({ method: 'Page.navigatedWithinDocument', params: { frameId: 'main' } });
+    navigation.handleMessage({ method: 'Page.frameStoppedLoading', params: { frameId: 'main' } });
+    expect(commands).toHaveLength(1);
+    reply(0, 1);
+    expect(publish).not.toHaveBeenCalled();
+    expect(commands).toHaveLength(2);
+    reply(2);
+    expect(publish).toHaveBeenCalledOnce();
+    expect(publish.mock.calls[0][0].url).toBe('https://c.test/');
+  });
+
+  it('does not republish unchanged history when iframes replace their URL', () => {
+    const { navigation, publish, reply } = setup();
+    navigation.refresh();
+    reply(1);
+    for (let i = 0; i < 10; i++) {
+      navigation.handleMessage({ method: 'Page.navigatedWithinDocument', params: { frameId: 'child' } });
+      reply(1);
+    }
+    expect(publish).toHaveBeenCalledOnce();
+  });
+
+  it('ignores subframe loads and tracks the main frame across commits', () => {
+    const { navigation, commands } = setup();
+    navigation.handleMessage({ result: { frameTree: { frame: { id: 'main' } } } });
+    navigation.handleMessage({ method: 'Page.frameNavigated', params: { frame: { id: 'child', parentId: 'main' } } });
+    navigation.handleMessage({ method: 'Page.frameStoppedLoading', params: { frameId: 'child' } });
+    expect(commands).toHaveLength(0);
+    navigation.handleMessage({ method: 'Page.frameNavigated', params: { frame: { id: 'new-main' } } });
+    expect(navigation.isMainFrame('new-main')).toBe(true);
+    expect(navigation.isMainFrame('main')).toBe(false);
+    expect(commands).toHaveLength(1);
+  });
+
+  it('steps to adjacent history entries and reloads without a history query', () => {
+    const { navigation, commands, reply } = setup();
+    navigation.navigate('back');
+    reply(1);
+    expect(commands.at(-1)).toMatchObject({ method: 'Page.navigateToHistoryEntry', params: { entryId: 10 } });
+    navigation.navigate('forward');
+    reply(1);
+    expect(commands.at(-1)).toMatchObject({ method: 'Page.navigateToHistoryEntry', params: { entryId: 30 } });
+    navigation.navigate('reload');
+    expect(commands.at(-1)?.method).toBe('Page.reload');
+    expect(commands).toHaveLength(5);
+  });
+
+  it('does not navigate outside history and recovers after a failed query', () => {
+    const { navigation, commands, reply, publish } = setup();
+    navigation.navigate('back');
+    reply(0);
+    navigation.navigate('forward');
+    reply(2);
+    expect(commands).toHaveLength(2);
+    navigation.refresh();
+    expect(navigation.handleMessage({ id: 3 })).toBe(true);
+    expect(publish).not.toHaveBeenCalled();
+    navigation.refresh();
+    reply(1);
+    expect(publish).toHaveBeenCalledOnce();
+  });
+
+  it('leaves unrelated CDP replies alone and discards replies after detaching', () => {
+    const { navigation, commands, publish, reply } = setup();
+    navigation.refresh();
+    expect(navigation.handleMessage({ id: 99 })).toBe(false);
+    navigation.dispose();
+    reply(1);
+    navigation.navigate('reload');
+    navigation.refresh();
+    expect(publish).not.toHaveBeenCalled();
+    expect(commands).toHaveLength(1);
+  });
+});

--- a/agent-container/src/browser-navigation.ts
+++ b/agent-container/src/browser-navigation.ts
@@ -23,6 +23,7 @@ export function createBrowserNavigation({ targetId, sendCommand, publish }: Brow
   let mainFrameId: string | null = null;
   let revision = 0;
   let pendingStateId: number | undefined;
+  let refreshQueued = false;
   let lastPublished: BrowserHistoryMessage | undefined;
   let disposed = false;
 
@@ -34,11 +35,13 @@ export function createBrowserNavigation({ targetId, sendCommand, publish }: Brow
     if (purpose === 'state') pendingStateId = id;
   }
 
-  function refresh() {
-    revision++;
-    // A new navigation supersedes an outstanding query. Its reply will trigger
-    // one fresh query, regardless of how many lifecycle events arrived meanwhile.
+  function refresh(documentChanged = false) {
+    if (disposed) return;
+    if (documentChanged) revision++;
+    // Only a main-document URL change makes an outstanding reply obsolete.
+    // Iframe/load churn queues one refresh without starving useful responses.
     if (pendingStateId === undefined) request('state');
+    else refreshQueued = true;
   }
 
   function isMainFrame(frameId: string | undefined) {
@@ -52,13 +55,13 @@ export function createBrowserNavigation({ targetId, sendCommand, publish }: Brow
     if (message.method === 'Page.frameNavigated' && message.params?.frame && !message.params.frame.parentId) {
       mainFrameId = message.params.frame.id;
       // The document is visible before all its resources finish loading.
-      refresh();
+      refresh(true);
     } else if (message.method === 'Page.frameStoppedLoading' && isMainFrame(message.params?.frameId)) {
       refresh();
     } else if (message.method === 'Page.navigatedWithinDocument') {
       // Subframe history can affect Back/Forward too. Unchanged state is deduped
       // below, so iframe replaceState churn does not repeatedly render the tray.
-      refresh();
+      refresh(isMainFrame(message.params?.frameId));
     }
 
     const query = message.id === undefined ? undefined : pending.get(message.id);
@@ -66,10 +69,12 @@ export function createBrowserNavigation({ targetId, sendCommand, publish }: Brow
     pending.delete(message.id);
     if (query.purpose === 'state') {
       pendingStateId = undefined;
-      if (query.revision !== revision) {
+      const superseded = query.revision !== revision;
+      if (superseded || refreshQueued) {
+        refreshQueued = false;
         request('state');
-        return true;
       }
+      if (superseded) return true;
     }
     const { entries, currentIndex } = message.result ?? {};
     if (!Array.isArray(entries) || !Number.isInteger(currentIndex) || currentIndex === undefined ||

--- a/agent-container/src/browser-navigation.ts
+++ b/agent-container/src/browser-navigation.ts
@@ -1,0 +1,109 @@
+import type { BrowserHistoryMessage, BrowserNavigateAction } from './browser-stream-protocol';
+
+interface NavigationMessage {
+  id?: number;
+  method?: string;
+  params?: { frameId?: string; frame?: { id: string; parentId?: string } };
+  result?: {
+    frameTree?: { frame?: { id: string } };
+    entries?: Array<{ id: number; url: string }>;
+    currentIndex?: number;
+  };
+}
+
+interface BrowserNavigationOptions {
+  targetId: string;
+  sendCommand: (method: string, params?: Record<string, unknown>) => number | undefined;
+  publish: (message: BrowserHistoryMessage) => void;
+}
+
+/** Owns navigation for one CDP attachment; no socket or server lifetime of its own. */
+export function createBrowserNavigation({ targetId, sendCommand, publish }: BrowserNavigationOptions) {
+  const pending = new Map<number, { purpose: 'state' | 'back' | 'forward'; revision: number }>();
+  let mainFrameId: string | null = null;
+  let revision = 0;
+  let pendingStateId: number | undefined;
+  let lastPublished: BrowserHistoryMessage | undefined;
+  let disposed = false;
+
+  function request(purpose: 'state' | 'back' | 'forward') {
+    if (disposed) return;
+    const id = sendCommand('Page.getNavigationHistory');
+    if (id === undefined) return;
+    pending.set(id, { purpose, revision });
+    if (purpose === 'state') pendingStateId = id;
+  }
+
+  function refresh() {
+    revision++;
+    // A new navigation supersedes an outstanding query. Its reply will trigger
+    // one fresh query, regardless of how many lifecycle events arrived meanwhile.
+    if (pendingStateId === undefined) request('state');
+  }
+
+  function isMainFrame(frameId: string | undefined) {
+    return !mainFrameId || frameId === mainFrameId;
+  }
+
+  function handleMessage(message: NavigationMessage): boolean {
+    if (disposed) return false;
+    const discoveredFrame = message.result?.frameTree?.frame?.id;
+    if (discoveredFrame) mainFrameId = discoveredFrame;
+    if (message.method === 'Page.frameNavigated' && message.params?.frame && !message.params.frame.parentId) {
+      mainFrameId = message.params.frame.id;
+      // The document is visible before all its resources finish loading.
+      refresh();
+    } else if (message.method === 'Page.frameStoppedLoading' && isMainFrame(message.params?.frameId)) {
+      refresh();
+    } else if (message.method === 'Page.navigatedWithinDocument') {
+      // Subframe history can affect Back/Forward too. Unchanged state is deduped
+      // below, so iframe replaceState churn does not repeatedly render the tray.
+      refresh();
+    }
+
+    const query = message.id === undefined ? undefined : pending.get(message.id);
+    if (!query || message.id === undefined) return false;
+    pending.delete(message.id);
+    if (query.purpose === 'state') {
+      pendingStateId = undefined;
+      if (query.revision !== revision) {
+        request('state');
+        return true;
+      }
+    }
+    const { entries, currentIndex } = message.result ?? {};
+    if (!Array.isArray(entries) || !Number.isInteger(currentIndex) || currentIndex === undefined ||
+      currentIndex < 0 || currentIndex >= entries.length) return true;
+    if (query.purpose !== 'state') {
+      const entry = entries[currentIndex + (query.purpose === 'back' ? -1 : 1)];
+      if (entry) sendCommand('Page.navigateToHistoryEntry', { entryId: entry.id });
+      return true;
+    }
+    const next: BrowserHistoryMessage = {
+      type: 'history_state', targetId,
+      canGoBack: currentIndex > 0,
+      canGoForward: currentIndex < entries.length - 1,
+      url: entries[currentIndex].url,
+    };
+    if (next.url !== lastPublished?.url || next.canGoBack !== lastPublished?.canGoBack ||
+      next.canGoForward !== lastPublished?.canGoForward) {
+      lastPublished = next;
+      publish(next);
+    }
+    return true;
+  }
+
+  return {
+    refresh,
+    handleMessage,
+    isMainFrame,
+    navigate(action: BrowserNavigateAction) {
+      if (disposed) return;
+      if (action === 'reload') sendCommand('Page.reload');
+      else request(action);
+    },
+    dispose() { disposed = true; pending.clear(); },
+  };
+}
+
+export type BrowserNavigation = ReturnType<typeof createBrowserNavigation>;

--- a/agent-container/src/browser-stream-protocol.ts
+++ b/agent-container/src/browser-stream-protocol.ts
@@ -1,0 +1,35 @@
+/** Browser stream types live in the container so its standalone image can build them. */
+export interface BrowserTabInfo {
+  targetId: string;
+  index: number;
+  url: string;
+  title: string;
+  faviconUrl?: string;
+  /** The agent's active tab, which can differ from the viewer's selection. */
+  active: boolean;
+}
+
+export type BrowserNavigateAction = 'back' | 'forward' | 'reload';
+
+export interface BrowserHistoryState {
+  canGoBack: boolean;
+  canGoForward: boolean;
+  url: string;
+}
+
+export interface BrowserHistoryMessage extends BrowserHistoryState {
+  type: 'history_state';
+  /** Optional while older container images are still in use. */
+  targetId?: string;
+}
+
+export interface BrowserTabListMessage {
+  type: 'tab_list';
+  tabs: BrowserTabInfo[];
+  activeTargetId: string;
+}
+
+export interface BrowserNavigateCommand {
+  type: 'navigate';
+  action: BrowserNavigateAction;
+}

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -2283,6 +2283,8 @@ let cdpScreencast: {
   autoFollow: boolean;
   /** Pending CDP message IDs for get_selection requests */
   pendingSelections: Set<number>;
+  /** Pending Page.getNavigationHistory requests, by CDP message ID, and why each was asked */
+  pendingHistory: Map<number, HistoryPurpose>;
   /** Main frame ID — used to filter loading events to top-level frame only */
   mainFrameId: string | null;
 } | null = null;
@@ -2303,6 +2305,8 @@ interface PageTarget {
   id: string;
   url: string;
   title: string;
+  /** Chrome's own favicon URL for the page, when it has resolved one. */
+  faviconUrl?: string;
   wsUrl: string;
   /** If true, wsUrl is a browser-level URL; connectCdpToTarget must use Target.attachToTarget */
   requiresSession: boolean;
@@ -2314,6 +2318,8 @@ interface BrowserTabInfo {
   index: number;
   url: string;
   title: string;
+  /** Favicon URL for the tab strip; absent when Chrome has none yet, and the viewer falls back to a globe. */
+  faviconUrl?: string;
   active: boolean;
 }
 
@@ -2337,7 +2343,7 @@ async function getAllPageTargets(): Promise<PageTarget[]> {
   const endpoint = getCdpHttpEndpoint();
   try {
     const res = await fetch(`${endpoint}/json`);
-    const targets = await res.json() as Array<{ id: string; type: string; url: string; title?: string; webSocketDebuggerUrl: string }>;
+    const targets = await res.json() as Array<{ id: string; type: string; url: string; title?: string; faviconUrl?: string; webSocketDebuggerUrl: string }>;
 
     const pages = targets.filter(t => t.type === 'page');
     if (pages.length > 0) {
@@ -2352,6 +2358,7 @@ async function getAllPageTargets(): Promise<PageTarget[]> {
         id: p.id,
         url: p.url,
         title: decodeChromeTargetTitle(p.title || ''),
+        faviconUrl: p.faviconUrl || undefined,
         wsUrl: p.webSocketDebuggerUrl,
         requiresSession: false,
       }));
@@ -2624,6 +2631,24 @@ app.post('/browser/fill-credential', async (c) => {
 });
 
 /** Helper to build a CDP message, adding sessionId when in session mode */
+/** Why a navigation-history query was sent: to step through it, or to tell the viewer where it stands. */
+type HistoryPurpose = 'back' | 'forward' | 'state';
+
+/**
+ * Ask Chrome for the current tab's navigation history. The reply is picked up
+ * in the screencast message handler under `pendingHistory`: a 'state' query
+ * becomes a `history_state` frame for the viewer (back/forward enablement and
+ * the address bar's URL); 'back'/'forward' step to the neighbouring entry.
+ */
+function requestHistory(state: NonNullable<typeof cdpScreencast>, purpose: HistoryPurpose): void {
+  if (state.cdpWs.readyState !== WebSocket.OPEN) return;
+  // Capture the message ID before cdpMsg increments it, to avoid re-parsing
+  const msgId = state.msgId + 1;
+  const msgStr = cdpMsg(state, 'Page.getNavigationHistory');
+  state.pendingHistory.set(msgId, purpose);
+  state.cdpWs.send(msgStr);
+}
+
 function cdpMsg(state: NonNullable<typeof cdpScreencast>, method: string, params?: Record<string, unknown>): string {
   const msg: Record<string, unknown> = { id: ++state.msgId, method };
   if (params) msg.params = params;
@@ -2635,7 +2660,7 @@ function cdpMsg(state: NonNullable<typeof cdpScreencast>, method: string, params
 function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket, requiresSession = false) {
   const cdpWs = new WebSocket(wsUrl);
   const prevAutoFollow = cdpScreencast?.autoFollow ?? true;
-  cdpScreencast = { clientWs, cdpWs, currentTargetId: targetId, msgId: 0, lastDeviceWidth: 0, lastDeviceHeight: 0, cdpSessionId: null, autoFollow: prevAutoFollow, pendingSelections: new Set(), mainFrameId: null as string | null };
+  cdpScreencast = { clientWs, cdpWs, currentTargetId: targetId, msgId: 0, lastDeviceWidth: 0, lastDeviceHeight: 0, cdpSessionId: null, autoFollow: prevAutoFollow, pendingSelections: new Set(), pendingHistory: new Map(), mainFrameId: null as string | null };
   const state = cdpScreencast;
 
   cdpWs.on('open', () => {
@@ -2657,6 +2682,7 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
       // top-level frame, not iframes/ads that load continuously.
       const frameTreeId = ++state.msgId;
       cdpWs.send(JSON.stringify({ id: frameTreeId, method: 'Page.getFrameTree', ...(state.cdpSessionId ? { sessionId: state.cdpSessionId } : {}) }));
+      requestHistory(state, 'state');
     }
   });
 
@@ -2677,6 +2703,7 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
         }));
         // Enable Page domain to receive navigation lifecycle events
         cdpWs.send(cdpMsg(state, 'Page.enable'));
+        requestHistory(state, 'state');
         return;
       }
 
@@ -2708,6 +2735,30 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
             type: 'page_loading',
             loading: msg.method === 'Page.frameStartedLoading',
           }));
+          // The page settled somewhere; tell the viewer where.
+          if (msg.method === 'Page.frameStoppedLoading') requestHistory(state, 'state');
+        }
+      } else if (msg.method === 'Page.navigatedWithinDocument') {
+        // Hash / pushState navigations never fire the loading events above.
+        requestHistory(state, 'state');
+      } else if (msg.id && state.pendingHistory.has(msg.id)) {
+        const purpose = state.pendingHistory.get(msg.id)!;
+        state.pendingHistory.delete(msg.id);
+        const entries = msg.result?.entries as Array<{ id: number; url: string }> | undefined;
+        const currentIndex = msg.result?.currentIndex as number | undefined;
+        if (!entries || typeof currentIndex !== 'number') return;
+        if (purpose === 'state') {
+          if (clientWs.readyState === WebSocket.OPEN) {
+            clientWs.send(JSON.stringify({
+              type: 'history_state',
+              canGoBack: currentIndex > 0,
+              canGoForward: currentIndex < entries.length - 1,
+              url: entries[currentIndex]?.url ?? '',
+            }));
+          }
+        } else {
+          const entry = entries[purpose === 'back' ? currentIndex - 1 : currentIndex + 1];
+          if (entry) cdpWs.send(cdpMsg(state, 'Page.navigateToHistoryEntry', { entryId: entry.id }));
         }
       } else if (msg.id && state.pendingSelections.has(msg.id)) {
         state.pendingSelections.delete(msg.id);
@@ -2841,6 +2892,7 @@ async function broadcastTabList(prefetched?: { allTargets: PageTarget[]; daemonT
         url: dt.url,
         // Prefer Chrome's title (actual <title> tag) over daemon's (often just domain)
         title: target.title || dt.title || '',
+        faviconUrl: target.faviconUrl,
         active: dt.active,
       });
     }
@@ -2855,6 +2907,7 @@ async function broadcastTabList(prefetched?: { allTargets: PageTarget[]; daemonT
         index: i,
         url: t.url,
         title: t.title || '',
+        faviconUrl: t.faviconUrl,
         active: t.id === currentTargetId,
       }));
     }
@@ -3027,7 +3080,14 @@ function handleBrowserStreamConnection(ws: WebSocket) {
           }
         }
       } else if (cdpScreencast.cdpWs.readyState === WebSocket.OPEN) {
-        if (data.type === 'input_mouse') {
+        if (data.type === 'navigate') {
+          // Viewer's back / forward / reload buttons, acting on the tab being viewed.
+          if (data.action === 'reload') {
+            cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Page.reload'));
+          } else if (data.action === 'back' || data.action === 'forward') {
+            requestHistory(cdpScreencast, data.action);
+          }
+        } else if (data.type === 'input_mouse') {
           cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Input.dispatchMouseEvent', {
             type: data.eventType,
             x: Math.round(data.x),

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -42,6 +42,8 @@ import {
 } from './workspace-entry-operations';
 
 import { getEditingCommands } from './cdp-editing-commands';
+import { createBrowserNavigation, type BrowserNavigation } from './browser-navigation';
+import type { BrowserTabInfo, BrowserTabListMessage } from './browser-stream-protocol';
 import { CREDENTIAL_AUTOFILL_FUNCTION } from './credential-autofill-script';
 import { selectActivePageTarget } from './active-page-target';
 import { decodeChromeTargetTitle } from './chrome-target-title';
@@ -2283,10 +2285,7 @@ let cdpScreencast: {
   autoFollow: boolean;
   /** Pending CDP message IDs for get_selection requests */
   pendingSelections: Set<number>;
-  /** Pending Page.getNavigationHistory requests, by CDP message ID, and why each was asked */
-  pendingHistory: Map<number, HistoryPurpose>;
-  /** Main frame ID — used to filter loading events to top-level frame only */
-  mainFrameId: string | null;
+  navigation: BrowserNavigation;
 } | null = null;
 
 /** Derive the CDP HTTP endpoint from the current browser state */
@@ -2310,17 +2309,6 @@ interface PageTarget {
   wsUrl: string;
   /** If true, wsUrl is a browser-level URL; connectCdpToTarget must use Target.attachToTarget */
   requiresSession: boolean;
-}
-
-// Protocol: see src/renderer/components/browser/browser-preview.tsx
-interface BrowserTabInfo {
-  targetId: string;
-  index: number;
-  url: string;
-  title: string;
-  /** Favicon URL for the tab strip; absent when Chrome has none yet, and the viewer falls back to a globe. */
-  faviconUrl?: string;
-  active: boolean;
 }
 
 /**
@@ -2631,24 +2619,6 @@ app.post('/browser/fill-credential', async (c) => {
 });
 
 /** Helper to build a CDP message, adding sessionId when in session mode */
-/** Why a navigation-history query was sent: to step through it, or to tell the viewer where it stands. */
-type HistoryPurpose = 'back' | 'forward' | 'state';
-
-/**
- * Ask Chrome for the current tab's navigation history. The reply is picked up
- * in the screencast message handler under `pendingHistory`: a 'state' query
- * becomes a `history_state` frame for the viewer (back/forward enablement and
- * the address bar's URL); 'back'/'forward' step to the neighbouring entry.
- */
-function requestHistory(state: NonNullable<typeof cdpScreencast>, purpose: HistoryPurpose): void {
-  if (state.cdpWs.readyState !== WebSocket.OPEN) return;
-  // Capture the message ID before cdpMsg increments it, to avoid re-parsing
-  const msgId = state.msgId + 1;
-  const msgStr = cdpMsg(state, 'Page.getNavigationHistory');
-  state.pendingHistory.set(msgId, purpose);
-  state.cdpWs.send(msgStr);
-}
-
 function cdpMsg(state: NonNullable<typeof cdpScreencast>, method: string, params?: Record<string, unknown>): string {
   const msg: Record<string, unknown> = { id: ++state.msgId, method };
   if (params) msg.params = params;
@@ -2660,10 +2630,28 @@ function cdpMsg(state: NonNullable<typeof cdpScreencast>, method: string, params
 function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket, requiresSession = false) {
   const cdpWs = new WebSocket(wsUrl);
   const prevAutoFollow = cdpScreencast?.autoFollow ?? true;
-  cdpScreencast = { clientWs, cdpWs, currentTargetId: targetId, msgId: 0, lastDeviceWidth: 0, lastDeviceHeight: 0, cdpSessionId: null, autoFollow: prevAutoFollow, pendingSelections: new Set(), pendingHistory: new Map(), mainFrameId: null as string | null };
-  const state = cdpScreencast;
+  const state: NonNullable<typeof cdpScreencast> = {
+    clientWs, cdpWs, currentTargetId: targetId, msgId: 0,
+    lastDeviceWidth: 0, lastDeviceHeight: 0, cdpSessionId: null,
+    autoFollow: prevAutoFollow, pendingSelections: new Set(),
+    navigation: createBrowserNavigation({
+      targetId,
+      sendCommand(method, params) {
+        if (cdpScreencast !== state || cdpWs.readyState !== WebSocket.OPEN) return;
+        cdpWs.send(cdpMsg(state, method, params));
+        return state.msgId;
+      },
+      publish(message) {
+        if (cdpScreencast === state && clientWs.readyState === WebSocket.OPEN) {
+          clientWs.send(JSON.stringify(message));
+        }
+      },
+    }),
+  };
+  cdpScreencast = state;
 
   cdpWs.on('open', () => {
+    if (cdpScreencast !== state) { cdpWs.close(); return; }
     if (requiresSession) {
       // Remote CDP: attach to target with flattened session first
       cdpWs.send(JSON.stringify({
@@ -2682,18 +2670,14 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
       // top-level frame, not iframes/ads that load continuously.
       const frameTreeId = ++state.msgId;
       cdpWs.send(JSON.stringify({ id: frameTreeId, method: 'Page.getFrameTree', ...(state.cdpSessionId ? { sessionId: state.cdpSessionId } : {}) }));
-      requestHistory(state, 'state');
+      state.navigation.refresh();
     }
   });
 
   cdpWs.on('message', (rawData) => {
+    if (cdpScreencast !== state) return;
     try {
       const msg = JSON.parse(rawData.toString());
-
-      // Capture main frame ID from Page.getFrameTree response
-      if (msg.result?.frameTree?.frame?.id && !state.mainFrameId) {
-        state.mainFrameId = msg.result.frameTree.frame.id;
-      }
 
       // Handle attachToTarget response — start screencast once we have a session
       if (requiresSession && !state.cdpSessionId && msg.result?.sessionId) {
@@ -2701,14 +2685,16 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
         cdpWs.send(cdpMsg(state, 'Page.startScreencast', {
           format: 'jpeg', quality: 80, maxWidth: 1280, maxHeight: 720, everyNthFrame: 1,
         }));
-        // Enable Page domain to receive navigation lifecycle events
+        // Discover the main frame in remote session mode too.
         cdpWs.send(cdpMsg(state, 'Page.enable'));
-        requestHistory(state, 'state');
+        cdpWs.send(cdpMsg(state, 'Page.getFrameTree'));
+        state.navigation.refresh();
         return;
       }
 
       // In session mode, only handle messages for our session
       if (state.cdpSessionId && msg.sessionId && msg.sessionId !== state.cdpSessionId) return;
+      if (state.navigation.handleMessage(msg)) return;
 
       if (msg.method === 'Page.screencastFrame') {
         cdpWs.send(cdpMsg(state, 'Page.screencastFrameAck', { sessionId: msg.params.sessionId }));
@@ -2730,35 +2716,11 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
         // Only forward loading state for the main frame — subframes (ads,
         // analytics, iframes) load continuously and would keep the spinner on.
         const frameId = msg.params?.frameId;
-        if ((!state.mainFrameId || frameId === state.mainFrameId) && clientWs.readyState === WebSocket.OPEN) {
+        if (state.navigation.isMainFrame(frameId) && clientWs.readyState === WebSocket.OPEN) {
           clientWs.send(JSON.stringify({
             type: 'page_loading',
             loading: msg.method === 'Page.frameStartedLoading',
           }));
-          // The page settled somewhere; tell the viewer where.
-          if (msg.method === 'Page.frameStoppedLoading') requestHistory(state, 'state');
-        }
-      } else if (msg.method === 'Page.navigatedWithinDocument') {
-        // Hash / pushState navigations never fire the loading events above.
-        requestHistory(state, 'state');
-      } else if (msg.id && state.pendingHistory.has(msg.id)) {
-        const purpose = state.pendingHistory.get(msg.id)!;
-        state.pendingHistory.delete(msg.id);
-        const entries = msg.result?.entries as Array<{ id: number; url: string }> | undefined;
-        const currentIndex = msg.result?.currentIndex as number | undefined;
-        if (!entries || typeof currentIndex !== 'number') return;
-        if (purpose === 'state') {
-          if (clientWs.readyState === WebSocket.OPEN) {
-            clientWs.send(JSON.stringify({
-              type: 'history_state',
-              canGoBack: currentIndex > 0,
-              canGoForward: currentIndex < entries.length - 1,
-              url: entries[currentIndex]?.url ?? '',
-            }));
-          }
-        } else {
-          const entry = entries[purpose === 'back' ? currentIndex - 1 : currentIndex + 1];
-          if (entry) cdpWs.send(cdpMsg(state, 'Page.navigateToHistoryEntry', { entryId: entry.id }));
         }
       } else if (msg.id && state.pendingSelections.has(msg.id)) {
         state.pendingSelections.delete(msg.id);
@@ -2771,6 +2733,7 @@ function connectCdpToTarget(targetId: string, wsUrl: string, clientWs: WebSocket
   });
 
   cdpWs.on('close', () => {
+    state.navigation.dispose();
     // If this wasn't our active connection (already replaced by a tab switch), ignore
     if (cdpScreencast?.cdpWs !== cdpWs) return;
 
@@ -2927,7 +2890,7 @@ async function broadcastTabList(prefetched?: { allTargets: PageTarget[]; daemonT
       type: 'tab_list',
       tabs,
       activeTargetId: activeEntry?.targetId ?? cdpScreencast?.currentTargetId ?? '',
-    }));
+    } satisfies BrowserTabListMessage));
   } catch (err) {
     console.error('[CDP] Failed to broadcast tab list:', err);
   }
@@ -3082,10 +3045,8 @@ function handleBrowserStreamConnection(ws: WebSocket) {
       } else if (cdpScreencast.cdpWs.readyState === WebSocket.OPEN) {
         if (data.type === 'navigate') {
           // Viewer's back / forward / reload buttons, acting on the tab being viewed.
-          if (data.action === 'reload') {
-            cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Page.reload'));
-          } else if (data.action === 'back' || data.action === 'forward') {
-            requestHistory(cdpScreencast, data.action);
+          if (data.action === 'reload' || data.action === 'back' || data.action === 'forward') {
+            cdpScreencast.navigation.navigate(data.action);
           }
         } else if (data.type === 'input_mouse') {
           cdpScreencast.cdpWs.send(cdpMsg(cdpScreencast, 'Input.dispatchMouseEvent', {

--- a/src/renderer/components/browser/browser-tab-bar.tsx
+++ b/src/renderer/components/browser/browser-tab-bar.tsx
@@ -7,16 +7,8 @@ import {
   ContextMenuTrigger,
 } from '@renderer/components/ui/context-menu'
 
-// Protocol: see agent-container/src/server.ts
-export interface BrowserTabInfo {
-  targetId: string
-  index: number
-  url: string
-  title: string
-  /** Chrome's favicon URL for the page; missing until it has resolved one. */
-  faviconUrl?: string
-  active: boolean // true = agent's active tab
-}
+import type { BrowserTabInfo } from '@shared/lib/browser-stream-protocol'
+export type { BrowserTabInfo } from '@shared/lib/browser-stream-protocol'
 
 interface BrowserTabBarProps {
   tabs: BrowserTabInfo[]

--- a/src/renderer/components/browser/browser-tab-bar.tsx
+++ b/src/renderer/components/browser/browser-tab-bar.tsx
@@ -13,6 +13,8 @@ export interface BrowserTabInfo {
   index: number
   url: string
   title: string
+  /** Chrome's favicon URL for the page; missing until it has resolved one. */
+  faviconUrl?: string
   active: boolean // true = agent's active tab
 }
 

--- a/src/renderer/hooks/use-browser-stream.test.tsx
+++ b/src/renderer/hooks/use-browser-stream.test.tsx
@@ -355,3 +355,61 @@ describe('useBrowserStream history', () => {
     expect(hook.result.current.pageUrl).toBe('https://b.test')
   })
 })
+
+
+describe('useBrowserStream ordered history', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    FakeWebSocket.instances = []
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    mockApiFetch.mockResolvedValue({ json: () => Promise.resolve({ active: true, sessionId: 's' }) })
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  async function setup() {
+    const canvasRef = createRef<HTMLCanvasElement | null>()
+    const hook = renderHook(() => useBrowserStream(baseOpts(canvasRef)))
+    await settle()
+    const ws = FakeWebSocket.instances[0]
+    act(() => {
+      ws.completeHandshake()
+      ws.emit({ type: 'tab_list', tabs: [
+        { targetId: 't1', index: 0, url: 'https://a.test', title: 'A', active: true },
+        { targetId: 't2', index: 1, url: 'https://b.test', title: 'B', active: false },
+      ], activeTargetId: 't1' })
+      ws.emit({ type: 'history_state', targetId: 't1', canGoBack: true, canGoForward: false, url: 'https://a.test' })
+    })
+    return {hook, ws}
+  }
+
+  it('preserves destination history when switch and history frames are batched', async () => {
+    const {hook, ws} = await setup()
+    act(() => {
+      ws.emit({ type: 'tab_switched', targetId: 't2' })
+      ws.emit({ type: 'history_state', targetId: 't2', canGoBack: true, canGoForward: true, url: 'https://b.test' })
+    })
+    expect(hook.result.current.viewingTargetId).toBe('t2')
+    expect(hook.result.current.pageUrl).toBe('https://b.test')
+    expect(hook.result.current.canGoBack).toBe(true)
+    expect(hook.result.current.canGoForward).toBe(true)
+  })
+
+  it('ignores the old tab history after a manual switch', async () => {
+    const {hook, ws} = await setup()
+    act(() => hook.result.current.handleTabClick('t2'))
+    act(() => ws.emit({type:'history_state', targetId:'t1', canGoBack:true, canGoForward:false, url:'https://a.test/old'}))
+    expect(hook.result.current.pageUrl).toBe('')
+    act(() => ws.emit({type:'history_state', targetId:'t2', canGoBack:false, canGoForward:true, url:'https://b.test'}))
+    expect(hook.result.current.pageUrl).toBe('https://b.test')
+  })
+
+  it('clears pinned history when following the agent again', async () => {
+    const {hook, ws} = await setup()
+    act(() => hook.result.current.handleTabClick('t2'))
+    act(() => ws.emit({type:'history_state', targetId:'t2', canGoBack:true, canGoForward:true, url:'https://b.test'}))
+    act(() => hook.result.current.toggleAutoFollow())
+    expect(hook.result.current.viewingTargetId).toBe('t1')
+    expect(hook.result.current.pageUrl).toBe('')
+    expect(hook.result.current.canGoBack).toBe(false)
+  })
+})

--- a/src/renderer/hooks/use-browser-stream.test.tsx
+++ b/src/renderer/hooks/use-browser-stream.test.tsx
@@ -52,6 +52,12 @@ class FakeWebSocket {
     this.onmessage?.({ data: JSON.stringify(payload) })
   }
 
+  /** Messages the hook sent, parsed. */
+  sent: unknown[] = []
+  send(data: string) {
+    this.sent.push(JSON.parse(data))
+  }
+
   close() {
     if (this.readyState === FakeWebSocket.CLOSED) return
     this.readyState = FakeWebSocket.CLOSED
@@ -262,5 +268,90 @@ describe('useBrowserStream reconnect', () => {
 
     expect(FakeWebSocket.instances).toHaveLength(7)
     expect(clearBrowserActive).not.toHaveBeenCalled()
+  })
+})
+
+describe('useBrowserStream history', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    FakeWebSocket.instances = []
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    mockApiFetch.mockResolvedValue({
+      json: () => Promise.resolve({ active: true, sessionId: 's' }),
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  async function openSocket() {
+    const canvasRef = createRef<HTMLCanvasElement | null>()
+    const hook = renderHook(() => useBrowserStream(baseOpts(canvasRef)))
+    await settle()
+    const ws = FakeWebSocket.instances[0]
+    act(() => {
+      ws.completeHandshake()
+    })
+    await settle()
+    return { hook, ws }
+  }
+
+  it('starts with nowhere to go and no address', async () => {
+    const { hook } = await openSocket()
+    expect(hook.result.current.canGoBack).toBe(false)
+    expect(hook.result.current.canGoForward).toBe(false)
+    expect(hook.result.current.pageUrl).toBe('')
+  })
+
+  it('takes back/forward enablement and the address from a history_state frame', async () => {
+    const { hook, ws } = await openSocket()
+    act(() => {
+      ws.emit({ type: 'history_state', canGoBack: true, canGoForward: false, url: 'https://example.com/pricing' })
+    })
+    expect(hook.result.current.canGoBack).toBe(true)
+    expect(hook.result.current.canGoForward).toBe(false)
+    expect(hook.result.current.pageUrl).toBe('https://example.com/pricing')
+  })
+
+  it('sends a navigate command for back, forward, and reload', async () => {
+    const { hook, ws } = await openSocket()
+    act(() => {
+      hook.result.current.navigate('back')
+      hook.result.current.navigate('forward')
+      hook.result.current.navigate('reload')
+    })
+    expect(ws.sent).toEqual([
+      { type: 'navigate', action: 'back' },
+      { type: 'navigate', action: 'forward' },
+      { type: 'navigate', action: 'reload' },
+    ])
+  })
+
+  it('forgets the old tab\'s history when the viewed tab changes', async () => {
+    const { hook, ws } = await openSocket()
+    act(() => {
+      ws.emit({ type: 'tab_list', tabs: [
+        { targetId: 't1', index: 0, url: 'https://a.test', title: 'A', active: true },
+        { targetId: 't2', index: 1, url: 'https://b.test', title: 'B', active: false },
+      ], activeTargetId: 't1' })
+      ws.emit({ type: 'history_state', canGoBack: true, canGoForward: true, url: 'https://a.test/2' })
+    })
+    expect(hook.result.current.canGoBack).toBe(true)
+
+    act(() => {
+      hook.result.current.handleTabClick('t2')
+    })
+    expect(hook.result.current.canGoBack).toBe(false)
+    expect(hook.result.current.canGoForward).toBe(false)
+    expect(hook.result.current.pageUrl).toBe('')
+    expect(ws.sent).toContainEqual({ type: 'switch_tab', targetId: 't2' })
+
+    // The container attaches to the new tab and reports where it stands.
+    act(() => {
+      ws.emit({ type: 'history_state', canGoBack: false, canGoForward: true, url: 'https://b.test' })
+    })
+    expect(hook.result.current.canGoForward).toBe(true)
+    expect(hook.result.current.pageUrl).toBe('https://b.test')
   })
 })

--- a/src/renderer/hooks/use-browser-stream.ts
+++ b/src/renderer/hooks/use-browser-stream.ts
@@ -8,6 +8,16 @@ import { useUser } from '@renderer/context/user-context'
 
 const MODIFIER_KEYS = new Set(['Shift', 'Control', 'Alt', 'Meta'])
 
+export type NavigateAction = 'back' | 'forward' | 'reload'
+
+interface HistoryState {
+  canGoBack: boolean
+  canGoForward: boolean
+  url: string
+}
+
+const EMPTY_HISTORY: HistoryState = { canGoBack: false, canGoForward: false, url: '' }
+
 // Reconnect backoff for a socket that keeps dying before it opens.
 const RECONNECT_BASE_MS = 1000
 const MAX_RECONNECT_DELAY_MS = 8000
@@ -35,6 +45,10 @@ export function useBrowserStream({
 
   const [connected, setConnected] = useState(false)
   const [pageLoading, setPageLoading] = useState(false)
+  // Where the viewed tab stands in its history, from the container's
+  // `history_state` frames. Reset whenever the viewed tab changes; the
+  // container sends a fresh one once it has attached to the new target.
+  const [history, setHistory] = useState<HistoryState>(EMPTY_HISTORY)
   const [reconnectKey, setReconnectKey] = useState(0)
   const [showCloseWarning, setShowCloseWarning] = useState(false)
   const [isClosing, setIsClosing] = useState(false)
@@ -188,6 +202,12 @@ export function useBrowserStream({
 
         if (data.type === 'page_loading') {
           setPageLoading(prev => prev === data.loading ? prev : data.loading)
+        } else if (data.type === 'history_state') {
+          setHistory({
+            canGoBack: data.canGoBack === true,
+            canGoForward: data.canGoForward === true,
+            url: typeof data.url === 'string' ? data.url : '',
+          })
         } else if (data.type === 'frame' && data.data) {
           if (!resizing) {
             const blob = base64ToBlob(data.data, 'image/jpeg')
@@ -204,7 +224,8 @@ export function useBrowserStream({
           setTabs(prev => {
             if (prev.length === data.tabs.length && prev.every((t: BrowserTabInfo, i: number) =>
               t.targetId === data.tabs[i].targetId && t.title === data.tabs[i].title &&
-              t.url === data.tabs[i].url && t.active === data.tabs[i].active
+              t.url === data.tabs[i].url && t.active === data.tabs[i].active &&
+              t.faviconUrl === data.tabs[i].faviconUrl
             )) return prev
             return data.tabs
           })
@@ -214,7 +235,11 @@ export function useBrowserStream({
           }
         } else if (data.type === 'tab_switched') {
           setAgentActiveTargetId(prev => prev === data.targetId ? prev : data.targetId)
-          setViewingTargetId(prev => prev === data.targetId ? prev : data.targetId)
+          setViewingTargetId(prev => {
+            if (prev === data.targetId) return prev
+            setHistory(EMPTY_HISTORY)
+            return data.targetId
+          })
         } else if (data.type === 'selection_result' && data.text) {
           navigator.clipboard.writeText(data.text).catch(() => {})
         } else if (data.type === 'browser_closed') {
@@ -480,8 +505,14 @@ export function useBrowserStream({
     if (targetId === viewingTargetId) return
     setAutoFollow(false)
     setViewingTargetId(targetId)
+    setHistory(EMPTY_HISTORY)
     sendMessage({ type: 'switch_tab', targetId })
   }, [viewingTargetId, sendMessage])
+
+  /** Back / forward / reload on the tab being viewed. */
+  const navigate = useCallback((action: NavigateAction) => {
+    sendMessage({ type: 'navigate', action })
+  }, [sendMessage])
 
   const handleCloseTab = useCallback((targetId: string) => {
     sendMessage({ type: 'close_tab', targetId })
@@ -555,6 +586,11 @@ export function useBrowserStream({
     handleTabClick,
     handleCloseTab,
     toggleAutoFollow,
+    // History
+    canGoBack: history.canGoBack,
+    canGoForward: history.canGoForward,
+    pageUrl: history.url,
+    navigate,
     // Close handlers
     closeBrowser,
     handleCloseClick,

--- a/src/renderer/hooks/use-browser-stream.ts
+++ b/src/renderer/hooks/use-browser-stream.ts
@@ -1,5 +1,6 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
-import type { BrowserTabInfo } from '@renderer/components/browser/browser-tab-bar'
+import { useState, useEffect, useRef, useCallback, useReducer } from 'react'
+import type { BrowserTabInfo, BrowserNavigateAction } from '@shared/lib/browser-stream-protocol'
+import { browserViewReducer, initialBrowserView } from '@renderer/lib/browser-stream-state'
 import { getApiBaseUrl } from '@renderer/lib/env'
 import { apiFetch } from '@renderer/lib/api'
 import { clearBrowserActive } from '@renderer/hooks/use-message-stream'
@@ -8,15 +9,7 @@ import { useUser } from '@renderer/context/user-context'
 
 const MODIFIER_KEYS = new Set(['Shift', 'Control', 'Alt', 'Meta'])
 
-export type NavigateAction = 'back' | 'forward' | 'reload'
-
-interface HistoryState {
-  canGoBack: boolean
-  canGoForward: boolean
-  url: string
-}
-
-const EMPTY_HISTORY: HistoryState = { canGoBack: false, canGoForward: false, url: '' }
+export type NavigateAction = BrowserNavigateAction
 
 // Reconnect backoff for a socket that keeps dying before it opens.
 const RECONNECT_BASE_MS = 1000
@@ -45,10 +38,6 @@ export function useBrowserStream({
 
   const [connected, setConnected] = useState(false)
   const [pageLoading, setPageLoading] = useState(false)
-  // Where the viewed tab stands in its history, from the container's
-  // `history_state` frames. Reset whenever the viewed tab changes; the
-  // container sends a fresh one once it has attached to the new target.
-  const [history, setHistory] = useState<HistoryState>(EMPTY_HISTORY)
   const [reconnectKey, setReconnectKey] = useState(0)
   const [showCloseWarning, setShowCloseWarning] = useState(false)
   const [isClosing, setIsClosing] = useState(false)
@@ -58,7 +47,8 @@ export function useBrowserStream({
   // Multi-tab state
   const [tabs, setTabs] = useState<BrowserTabInfo[]>([])
   const [agentActiveTargetId, setAgentActiveTargetId] = useState<string | null>(null)
-  const [viewingTargetId, setViewingTargetId] = useState<string | null>(null)
+  const [{ targetId: viewingTargetId, history }, dispatchView] = useReducer(browserViewReducer, initialBrowserView)
+  const setViewingTargetId = useCallback((targetId: string | null) => dispatchView({ type: 'view', targetId }), [])
   const [autoFollow, setAutoFollow] = useState(true)
   const autoFollowRef = useRef(autoFollow)
   autoFollowRef.current = autoFollow
@@ -174,6 +164,7 @@ export function useBrowserStream({
 
     ws.onopen = () => {
       failedReconnectsRef.current = 0
+      dispatchView({ type: 'reset' })
       setConnected(true)
     }
 
@@ -203,10 +194,14 @@ export function useBrowserStream({
         if (data.type === 'page_loading') {
           setPageLoading(prev => prev === data.loading ? prev : data.loading)
         } else if (data.type === 'history_state') {
-          setHistory({
-            canGoBack: data.canGoBack === true,
-            canGoForward: data.canGoForward === true,
-            url: typeof data.url === 'string' ? data.url : '',
+          dispatchView({
+            type: 'history',
+            targetId: typeof data.targetId === 'string' ? data.targetId : undefined,
+            history: {
+              canGoBack: data.canGoBack === true,
+              canGoForward: data.canGoForward === true,
+              url: typeof data.url === 'string' ? data.url : '',
+            },
           })
         } else if (data.type === 'frame' && data.data) {
           if (!resizing) {
@@ -231,15 +226,11 @@ export function useBrowserStream({
           })
           setAgentActiveTargetId(prev => prev === data.activeTargetId ? prev : data.activeTargetId)
           if (autoFollowRef.current) {
-            setViewingTargetId(prev => prev === data.activeTargetId ? prev : data.activeTargetId)
+            setViewingTargetId(data.activeTargetId)
           }
         } else if (data.type === 'tab_switched') {
           setAgentActiveTargetId(prev => prev === data.targetId ? prev : data.targetId)
-          setViewingTargetId(prev => {
-            if (prev === data.targetId) return prev
-            setHistory(EMPTY_HISTORY)
-            return data.targetId
-          })
+          setViewingTargetId(data.targetId)
         } else if (data.type === 'selection_result' && data.text) {
           navigator.clipboard.writeText(data.text).catch(() => {})
         } else if (data.type === 'browser_closed') {
@@ -257,6 +248,7 @@ export function useBrowserStream({
       if (wsRef.current !== ws) return
       setConnected(false)
       setPageLoading(false)
+      dispatchView({ type: 'reset' })
       if (browserGone) {
         clearBrowserActive(sessionId)
         return
@@ -301,7 +293,7 @@ export function useBrowserStream({
       wsRef.current = null
       setConnected(false)
     }
-  }, [browserActive, isConnected, agentSlug, sessionId, renderFrame, reconnectKey])
+  }, [browserActive, isConnected, agentSlug, sessionId, renderFrame, reconnectKey, setViewingTargetId])
 
   // Reset overlay dismiss state when attention state ends
   useEffect(() => {
@@ -316,7 +308,7 @@ export function useBrowserStream({
       setViewingTargetId(agentActiveTargetId)
       setAutoFollow(true)
     }
-  }, [tabs, viewingTargetId, agentActiveTargetId])
+  }, [tabs, viewingTargetId, agentActiveTargetId, setViewingTargetId])
 
   // Prevent default scroll behavior (must use native listener with passive: false
   // so preventDefault() works; React's onWheel is passive and can't prevent scrolling)
@@ -505,14 +497,13 @@ export function useBrowserStream({
     if (targetId === viewingTargetId) return
     setAutoFollow(false)
     setViewingTargetId(targetId)
-    setHistory(EMPTY_HISTORY)
     sendMessage({ type: 'switch_tab', targetId })
-  }, [viewingTargetId, sendMessage])
+  }, [viewingTargetId, sendMessage, setViewingTargetId])
 
   /** Back / forward / reload on the tab being viewed. */
   const navigate = useCallback((action: NavigateAction) => {
-    sendMessage({ type: 'navigate', action })
-  }, [sendMessage])
+    if (!isViewOnly) sendMessage({ type: 'navigate', action })
+  }, [sendMessage, isViewOnly])
 
   const handleCloseTab = useCallback((targetId: string) => {
     sendMessage({ type: 'close_tab', targetId })
@@ -525,7 +516,7 @@ export function useBrowserStream({
     if (next && agentActiveTargetId) {
       setViewingTargetId(agentActiveTargetId)
     }
-  }, [autoFollow, agentActiveTargetId, sendMessage])
+  }, [autoFollow, agentActiveTargetId, sendMessage, setViewingTargetId])
 
   const closeBrowser = useCallback(async () => {
     setIsClosing(true)

--- a/src/renderer/lib/browser-stream-state.ts
+++ b/src/renderer/lib/browser-stream-state.ts
@@ -1,0 +1,30 @@
+import type { BrowserHistoryState } from '@shared/lib/browser-stream-protocol'
+
+const emptyHistory: BrowserHistoryState = { canGoBack: false, canGoForward: false, url: '' }
+
+interface BrowserViewState {
+  targetId: string | null
+  history: BrowserHistoryState
+}
+
+type BrowserViewAction =
+  | { type: 'view'; targetId: string | null }
+  | { type: 'history'; targetId?: string; history: BrowserHistoryState }
+  | { type: 'reset' }
+
+export const initialBrowserView: BrowserViewState = { targetId: null, history: emptyHistory }
+
+/** Apply tab and history messages in order, including when React batches them. */
+export function browserViewReducer(state: BrowserViewState, action: BrowserViewAction): BrowserViewState {
+  if (action.type === 'reset') return initialBrowserView
+  if (action.type === 'view') {
+    return action.targetId === state.targetId ? state : { targetId: action.targetId, history: emptyHistory }
+  }
+  // A closing CDP connection can have a reply in flight after the viewer switches.
+  if (action.targetId && state.targetId && action.targetId !== state.targetId) return state
+  const targetId = state.targetId ?? action.targetId ?? null
+  const { history } = action
+  if (targetId === state.targetId && history.url === state.history.url &&
+    history.canGoBack === state.history.canGoBack && history.canGoForward === state.history.canGoForward) return state
+  return { targetId, history }
+}

--- a/src/shared/lib/browser-stream-protocol.ts
+++ b/src/shared/lib/browser-stream-protocol.ts
@@ -1,0 +1,9 @@
+// Type-only bridge: the container owns the wire contract and builds independently.
+export type {
+  BrowserTabInfo,
+  BrowserHistoryState,
+  BrowserHistoryMessage,
+  BrowserTabListMessage,
+  BrowserNavigateAction,
+  BrowserNavigateCommand,
+} from '../../../agent-container/src/browser-stream-protocol'

--- a/src/shared/lib/container/mock-browser-scenario.ts
+++ b/src/shared/lib/container/mock-browser-scenario.ts
@@ -1,3 +1,4 @@
+import type { BrowserTabListMessage } from '../browser-stream-protocol'
 /**
  * Browser scenario for E2E testing.
  *
@@ -201,7 +202,7 @@ export class BrowserScenario implements MockScenario {
           active: t.id === activeId,
         })),
         activeTargetId: activeId ?? '',
-      })
+      } satisfies BrowserTabListMessage)
       wss.clients.forEach((ws) => {
         if (ws.readyState === WebSocket.OPEN && lastTabListJson) ws.send(lastTabListJson)
       })

--- a/src/shared/lib/container/mock-browser-scenario.ts
+++ b/src/shared/lib/container/mock-browser-scenario.ts
@@ -99,6 +99,9 @@ export class BrowserScenario implements MockScenario {
     // get an immediate frame even if the page is static and CDP stopped sending.
     let lastMetadataJson: string | null = null
     let lastFrameBuffer: Buffer | null = null
+    // The tab list is sent once per connection, the way the container does after
+    // a page settles, so the renderer's tab strip has something to draw.
+    let lastTabListJson: string | null = null
 
     wss.on('connection', (ws) => {
       console.log('[BrowserScenario] WS client connected to mock stream')
@@ -107,6 +110,7 @@ export class BrowserScenario implements MockScenario {
         ws.send(lastMetadataJson)
         ws.send(lastFrameBuffer)
       }
+      if (lastTabListJson) ws.send(lastTabListJson)
     })
 
     await new Promise<void>((resolve) => {
@@ -152,7 +156,7 @@ export class BrowserScenario implements MockScenario {
     //    Page.startScreencast only works on page targets, not the browser target.
     //    /json returns the list of page targets; /json/version returns the browser target.
     const pagesRes = await fetch(`http://127.0.0.1:${cdpPort}/json`)
-    const pages = (await pagesRes.json()) as Array<{ webSocketDebuggerUrl: string; type: string }>
+    const pages = (await pagesRes.json()) as Array<{ id: string; webSocketDebuggerUrl: string; type: string }>
     const pageTarget = pages.find((p) => p.type === 'page')
     if (!pageTarget) {
       throw new Error('No page target found in Chrome')
@@ -178,6 +182,32 @@ export class BrowserScenario implements MockScenario {
 
     // Wait a moment for navigation
     await new Promise((r) => setTimeout(r, 2000))
+
+    // Tab list from Chrome's own page targets — same shape the container sends
+    // (see broadcastTabList in agent-container/src/server.ts).
+    try {
+      const listRes = await fetch(`http://127.0.0.1:${cdpPort}/json`)
+      const targets = (await listRes.json()) as Array<{ id: string; type: string; url: string; title: string; faviconUrl?: string; webSocketDebuggerUrl: string }>
+      const pageTargets = targets.filter((t) => t.type === 'page')
+      const activeId = pageTargets.find((t) => t.webSocketDebuggerUrl === pageTarget.webSocketDebuggerUrl)?.id ?? pageTargets[0]?.id
+      lastTabListJson = JSON.stringify({
+        type: 'tab_list',
+        tabs: pageTargets.map((t, i) => ({
+          targetId: t.id,
+          index: i,
+          url: t.url,
+          title: t.title || '',
+          faviconUrl: t.faviconUrl || undefined,
+          active: t.id === activeId,
+        })),
+        activeTargetId: activeId ?? '',
+      })
+      wss.clients.forEach((ws) => {
+        if (ws.readyState === WebSocket.OPEN && lastTabListJson) ws.send(lastTabListJson)
+      })
+    } catch (err) {
+      console.warn('[BrowserScenario] Could not build tab list:', err)
+    }
 
     // 8. Start screencast on the page target
     cdpSend('Page.startScreencast', {


### PR DESCRIPTION
Adds browser navigation commands and history state to the screencast protocol, with favicon metadata in tab lists. First in the stack: main → #997 → #998 → #999 → #1000 → #1001. **No visible UI change.**

The container's navigation controller handles Back, Forward, and Reload and refreshes history when a main document commits, so the address and navigation flags update even if a resource never finishes loading. It coalesces overlapping history queries, rejects superseded replies, and suppresses unchanged history messages. Continuous iframe activity still allows useful current-document history replies through.

Transport types live in a shared protocol module. The renderer keeps the viewed tab and its history in one reducer, preserving message order when React batches a tab switch with its destination history and ignoring history from a retired target. The mock browser emits typed tab lists.

The new navigation commands require a rebuilt container image. Older images ignore those commands.

## Validation

- Renderer and container type checks pass; changed-area lint has no errors.
- Browser hook tests cover wire commands, batched tab/history ordering, target changes, and refollowing.
- Eight navigation-controller tests cover document commits, coalescing, stale replies, continuous iframe activity, subframes, history bounds, and disposal.
- Real local Chromium check: history updates while the destination image remains pending; ten iframe history changes emit zero duplicate history frames.
