### PR TITLE
feat(browser): restyle the browser tray onto the file drawer layout

### DIFF
--- a/e2e/helpers/browser-stream.ts
+++ b/e2e/helpers/browser-stream.ts
@@ -1,0 +1,49 @@
+import type { Locator, Page, WebSocketRoute } from '@playwright/test'
+import type { BrowserTabListMessage } from '../../src/shared/lib/browser-stream-protocol'
+
+/** Exercise the real stream decoder and layout with a deterministic page size. */
+export async function mockBrowserStream(page: Page, width: number, height: number) {
+  const data = await page.evaluate(
+    ({ width, height }) => {
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')!
+      ctx.fillStyle = '#e5efff'
+      ctx.fillRect(0, 0, width, height)
+      return canvas.toDataURL('image/jpeg').split(',')[1]
+    },
+    { width, height },
+  )
+  const frame = Buffer.from(data, 'base64')
+  const messages: string[] = []
+  let socket: WebSocketRoute | undefined
+  await page.routeWebSocket('**/api/agents/*/browser/stream', (ws) => {
+    socket = ws
+    ws.onMessage((message) => messages.push(String(message)))
+    ws.send(
+      JSON.stringify({
+        type: 'tab_list',
+        activeTargetId: 'test-page',
+        tabs: [{ targetId: 'test-page', index: 0, url: 'https://example.test/', title: 'Test page', active: true }],
+      } satisfies BrowserTabListMessage),
+    )
+    ws.send(JSON.stringify({ type: 'metadata', deviceWidth: width, deviceHeight: height }))
+    ws.send(frame)
+  })
+  // WebSocket routing is installed by an init script and needs a new document.
+  await page.reload()
+  return { messages, send: (message: object) => socket?.send(JSON.stringify(message)) }
+}
+
+/** Checking hit testing avoids Playwright scrolling an offscreen button into view. */
+export async function isControlReachable(control: Locator) {
+  return control.evaluate((element) => {
+    const rect = element.getBoundingClientRect()
+    return (
+      rect.top >= 0 &&
+      rect.bottom <= window.innerHeight &&
+      element.contains(document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2))
+    )
+  })
+}

--- a/e2e/specs/browser-stream.spec.ts
+++ b/e2e/specs/browser-stream.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 import { AppPage } from '../pages/app.page'
 import { AgentPage } from '../pages/agent.page'
 import { SessionPage } from '../pages/session.page'
-
+import { isControlReachable, mockBrowserStream } from '../helpers/browser-stream'
 
 test.describe('Browser Streaming', () => {
   let appPage: AppPage
@@ -64,5 +64,20 @@ test.describe('Browser Streaming', () => {
 
     // Verify no page errors occurred during the flow
     expect(pageErrors).toEqual([])
+  })
+
+  test('keeps the browser controls reachable for a tall page in a short drawer', async ({ page }) => {
+    await page.setViewportSize({ width: 1200, height: 600 })
+    await mockBrowserStream(page, 600, 800)
+    await sessionPage.sendMessage('browse data:text/html,<h1>Tall page</h1>')
+    await expect(page.getByTestId('browser-canvas')).toHaveAttribute('height', '800')
+
+    const rail = page.getByTestId('browser-tray-rail')
+    await expect.poll(() => rail.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(true)
+    for (const testId of ['browser-tray-stop', 'browser-tray-expand']) {
+      await expect.poll(() => isControlReachable(page.getByTestId(testId))).toBe(true)
+    }
+    await page.getByTestId('browser-tray-stop').click()
+    await expect(page.getByRole('alertdialog')).toBeVisible()
   })
 })

--- a/src/renderer/components/browser/browser-tab-bar.test.tsx
+++ b/src/renderer/components/browser/browser-tab-bar.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserTabBar, type BrowserTabInfo } from './browser-tab-bar'
 
@@ -45,13 +45,36 @@ describe('BrowserTabBar', () => {
     expect(screen.getByText('Tab 3')).toBeInTheDocument()
   })
 
-  it('highlights the viewing tab with bg-background class', () => {
+  it('raises the viewing tab as a card (bg-background on the tab shell)', () => {
     render(<BrowserTabBar {...defaultProps} viewingTargetId="target-1" />)
-    const viewingButton = screen.getByText('Tab 1').closest('button')!
-    expect(viewingButton.className).toContain('bg-background')
+    const viewingTab = screen.getByText('Tab 1').closest('[data-testid="browser-tab"]')!
+    expect(viewingTab.className).toContain('bg-background')
+    expect(viewingTab).toHaveAttribute('data-active')
 
-    const otherButton = screen.getByText('Tab 2').closest('button')!
-    expect(otherButton.className).not.toContain('bg-background')
+    const otherTab = screen.getByText('Tab 2').closest('[data-testid="browser-tab"]')!
+    expect(otherTab).not.toHaveAttribute('data-active')
+  })
+
+  it('renders the trailing control at the right end of the strip', () => {
+    render(<BrowserTabBar {...defaultProps} trailing={<button>hide</button>} />)
+    expect(screen.getByText('hide')).toBeInTheDocument()
+  })
+
+  it('renders the strip with no tabs so the drawer controls stay reachable', () => {
+    render(<BrowserTabBar {...defaultProps} tabs={[]} trailing={<button>hide</button>} />)
+    expect(screen.getByTestId('browser-tab-bar')).toBeInTheDocument()
+    expect(screen.getByText('hide')).toBeInTheDocument()
+    expect(screen.queryByTestId('browser-tab')).toBeNull()
+  })
+
+  it('shows a per-tab close on every tab but the agent-active one', async () => {
+    const onCloseTab = vi.fn()
+    const user = userEvent.setup()
+    render(<BrowserTabBar {...defaultProps} onCloseTab={onCloseTab} />)
+
+    expect(screen.queryByLabelText('Close Tab 0')).toBeNull()
+    await user.click(screen.getByLabelText('Close Tab 1'))
+    expect(onCloseTab).toHaveBeenCalledWith('target-1')
   })
 
   it('shows agent-active indicator (blue dot) on active tab', () => {
@@ -75,38 +98,10 @@ describe('BrowserTabBar', () => {
     expect(onTabClick).toHaveBeenCalledWith('target-2')
   })
 
-  it('shows Eye icon and blue text when autoFollow is true', () => {
-    render(<BrowserTabBar {...defaultProps} autoFollow={true} />)
-    const toggleButton = screen.getByTitle('Auto-following agent (click to pin)')
-    expect(toggleButton.className).toContain('text-blue-500')
-  })
 
-  it('shows EyeOff icon when autoFollow is false', () => {
-    render(<BrowserTabBar {...defaultProps} autoFollow={false} />)
-    const toggleButton = screen.getByTitle('Not following agent (click to follow)')
-    expect(toggleButton).toBeInTheDocument()
-  })
 
-  it('calls onToggleAutoFollow when toggle button is clicked', async () => {
-    const onToggleAutoFollow = vi.fn()
-    const user = userEvent.setup()
-    render(<BrowserTabBar {...defaultProps} onToggleAutoFollow={onToggleAutoFollow} />)
 
-    await user.click(screen.getByTitle('Auto-following agent (click to pin)'))
-    expect(onToggleAutoFollow).toHaveBeenCalledOnce()
-  })
 
-  it('shows loading spinner when loading is true', () => {
-    const { container } = render(<BrowserTabBar {...defaultProps} loading={true} />)
-    const spinner = container.querySelector('.animate-spin')
-    expect(spinner).toBeInTheDocument()
-  })
-
-  it('does not show loading spinner when loading is false', () => {
-    const { container } = render(<BrowserTabBar {...defaultProps} loading={false} />)
-    const spinner = container.querySelector('.animate-spin')
-    expect(spinner).not.toBeInTheDocument()
-  })
 
   it('right-click on tab shows context menu with Close tab', async () => {
     const user = userEvent.setup()
@@ -135,5 +130,54 @@ describe('BrowserTabBar', () => {
     await user.pointer({ keys: '[MouseRight]', target: screen.getByText('Tab 1') })
     await user.click(await screen.findByText('Close tab'))
     expect(onCloseTab).toHaveBeenCalledWith('target-1')
+  })
+
+  it('shows the favicon when the tab has one and a globe when it does not', () => {
+    const tabs: BrowserTabInfo[] = [
+      { targetId: 't1', index: 0, url: 'https://github.com', title: 'GitHub', faviconUrl: 'https://github.com/favicon.svg', active: true },
+      { targetId: 't2', index: 1, url: 'https://example.com', title: 'Example', active: false },
+    ]
+    render(<BrowserTabBar {...defaultProps} tabs={tabs} />)
+    const icon = screen.getByTestId('browser-tab-favicon')
+    expect(icon).toHaveAttribute('src', 'https://github.com/favicon.svg')
+    expect(screen.getAllByTestId('browser-tab-globe')).toHaveLength(1)
+  })
+
+  it('falls back to the globe when the favicon fails to load', () => {
+    const tabs: BrowserTabInfo[] = [
+      { targetId: 't1', index: 0, url: 'https://internal.test', title: 'Internal', faviconUrl: 'https://internal.test/favicon.ico', active: true },
+    ]
+    render(<BrowserTabBar {...defaultProps} tabs={tabs} />)
+    fireEvent.error(screen.getByTestId('browser-tab-favicon'))
+    expect(screen.queryByTestId('browser-tab-favicon')).toBeNull()
+    expect(screen.getByTestId('browser-tab-globe')).toBeInTheDocument()
+  })
+  it('shows Eye icon and blue text when autoFollow is true', () => {
+    render(<BrowserTabBar {...defaultProps} autoFollow={true} />)
+    const toggleButton = screen.getByTitle('Auto-following agent (click to pin)')
+    expect(toggleButton.className).toContain('text-blue-500')
+  })
+
+  it('shows EyeOff icon when autoFollow is false', () => {
+    render(<BrowserTabBar {...defaultProps} autoFollow={false} />)
+    expect(screen.getByTitle('Not following agent (click to follow)')).toBeInTheDocument()
+  })
+
+  it('calls onToggleAutoFollow when toggle button is clicked', async () => {
+    const onToggleAutoFollow = vi.fn()
+    const user = userEvent.setup()
+    render(<BrowserTabBar {...defaultProps} onToggleAutoFollow={onToggleAutoFollow} />)
+    await user.click(screen.getByTitle('Auto-following agent (click to pin)'))
+    expect(onToggleAutoFollow).toHaveBeenCalledOnce()
+  })
+
+  it('shows loading spinner when loading is true', () => {
+    const { container } = render(<BrowserTabBar {...defaultProps} loading={true} />)
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('does not show loading spinner when loading is false', () => {
+    const { container } = render(<BrowserTabBar {...defaultProps} loading={false} />)
+    expect(container.querySelector('.animate-spin')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/browser/browser-tab-bar.tsx
+++ b/src/renderer/components/browser/browser-tab-bar.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useState } from 'react'
+import { DrawerTabStrip, drawerTabClassName } from '@renderer/components/tray/drawer-tab-strip'
 import { Eye, EyeOff, Globe, Loader2, X } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
 import {
@@ -52,9 +53,6 @@ interface BrowserTabBarProps {
   trailing?: ReactNode
 }
 
-/** Sub-pixel slack: a scroller's scrollLeft rarely lands exactly on zero. */
-const EDGE_EPSILON_PX = 1
-
 function tabLabel(tab: BrowserTabInfo): string {
   return tab.title || tab.url || `Tab ${tab.index + 1}`
 }
@@ -80,145 +78,94 @@ export function BrowserTabBar({
   onLeadingTabFlush,
   trailing,
 }: BrowserTabBarProps) {
-  const groupRef = useRef<HTMLDivElement>(null)
-  const trackRef = useRef<HTMLDivElement>(null)
-  const [scrollLeft, setScrollLeft] = useState(0)
-
   const viewingIndex = tabs.findIndex((tab) => tab.targetId === viewingTargetId)
-
-  /** Scroll just far enough to bring a tab fully into the strip. */
-  const reveal = useCallback((index: number) => {
-    const group = groupRef.current
-    const track = trackRef.current
-    const tab = track?.children[index] as HTMLElement | undefined
-    if (!group || !track || !tab) return
-    const left = tab.offsetLeft - track.offsetLeft
-    const right = left + tab.offsetWidth
-    if (left < group.scrollLeft) {
-      group.scrollTo({ left, behavior: 'smooth' })
-    } else if (right > group.scrollLeft + group.clientWidth) {
-      group.scrollTo({ left: right - group.clientWidth, behavior: 'smooth' })
-    }
-  }, [])
-
-  useLayoutEffect(() => {
-    if (viewingIndex >= 0) reveal(viewingIndex)
-  }, [reveal, viewingIndex, tabs.length])
-
-  const atStart = scrollLeft <= EDGE_EPSILON_PX
-  useEffect(() => {
-    onLeadingTabFlush?.(viewingIndex === 0 && atStart)
-  }, [onLeadingTabFlush, viewingIndex, atStart])
-
   return (
-    <div
-      // pl-4 matches the body card's 16px inset, so the first tab's left edge
-      // is flush with the card's (the card's top-left corner is square for this).
-      className="relative flex items-end bg-muted/60 pl-4 pr-2 pt-1.5 shrink-0"
-      data-testid="browser-tab-bar"
+    <DrawerTabStrip
+      tabCount={tabs.length}
+      activeIndex={viewingIndex}
+      onLeadingTabFlush={onLeadingTabFlush}
+      testId="browser-tab"
+      trailing={
+        <>
+          {loading && <Loader2 className="h-3 w-3 animate-spin shrink-0" />}
+          <button
+            type="button"
+            className={cn(
+              'p-0.5 rounded transition-colors shrink-0',
+              autoFollow ? 'text-blue-500 hover:text-blue-600' : 'text-muted-foreground hover:text-foreground',
+            )}
+            onClick={onToggleAutoFollow}
+            title={autoFollow ? 'Auto-following agent (click to pin)' : 'Not following agent (click to follow)'}
+            aria-label={autoFollow ? 'Auto-following agent (click to pin)' : 'Not following agent (click to follow)'}
+          >
+            {autoFollow ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+          </button>
+          {trailing}
+        </>
+      }
     >
-      {/* pb-px/-mb-px holds the viewed tab's 1px overhang onto the body card
-          without letting the vertical axis overflow (see file-tab-bar.tsx). */}
-      <div
-        ref={groupRef}
-        onScroll={(e) => setScrollLeft(e.currentTarget.scrollLeft)}
-        className="file-tab-scroller min-w-0 flex-1 -mb-px overflow-x-auto overflow-y-hidden pb-px"
-      >
-        <div ref={trackRef} className="flex w-full items-end gap-px">
-          {tabs.map((tab, index) => {
-            const isViewing = tab.targetId === viewingTargetId
-            const isAgentActive = tab.active
-            const label = tabLabel(tab)
+      {(reveal) =>
+        tabs.map((tab, index) => {
+          const isViewing = tab.targetId === viewingTargetId
+          const isAgentActive = tab.active
+          const label = tabLabel(tab)
 
-            return (
-              <ContextMenu key={tab.targetId}>
-                <ContextMenuTrigger asChild>
-                  {/* A shell, not a control: it holds the select and close
+          return (
+            <ContextMenu key={tab.targetId}>
+              <ContextMenuTrigger asChild>
+                {/* A shell, not a control: it holds the select and close
                       buttons, and a <button> may not contain another. */}
-                  <div
-                    data-testid="browser-tab"
-                    data-active={isViewing || undefined}
-                    className={cn(
-                      'group relative flex h-8 flex-[0_1_160px] items-center rounded-t-lg pr-2 text-left text-xs transition-colors',
-                      isViewing
-                        ? 'z-10 min-w-[9.5rem] -mb-px border border-b-0 border-black/5 bg-background text-foreground shadow-[0_-1px_2px_rgba(0,0,0,0.04)] dark:border-white/5'
-                        : 'min-w-[4.25rem] text-foreground hover:bg-background/60',
-                      // hairline separator on the left of inactive tabs that don't touch the viewed card
-                      index > 0 && index !== viewingIndex && index - 1 !== viewingIndex &&
-                        'before:absolute before:left-0 before:top-2 before:bottom-2 before:w-px before:bg-border/60',
-                    )}
+                <div
+                  data-testid="browser-tab"
+                  data-active={isViewing || undefined}
+                  className={drawerTabClassName(index, viewingIndex)}
+                >
+                  <button
+                    type="button"
+                    onClick={() => onTabClick(tab.targetId)}
+                    onFocus={() => reveal(index)}
+                    title={tab.title || tab.url}
+                    data-testid="browser-tab-select"
+                    className="flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left"
                   >
+                    <span className="relative shrink-0">
+                      <TabIcon faviconUrl={tab.faviconUrl} title={label} />
+                      {isAgentActive && (
+                        <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-blue-500 shrink-0" />
+                      )}
+                    </span>
+                    {/* Overflowing names fade out at the right edge instead of ellipsizing, as in Chrome. */}
+                    <span className="min-w-0 flex-1 overflow-hidden whitespace-nowrap [mask-image:linear-gradient(to_right,black_calc(100%-16px),transparent)]">
+                      {label}
+                    </span>
+                  </button>
+                  {/* The agent's own tab cannot be closed out from under it,
+                        so that one has no close control at all. */}
+                  {onCloseTab && !isAgentActive && (
                     <button
                       type="button"
-                      onClick={() => onTabClick(tab.targetId)}
-                      onFocus={() => reveal(index)}
-                      title={tab.title || tab.url}
-                      data-testid="browser-tab-select"
-                      className="flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left"
+                      data-testid="browser-tab-close"
+                      aria-label={`Close ${label}`}
+                      onClick={() => onCloseTab(tab.targetId)}
+                      className={cn(
+                        'shrink-0 rounded p-0.5 text-muted-foreground transition-opacity hover:bg-muted-foreground/20 hover:text-foreground group-hover:opacity-100 touch:opacity-100',
+                        isViewing ? 'opacity-100' : 'opacity-0',
+                      )}
                     >
-                      <span className="relative shrink-0">
-                        <TabIcon faviconUrl={tab.faviconUrl} title={label} />
-                        {isAgentActive && (
-                          <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-blue-500 shrink-0" />
-                        )}
-                      </span>
-                      {/* Overflowing names fade out at the right edge instead of ellipsizing, as in Chrome. */}
-                      <span className="min-w-0 flex-1 overflow-hidden whitespace-nowrap [mask-image:linear-gradient(to_right,black_calc(100%-16px),transparent)]">
-                        {label}
-                      </span>
+                      <X className="h-3 w-3" />
                     </button>
-                    {/* The agent's own tab cannot be closed out from under it,
-                        so that one has no close control at all. */}
-                    {onCloseTab && !isAgentActive && (
-                      <button
-                        type="button"
-                        data-testid="browser-tab-close"
-                        aria-label={`Close ${label}`}
-                        onClick={() => onCloseTab(tab.targetId)}
-                        className={cn(
-                          'shrink-0 rounded p-0.5 text-muted-foreground transition-opacity hover:bg-muted-foreground/20 hover:text-foreground group-hover:opacity-100 touch:opacity-100',
-                          isViewing ? 'opacity-100' : 'opacity-0',
-                        )}
-                      >
-                        <X className="h-3 w-3" />
-                      </button>
-                    )}
-                  </div>
-                </ContextMenuTrigger>
-                <ContextMenuContent>
-                  <ContextMenuItem
-                    disabled={isAgentActive}
-                    onClick={() => onCloseTab?.(tab.targetId)}
-                  >
-                    Close tab
-                  </ContextMenuItem>
-                </ContextMenuContent>
-              </ContextMenu>
-            )
-          })}
-        </div>
-      </div>
-
-      {/* ml-auto pins the controls right; pr-1.5 + the strip's pr-2 + the
-          buttons' p-0.5 puts the last icon's edge at 16px, flush with the body card. */}
-      {/* ml-auto pins the controls right; pr-1.5 + the strip's pr-2 + the
-          buttons' p-0.5 puts the last icon's edge at 16px, flush with the body card. */}
-      <div className="ml-auto flex h-8 shrink-0 items-center gap-1 pl-1 pr-1.5 text-muted-foreground">
-        {loading && <Loader2 className="h-3 w-3 animate-spin shrink-0" />}
-        <button
-          type="button"
-          className={cn(
-            'p-0.5 rounded transition-colors shrink-0',
-            autoFollow ? 'text-blue-500 hover:text-blue-600' : 'text-muted-foreground hover:text-foreground',
-          )}
-          onClick={onToggleAutoFollow}
-          title={autoFollow ? 'Auto-following agent (click to pin)' : 'Not following agent (click to follow)'}
-          aria-label={autoFollow ? 'Auto-following agent (click to pin)' : 'Not following agent (click to follow)'}
-        >
-          {autoFollow ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
-        </button>
-        {trailing}
-      </div>
-    </div>
+                  )}
+                </div>
+              </ContextMenuTrigger>
+              <ContextMenuContent>
+                <ContextMenuItem disabled={isAgentActive} onClick={() => onCloseTab?.(tab.targetId)}>
+                  Close tab
+                </ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu>
+          )
+        })
+      }
+    </DrawerTabStrip>
   )
 }

--- a/src/renderer/components/browser/browser-tab-bar.tsx
+++ b/src/renderer/components/browser/browser-tab-bar.tsx
@@ -1,4 +1,6 @@
-import { Eye, EyeOff, Loader2 } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { Eye, EyeOff, Globe, Loader2, X } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
 import {
   ContextMenu,
@@ -10,6 +12,28 @@ import {
 import type { BrowserTabInfo } from '@shared/lib/browser-stream-protocol'
 export type { BrowserTabInfo } from '@shared/lib/browser-stream-protocol'
 
+/**
+ * The tab's favicon, or a globe when there is none or it fails to load. The
+ * failure is remembered per URL so a dead icon does not retry on every render.
+ */
+function TabIcon({ faviconUrl, title }: { faviconUrl?: string; title: string }) {
+  const [failedUrl, setFailedUrl] = useState<string | null>(null)
+  if (!faviconUrl || failedUrl === faviconUrl) {
+    return <Globe className="h-3.5 w-3.5 text-inherit" data-testid="browser-tab-globe" />
+  }
+  return (
+    <img
+      src={faviconUrl}
+      alt=""
+      aria-hidden
+      className="h-3.5 w-3.5 rounded-sm object-contain"
+      data-testid="browser-tab-favicon"
+      data-title={title}
+      onError={() => setFailedUrl(faviconUrl)}
+    />
+  )
+}
+
 interface BrowserTabBarProps {
   tabs: BrowserTabInfo[]
   viewingTargetId: string | null
@@ -18,57 +42,183 @@ interface BrowserTabBarProps {
   onTabClick: (targetId: string) => void
   onCloseTab?: (targetId: string) => void
   onToggleAutoFollow: () => void
+  /**
+   * Whether the viewed tab's left edge is flush with the strip's left inset —
+   * true only for the first tab, unscrolled. The body card squares off its
+   * top-left corner to meet the tab when it is.
+   */
+  onLeadingTabFlush?: (flush: boolean) => void
+  /** Panel-level controls rendered after the last tab, at the strip's right edge (the drawer close). */
+  trailing?: ReactNode
 }
 
-export function BrowserTabBar({ tabs, viewingTargetId, autoFollow, loading, onTabClick, onCloseTab, onToggleAutoFollow }: BrowserTabBarProps) {
-  return (
-    <div className="flex items-center gap-0.5 px-1.5 py-1 bg-muted/30 border-b overflow-x-auto shrink-0" style={{ height: 30 }}>
-      {tabs.map((tab) => {
-        const isViewing = tab.targetId === viewingTargetId
-        const isAgentActive = tab.active
+/** Sub-pixel slack: a scroller's scrollLeft rarely lands exactly on zero. */
+const EDGE_EPSILON_PX = 1
 
-        return (
-          <ContextMenu key={tab.targetId}>
-            <ContextMenuTrigger asChild>
-              <button
-                className={cn(
-                  'relative flex items-center gap-1 px-2 py-1 rounded text-xs leading-tight max-w-[120px] truncate transition-colors',
-                  isViewing ? 'bg-background shadow-sm text-foreground' : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
-                )}
-                onClick={() => onTabClick(tab.targetId)}
-                title={tab.title || tab.url}
-              >
-                <span className="truncate">{tab.title || tab.url || `Tab ${tab.index + 1}`}</span>
-                {isAgentActive && (
-                  <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-blue-500 shrink-0" />
-                )}
-              </button>
-            </ContextMenuTrigger>
-            <ContextMenuContent>
-              <ContextMenuItem
-                disabled={isAgentActive}
-                onClick={() => onCloseTab?.(tab.targetId)}
-              >
-                Close tab
-              </ContextMenuItem>
-            </ContextMenuContent>
-          </ContextMenu>
-        )
-      })}
-      {loading && (
-        <Loader2 className="h-3 w-3 animate-spin text-muted-foreground shrink-0 ml-auto" />
-      )}
-      <button
-        className={cn(
-          loading ? '' : 'ml-auto',
-          'p-0.5 rounded transition-colors shrink-0',
-          autoFollow ? 'text-blue-500 hover:text-blue-600' : 'text-muted-foreground hover:text-foreground'
-        )}
-        onClick={onToggleAutoFollow}
-        title={autoFollow ? 'Auto-following agent (click to pin)' : 'Not following agent (click to follow)'}
+function tabLabel(tab: BrowserTabInfo): string {
+  return tab.title || tab.url || `Tab ${tab.index + 1}`
+}
+
+/**
+ * The browser drawer's tab strip, in the same Chrome-style dress as the file
+ * drawer's (`file-tab-bar.tsx`): tabs on a gray rail, the viewed tab raised as
+ * a card whose open bottom hides the body's top border, labels that fade out
+ * instead of ellipsizing.
+ *
+ * Unlike the file strip it always renders, even with no tabs: the drawer's own
+ * controls (auto-follow, hide panel) live at its right end, and a browser that
+ * is still connecting has a drawer to hide before it has a page to show.
+ */
+export function BrowserTabBar({
+  tabs,
+  viewingTargetId,
+  autoFollow,
+  loading,
+  onTabClick,
+  onCloseTab,
+  onToggleAutoFollow,
+  onLeadingTabFlush,
+  trailing,
+}: BrowserTabBarProps) {
+  const groupRef = useRef<HTMLDivElement>(null)
+  const trackRef = useRef<HTMLDivElement>(null)
+  const [scrollLeft, setScrollLeft] = useState(0)
+
+  const viewingIndex = tabs.findIndex((tab) => tab.targetId === viewingTargetId)
+
+  /** Scroll just far enough to bring a tab fully into the strip. */
+  const reveal = useCallback((index: number) => {
+    const group = groupRef.current
+    const track = trackRef.current
+    const tab = track?.children[index] as HTMLElement | undefined
+    if (!group || !track || !tab) return
+    const left = tab.offsetLeft - track.offsetLeft
+    const right = left + tab.offsetWidth
+    if (left < group.scrollLeft) {
+      group.scrollTo({ left, behavior: 'smooth' })
+    } else if (right > group.scrollLeft + group.clientWidth) {
+      group.scrollTo({ left: right - group.clientWidth, behavior: 'smooth' })
+    }
+  }, [])
+
+  useLayoutEffect(() => {
+    if (viewingIndex >= 0) reveal(viewingIndex)
+  }, [reveal, viewingIndex, tabs.length])
+
+  const atStart = scrollLeft <= EDGE_EPSILON_PX
+  useEffect(() => {
+    onLeadingTabFlush?.(viewingIndex === 0 && atStart)
+  }, [onLeadingTabFlush, viewingIndex, atStart])
+
+  return (
+    <div
+      // pl-4 matches the body card's 16px inset, so the first tab's left edge
+      // is flush with the card's (the card's top-left corner is square for this).
+      className="relative flex items-end bg-muted/60 pl-4 pr-2 pt-1.5 shrink-0"
+      data-testid="browser-tab-bar"
+    >
+      {/* pb-px/-mb-px holds the viewed tab's 1px overhang onto the body card
+          without letting the vertical axis overflow (see file-tab-bar.tsx). */}
+      <div
+        ref={groupRef}
+        onScroll={(e) => setScrollLeft(e.currentTarget.scrollLeft)}
+        className="file-tab-scroller min-w-0 flex-1 -mb-px overflow-x-auto overflow-y-hidden pb-px"
       >
-        {autoFollow ? <Eye className="h-3 w-3" /> : <EyeOff className="h-3 w-3" />}
-      </button>
+        <div ref={trackRef} className="flex w-full items-end gap-px">
+          {tabs.map((tab, index) => {
+            const isViewing = tab.targetId === viewingTargetId
+            const isAgentActive = tab.active
+            const label = tabLabel(tab)
+
+            return (
+              <ContextMenu key={tab.targetId}>
+                <ContextMenuTrigger asChild>
+                  {/* A shell, not a control: it holds the select and close
+                      buttons, and a <button> may not contain another. */}
+                  <div
+                    data-testid="browser-tab"
+                    data-active={isViewing || undefined}
+                    className={cn(
+                      'group relative flex h-8 flex-[0_1_160px] items-center rounded-t-lg pr-2 text-left text-xs transition-colors',
+                      isViewing
+                        ? 'z-10 min-w-[9.5rem] -mb-px border border-b-0 border-black/5 bg-background text-foreground shadow-[0_-1px_2px_rgba(0,0,0,0.04)] dark:border-white/5'
+                        : 'min-w-[4.25rem] text-foreground hover:bg-background/60',
+                      // hairline separator on the left of inactive tabs that don't touch the viewed card
+                      index > 0 && index !== viewingIndex && index - 1 !== viewingIndex &&
+                        'before:absolute before:left-0 before:top-2 before:bottom-2 before:w-px before:bg-border/60',
+                    )}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => onTabClick(tab.targetId)}
+                      onFocus={() => reveal(index)}
+                      title={tab.title || tab.url}
+                      data-testid="browser-tab-select"
+                      className="flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left"
+                    >
+                      <span className="relative shrink-0">
+                        <TabIcon faviconUrl={tab.faviconUrl} title={label} />
+                        {isAgentActive && (
+                          <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-blue-500 shrink-0" />
+                        )}
+                      </span>
+                      {/* Overflowing names fade out at the right edge instead of ellipsizing, as in Chrome. */}
+                      <span className="min-w-0 flex-1 overflow-hidden whitespace-nowrap [mask-image:linear-gradient(to_right,black_calc(100%-16px),transparent)]">
+                        {label}
+                      </span>
+                    </button>
+                    {/* The agent's own tab cannot be closed out from under it,
+                        so that one has no close control at all. */}
+                    {onCloseTab && !isAgentActive && (
+                      <button
+                        type="button"
+                        data-testid="browser-tab-close"
+                        aria-label={`Close ${label}`}
+                        onClick={() => onCloseTab(tab.targetId)}
+                        className={cn(
+                          'shrink-0 rounded p-0.5 text-muted-foreground transition-opacity hover:bg-muted-foreground/20 hover:text-foreground group-hover:opacity-100 touch:opacity-100',
+                          isViewing ? 'opacity-100' : 'opacity-0',
+                        )}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    )}
+                  </div>
+                </ContextMenuTrigger>
+                <ContextMenuContent>
+                  <ContextMenuItem
+                    disabled={isAgentActive}
+                    onClick={() => onCloseTab?.(tab.targetId)}
+                  >
+                    Close tab
+                  </ContextMenuItem>
+                </ContextMenuContent>
+              </ContextMenu>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* ml-auto pins the controls right; pr-1.5 + the strip's pr-2 + the
+          buttons' p-0.5 puts the last icon's edge at 16px, flush with the body card. */}
+      {/* ml-auto pins the controls right; pr-1.5 + the strip's pr-2 + the
+          buttons' p-0.5 puts the last icon's edge at 16px, flush with the body card. */}
+      <div className="ml-auto flex h-8 shrink-0 items-center gap-1 pl-1 pr-1.5 text-muted-foreground">
+        {loading && <Loader2 className="h-3 w-3 animate-spin shrink-0" />}
+        <button
+          type="button"
+          className={cn(
+            'p-0.5 rounded transition-colors shrink-0',
+            autoFollow ? 'text-blue-500 hover:text-blue-600' : 'text-muted-foreground hover:text-foreground',
+          )}
+          onClick={onToggleAutoFollow}
+          title={autoFollow ? 'Auto-following agent (click to pin)' : 'Not following agent (click to follow)'}
+          aria-label={autoFollow ? 'Auto-following agent (click to pin)' : 'Not following agent (click to follow)'}
+        >
+          {autoFollow ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+        </button>
+        {trailing}
+      </div>
     </div>
   )
 }

--- a/src/renderer/components/browser/browser-tray-content.tsx
+++ b/src/renderer/components/browser/browser-tray-content.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
-import { Globe, MousePointerClick, PanelRightClose, Pause, Play, Square, Expand, Shrink } from 'lucide-react'
+import { useState, useRef, useCallback } from 'react'
+import { Expand, MousePointerClick, PanelRight, Shrink, Square } from 'lucide-react'
 import { BrowserActivityLog } from './browser-activity-log'
 import { BrowserTabBar } from './browser-tab-bar'
 import { useBrowserStream } from '@renderer/hooks/use-browser-stream'
 import { Button } from '@renderer/components/ui/button'
 import { DeclineButton } from '@renderer/components/messages/decline-button'
-import { apiFetch } from '@renderer/lib/api'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import { linkify } from '@renderer/lib/linkify'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useBrowserInputActions } from '@renderer/hooks/use-browser-input-actions'
@@ -29,6 +29,15 @@ interface BrowserTrayContentProps {
   onToggleExpand?: () => void
 }
 
+/** The host of a page URL, for the title row's secondary text; nothing for a URL that will not parse. */
+function hostOf(url: string): string | null {
+  try {
+    return new URL(url).host || null
+  } catch {
+    return null
+  }
+}
+
 export function BrowserTrayContent({
   agentSlug,
   sessionId,
@@ -49,35 +58,10 @@ export function BrowserTrayContent({
     canvasRef,
   })
 
-  const [isPaused, setIsPaused] = useState(false)
-
-  const handlePauseResume = useCallback(async () => {
-    if (isPaused) {
-      try {
-        await apiFetch(`/api/agents/${agentSlug}/sessions/${sessionId}/messages`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content: 'resume' }),
-        })
-        setIsPaused(false)
-      } catch (err) {
-        console.error('Failed to resume session:', err)
-      }
-    } else {
-      try {
-        await apiFetch(`/api/agents/${agentSlug}/sessions/${sessionId}/interrupt`, {
-          method: 'POST',
-        })
-        setIsPaused(true)
-      } catch (err) {
-        console.error('Failed to pause session:', err)
-      }
-    }
-  }, [agentSlug, sessionId, isPaused])
-
-  useEffect(() => {
-    if (!browserActive) setIsPaused(false)
-  }, [browserActive])
+  // The body card squares off its top-left corner only while the viewed tab sits
+  // directly above it; the strip is the only thing that knows when that is.
+  const [leadingTabFlush, setLeadingTabFlush] = useState(false)
+  const onLeadingTabFlush = useCallback((flush: boolean) => setLeadingTabFlush(flush), [])
 
   const latestRequest = stream.pendingBrowserInputRequests.length > 0
     ? stream.pendingBrowserInputRequests[stream.pendingBrowserInputRequests.length - 1]
@@ -90,161 +74,204 @@ export function BrowserTrayContent({
     onResolved: (toolUseId) => stream.dismissBrowserInputRequest(toolUseId),
   })
 
+  // The card is headed by the page the user is looking at, the way the file
+  // card is headed by its filename. Before any tab exists it is just "Browser".
+  const viewingTab = stream.tabs.find((tab) => tab.targetId === stream.viewingTargetId) ?? null
+  const title = viewingTab?.title || 'Browser'
+  const host = viewingTab ? hostOf(viewingTab.url) : null
+
   return (
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden" data-testid="browser-drawer-panel">
-      {/* Header */}
-      <div className="flex items-center gap-2 px-4 py-2 text-sm text-muted-foreground select-none shrink-0">
-        <Globe className="h-4 w-4 shrink-0" />
-        <span className="flex-1 text-xs truncate font-medium">
-          {stream.needsAttention ? (
-            <span className="text-blue-600 dark:text-blue-400">Input needed</span>
-          ) : (
-            <>Browser{stream.connected ? '' : ' (connecting...)'}</>
-          )}
-        </span>
-        <button
-          className="p-0.5 rounded hover:bg-muted transition-colors"
-          onClick={onClose}
-          title="Hide browser panel"
-        >
-          <PanelRightClose className="h-4 w-4" />
-        </button>
-      </div>
-
-      {/* Tab bar */}
-      {stream.tabs.length >= 1 && (
-        <BrowserTabBar
-          tabs={stream.tabs}
-          viewingTargetId={stream.viewingTargetId}
-          autoFollow={stream.autoFollow}
-          loading={stream.pageLoading}
-          onTabClick={stream.handleTabClick}
-          onCloseTab={stream.handleCloseTab}
-          onToggleAutoFollow={stream.toggleAutoFollow}
-        />
-      )}
-
-      {/* Canvas viewport */}
-      <div className={cn('relative shrink-0 overflow-hidden bg-background border-y border-border/40', isActive && !stream.needsAttention && 'browser-glow-container')}>
-        <canvas
-          ref={canvasRef}
-          className={`w-full block ${stream.isViewOnly ? 'cursor-not-allowed' : 'cursor-default'}`}
-          style={{ aspectRatio: stream.aspectRatio, willChange: 'transform' }}
-          tabIndex={stream.isViewOnly ? -1 : 0}
-          data-testid="browser-canvas"
-          onMouseDown={stream.isViewOnly ? undefined : stream.handleMouseDown}
-          onMouseUp={stream.isViewOnly ? undefined : stream.handleMouseUp}
-          onMouseMove={stream.isViewOnly ? undefined : stream.handleMouseMove}
-          onWheel={stream.isViewOnly ? undefined : stream.handleWheel}
-          onKeyDown={stream.isViewOnly ? undefined : stream.handleKeyDown}
-          onKeyUp={stream.isViewOnly ? undefined : stream.handleKeyUp}
-          onPaste={stream.isViewOnly ? undefined : stream.handlePaste}
-          onContextMenu={(e) => e.preventDefault()}
-        />
-        {!stream.connected && (
-          <div className="absolute inset-0 flex items-center justify-center bg-black/50">
-            <span className="text-white text-xs">Connecting to browser stream...</span>
-          </div>
-        )}
-        {stream.showOverlay && (
-          <div
-            className="absolute inset-0 flex flex-col items-center justify-center bg-black/40 backdrop-blur-sm cursor-pointer z-10 transition-opacity duration-300"
-            role="button"
-            tabIndex={0}
-            onClick={stream.dismissOverlay}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault()
-                stream.dismissOverlay()
-              }
-            }}
+      {/* Page tabs, with the drawer's own hide control at the strip's right end. */}
+      <BrowserTabBar
+        tabs={stream.tabs}
+        viewingTargetId={stream.viewingTargetId}
+        autoFollow={stream.autoFollow}
+        loading={stream.pageLoading}
+        onTabClick={stream.handleTabClick}
+        onCloseTab={stream.handleCloseTab}
+        onToggleAutoFollow={stream.toggleAutoFollow}
+        onLeadingTabFlush={onLeadingTabFlush}
+        trailing={
+          // The drawer's own control, at the strip's right end like the file drawer's.
+          <button
+            type="button"
+            className="inline-flex p-0.5 rounded hover:bg-muted transition-colors"
+            onClick={onClose}
+            title="Hide browser panel"
+            aria-label="Hide browser panel"
           >
-            <span className="relative flex h-3 w-3 mb-2">
-              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
-              <span className="relative inline-flex rounded-full h-3 w-3 bg-blue-500"></span>
-            </span>
-            <span className="text-white text-sm font-medium mb-3">Your input needed</span>
-            <MousePointerClick className="h-6 w-6 text-white animate-pulse" />
-            <span className="text-white/70 text-xs mt-1">Click to interact</span>
-          </div>
-        )}
-      </div>
+            <PanelRight className="h-4 w-4" />
+          </button>
+        }
+      />
 
-      {/* Browser controls pill. translateZ(0) forces this onto its own compositing
-          layer so it paints above the screencast <canvas> (which sets
-          will-change: transform). Without its own layer, Safari/WebKit composites
-          the canvas layer over the z-index'd pill and the controls disappear. */}
+      {/* Browser body, on the same gray as the tab rail: the page card inset 16px
+          on every side, with the activity log sitting directly on the rail below it. */}
+      <div className="flex flex-1 min-h-0 flex-col bg-muted/60 px-4 pb-4">
       <div
-        className="sticky bottom-2 z-20 flex justify-center pointer-events-none shrink-0 -mt-10"
-        style={{ transform: 'translateZ(0)' }}
+        className={cn(
+          'flex w-full shrink-0 flex-col overflow-hidden rounded-lg border border-black/5 bg-background shadow-[0_1px_3px_rgba(0,0,0,0.04),0_2px_8px_rgba(0,0,0,0.03)] dark:border-white/5 dark:shadow-[0_1px_3px_rgba(0,0,0,0.2),0_2px_8px_rgba(0,0,0,0.15)]',
+          // Square only where a tab actually meets the corner.
+          leadingTabFlush && 'rounded-tl-none',
+        )}
+        data-testid="browser-tray-card"
       >
-        <div className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-background px-2 py-1 shadow-md pointer-events-auto">
-          {(isPaused || (isActive && !stream.needsAttention)) && (
-            <button
-              className="p-1.5 rounded-full hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-              onClick={handlePauseResume}
-              title={isPaused ? 'Resume' : 'Pause'}
-            >
-              {isPaused ? <Play className="h-3.5 w-3.5 fill-current" /> : <Pause className="h-3.5 w-3.5 fill-current" />}
-            </button>
-          )}
-          <button
-            className="p-1.5 rounded-full hover:bg-muted transition-colors text-red-500 hover:text-red-600"
-            onClick={stream.handleCloseClick}
-            title="Stop browser"
-          >
-            <Square className="h-3.5 w-3.5 fill-current" />
-          </button>
-          <button
-            className="p-1.5 rounded-full hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-            onClick={onToggleExpand}
-            title={isExpanded ? 'Collapse' : 'Expand'}
-          >
-            {isExpanded ? <Shrink className="h-3.5 w-3.5" /> : <Expand className="h-3.5 w-3.5" />}
-          </button>
+        {/* Title row: the viewed page and its state. */}
+        <div className="flex shrink-0 items-center gap-2 px-4 pt-4 pb-2" data-testid="browser-tray-title">
+          <div className="flex min-w-0 flex-1 items-baseline gap-2">
+            <h2 className="truncate text-sm font-medium text-foreground">{title}</h2>
+            {stream.needsAttention ? (
+              <span className="shrink-0 text-xs font-normal text-blue-600 dark:text-blue-400">Input needed</span>
+            ) : !stream.connected ? (
+              <span className="shrink-0 text-xs font-normal text-muted-foreground">Connecting…</span>
+            ) : host ? (
+              <span className="truncate text-xs font-normal text-muted-foreground" data-testid="browser-tray-host">{host}</span>
+            ) : null}
+          </div>
         </div>
+
+        {/* Canvas viewport */}
+        <div
+          className={cn(
+            'relative shrink-0 overflow-hidden bg-background border-t border-border/40',
+            isActive && !stream.needsAttention && 'browser-glow-container',
+          )}
+        >
+          <canvas
+            ref={canvasRef}
+            className={cn('block w-full', stream.isViewOnly ? 'cursor-not-allowed' : 'cursor-default')}
+            style={{ aspectRatio: stream.aspectRatio, willChange: 'transform' }}
+            tabIndex={stream.isViewOnly ? -1 : 0}
+            data-testid="browser-canvas"
+            onMouseDown={stream.isViewOnly ? undefined : stream.handleMouseDown}
+            onMouseUp={stream.isViewOnly ? undefined : stream.handleMouseUp}
+            onMouseMove={stream.isViewOnly ? undefined : stream.handleMouseMove}
+            onWheel={stream.isViewOnly ? undefined : stream.handleWheel}
+            onKeyDown={stream.isViewOnly ? undefined : stream.handleKeyDown}
+            onKeyUp={stream.isViewOnly ? undefined : stream.handleKeyUp}
+            onPaste={stream.isViewOnly ? undefined : stream.handlePaste}
+            onContextMenu={(e) => e.preventDefault()}
+          />
+          {!stream.connected && (
+            <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+              <span className="text-white text-xs">Connecting to browser stream...</span>
+            </div>
+          )}
+          {stream.showOverlay && (
+            <div
+              className="absolute inset-0 flex flex-col items-center justify-center bg-black/40 backdrop-blur-sm cursor-pointer z-10 transition-opacity duration-300"
+              role="button"
+              tabIndex={0}
+              onClick={stream.dismissOverlay}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  stream.dismissOverlay()
+                }
+              }}
+            >
+              <span className="relative flex h-3 w-3 mb-2">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
+                <span className="relative inline-flex rounded-full h-3 w-3 bg-blue-500"></span>
+              </span>
+              <span className="text-white text-sm font-medium mb-3">Your input needed</span>
+              <MousePointerClick className="h-6 w-6 text-white animate-pulse" />
+              <span className="text-white/70 text-xs mt-1">Click to interact</span>
+            </div>
+          )}
+
+          {/* Controls pill, floating over the bottom of the page. translateZ(0)
+              forces it onto its own compositing layer so it paints above the
+              screencast <canvas> (which sets will-change: transform); without
+              it Safari/WebKit composites the canvas over the pill. */}
+          <div
+            className="absolute bottom-2 left-1/2 z-20"
+            style={{ transform: 'translateX(-50%) translateZ(0)' }}
+            data-testid="browser-tray-pill"
+          >
+            <TooltipProvider delayDuration={300}>
+            <div className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-background px-2 py-1 shadow-md">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={stream.handleCloseClick}
+                    aria-label="Stop browser agent"
+                    data-testid="browser-tray-stop"
+                    className="p-1.5 rounded-full text-red-500 transition-colors hover:bg-muted hover:text-red-600"
+                  >
+                    <Square className="h-3.5 w-3.5 fill-current" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">Stop browser agent</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={onToggleExpand}
+                    aria-label={isExpanded ? 'Collapse' : 'Expand'}
+                    data-testid="browser-tray-expand"
+                    className="p-1.5 rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  >
+                    {isExpanded ? <Shrink className="h-3.5 w-3.5" /> : <Expand className="h-3.5 w-3.5" />}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">{isExpanded ? 'Collapse' : 'Expand'}</TooltipContent>
+              </Tooltip>
+            </div>
+            </TooltipProvider>
+          </div>
+        </div>
+
+        {/* Action bar */}
+        {stream.needsAttention && latestRequest && (
+          <div className="shrink-0 px-4 py-3 border-t border-border/40">
+            <div className="rounded-lg border border-border/60 bg-muted/30 p-3 flex items-center gap-2">
+              <span className="text-xs font-medium text-foreground flex-1 truncate">
+                {latestRequest.message ? linkify(latestRequest.message) : 'Your input needed'}
+              </span>
+              <DeclineButton
+                onDecline={(reason) => decline(latestRequest.toolUseId, reason)}
+                disabled={submittingAction !== null}
+                label="Decline"
+                showIcon={false}
+                size="sm"
+                // Chevron sits inside the grey action bar; clear the bar's bottom edge
+                // (plus a small gap) rather than offsetting from the chevron.
+                popoverSideOffset={18}
+                className="h-7 text-xs border-border text-foreground hover:bg-muted"
+                data-testid="browser-tray-decline-btn"
+              />
+              <Button
+                onClick={() => complete(latestRequest.toolUseId)}
+                loading={submittingAction === 'completing'}
+                disabled={submittingAction !== null}
+                size="sm"
+                className="h-7 text-xs bg-blue-600 text-white hover:bg-blue-700"
+              >
+                Done
+              </Button>
+            </div>
+            {actionError && (
+              <p className="mt-1 px-1 text-2xs text-destructive">{actionError}</p>
+            )}
+          </div>
+        )}
+
       </div>
 
-      {/* Action bar */}
-      {stream.needsAttention && latestRequest && (
-        <div className="shrink-0 px-4 mt-3">
-          <div className="rounded-lg border border-border/60 bg-muted/30 p-3 flex items-center gap-2">
-            <span className="text-xs font-medium text-foreground flex-1 truncate">
-              {latestRequest.message ? linkify(latestRequest.message) : 'Your input needed'}
-            </span>
-            <DeclineButton
-              onDecline={(reason) => decline(latestRequest.toolUseId, reason)}
-              disabled={submittingAction !== null}
-              label="Decline"
-              showIcon={false}
-              size="sm"
-              // Chevron sits inside the grey action bar; clear the bar's bottom edge
-              // (plus a small gap) rather than offsetting from the chevron.
-              popoverSideOffset={18}
-              className="h-7 text-xs border-border text-foreground hover:bg-muted"
-              data-testid="browser-tray-decline-btn"
-            />
-            <Button
-              onClick={() => complete(latestRequest.toolUseId)}
-              loading={submittingAction === 'completing'}
-              disabled={submittingAction !== null}
-              size="sm"
-              className="h-7 text-xs bg-blue-600 text-white hover:bg-blue-700"
-            >
-              Done
-            </Button>
-          </div>
-          {actionError && (
-            <p className="mt-1 px-1 text-2xs text-destructive">{actionError}</p>
-          )}
-        </div>
-      )}
-
-      {/* Activity log */}
-      <div className="flex items-center gap-1 py-1.5 border-b shrink-0 mx-4 mt-4">
+      {/* Activity log, on the rail rather than in the card. The log pads its own
+          rows 16px, so it is pulled back out to the rail's edge to line up with
+          the heading and the card. */}
+      <div className="flex items-center gap-1 py-1.5 border-b border-border/60 shrink-0 mt-4">
         <span className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">Activity</span>
       </div>
-      <BrowserActivityLog sessionId={sessionId} agentSlug={agentSlug} />
+      <div className="flex flex-1 min-h-0 flex-col -mx-4">
+        <BrowserActivityLog sessionId={sessionId} agentSlug={agentSlug} />
+      </div>
+      </div>
 
       {/* Close confirmation dialog */}
       <AlertDialog open={stream.showCloseWarning} onOpenChange={stream.setShowCloseWarning}>

--- a/src/renderer/components/browser/browser-tray-content.tsx
+++ b/src/renderer/components/browser/browser-tray-content.tsx
@@ -1,11 +1,11 @@
 import { useState, useRef, useCallback } from 'react'
-import { Expand, MousePointerClick, PanelRight, Shrink, Square } from 'lucide-react'
+import { PanelRight } from 'lucide-react'
+import { BrowserViewport } from './browser-viewport'
 import { BrowserActivityLog } from './browser-activity-log'
 import { BrowserTabBar } from './browser-tab-bar'
 import { useBrowserStream } from '@renderer/hooks/use-browser-stream'
 import { Button } from '@renderer/components/ui/button'
 import { DeclineButton } from '@renderer/components/messages/decline-button'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
 import { linkify } from '@renderer/lib/linkify'
 import { useMessageStream } from '@renderer/hooks/use-message-stream'
 import { useBrowserInputActions } from '@renderer/hooks/use-browser-input-actions'
@@ -63,12 +63,18 @@ export function BrowserTrayContent({
   const [leadingTabFlush, setLeadingTabFlush] = useState(false)
   const onLeadingTabFlush = useCallback((flush: boolean) => setLeadingTabFlush(flush), [])
 
-  const latestRequest = stream.pendingBrowserInputRequests.length > 0
-    ? stream.pendingBrowserInputRequests[stream.pendingBrowserInputRequests.length - 1]
-    : null
+  const latestRequest =
+    stream.pendingBrowserInputRequests.length > 0
+      ? stream.pendingBrowserInputRequests[stream.pendingBrowserInputRequests.length - 1]
+      : null
 
   // Same decline/complete behavior as the in-chat request card, shared via the hook.
-  const { submittingAction, error: actionError, complete, decline } = useBrowserInputActions({
+  const {
+    submittingAction,
+    error: actionError,
+    complete,
+    decline,
+  } = useBrowserInputActions({
     agentSlug,
     sessionId,
     onResolved: (toolUseId) => stream.dismissBrowserInputRequest(toolUseId),
@@ -108,169 +114,85 @@ export function BrowserTrayContent({
 
       {/* Browser body, on the same gray as the tab rail: the page card inset 16px
           on every side, with the activity log sitting directly on the rail below it. */}
-      <div className="flex flex-1 min-h-0 flex-col bg-muted/60 px-4 pb-4">
       <div
-        className={cn(
-          'flex w-full shrink-0 flex-col overflow-hidden rounded-lg border border-black/5 bg-background shadow-[0_1px_3px_rgba(0,0,0,0.04),0_2px_8px_rgba(0,0,0,0.03)] dark:border-white/5 dark:shadow-[0_1px_3px_rgba(0,0,0,0.2),0_2px_8px_rgba(0,0,0,0.15)]',
-          // Square only where a tab actually meets the corner.
-          leadingTabFlush && 'rounded-tl-none',
-        )}
-        data-testid="browser-tray-card"
+        className="flex flex-1 min-h-0 flex-col overflow-y-auto bg-muted/60 px-4 pb-4"
+        data-testid="browser-tray-rail"
       >
-        {/* Title row: the viewed page and its state. */}
-        <div className="flex shrink-0 items-center gap-2 px-4 pt-4 pb-2" data-testid="browser-tray-title">
-          <div className="flex min-w-0 flex-1 items-baseline gap-2">
-            <h2 className="truncate text-sm font-medium text-foreground">{title}</h2>
-            {stream.needsAttention ? (
-              <span className="shrink-0 text-xs font-normal text-blue-600 dark:text-blue-400">Input needed</span>
-            ) : !stream.connected ? (
-              <span className="shrink-0 text-xs font-normal text-muted-foreground">Connecting…</span>
-            ) : host ? (
-              <span className="truncate text-xs font-normal text-muted-foreground" data-testid="browser-tray-host">{host}</span>
-            ) : null}
-          </div>
-        </div>
-
-        {/* Canvas viewport */}
         <div
           className={cn(
-            'relative shrink-0 overflow-hidden bg-background border-t border-border/40',
-            isActive && !stream.needsAttention && 'browser-glow-container',
+            'flex w-full shrink-0 flex-col rounded-lg border border-black/5 bg-background shadow-[0_1px_3px_rgba(0,0,0,0.04),0_2px_8px_rgba(0,0,0,0.03)] dark:border-white/5 dark:shadow-[0_1px_3px_rgba(0,0,0,0.2),0_2px_8px_rgba(0,0,0,0.15)]',
+            // Square only where a tab actually meets the corner.
+            leadingTabFlush && 'rounded-tl-none',
           )}
+          data-testid="browser-tray-card"
         >
-          <canvas
-            ref={canvasRef}
-            className={cn('block w-full', stream.isViewOnly ? 'cursor-not-allowed' : 'cursor-default')}
-            style={{ aspectRatio: stream.aspectRatio, willChange: 'transform' }}
-            tabIndex={stream.isViewOnly ? -1 : 0}
-            data-testid="browser-canvas"
-            onMouseDown={stream.isViewOnly ? undefined : stream.handleMouseDown}
-            onMouseUp={stream.isViewOnly ? undefined : stream.handleMouseUp}
-            onMouseMove={stream.isViewOnly ? undefined : stream.handleMouseMove}
-            onWheel={stream.isViewOnly ? undefined : stream.handleWheel}
-            onKeyDown={stream.isViewOnly ? undefined : stream.handleKeyDown}
-            onKeyUp={stream.isViewOnly ? undefined : stream.handleKeyUp}
-            onPaste={stream.isViewOnly ? undefined : stream.handlePaste}
-            onContextMenu={(e) => e.preventDefault()}
-          />
-          {!stream.connected && (
-            <div className="absolute inset-0 flex items-center justify-center bg-black/50">
-              <span className="text-white text-xs">Connecting to browser stream...</span>
+          {/* Title row: the viewed page and its state. */}
+          <div className="flex shrink-0 items-center gap-2 px-4 pt-4 pb-2" data-testid="browser-tray-title">
+            <div className="flex min-w-0 flex-1 items-baseline gap-2">
+              <h2 className="truncate text-sm font-medium text-foreground">{title}</h2>
+              {stream.needsAttention ? (
+                <span className="shrink-0 text-xs font-normal text-blue-600 dark:text-blue-400">Input needed</span>
+              ) : !stream.connected ? (
+                <span className="shrink-0 text-xs font-normal text-muted-foreground">Connecting…</span>
+              ) : host ? (
+                <span className="truncate text-xs font-normal text-muted-foreground" data-testid="browser-tray-host">
+                  {host}
+                </span>
+              ) : null}
             </div>
-          )}
-          {stream.showOverlay && (
-            <div
-              className="absolute inset-0 flex flex-col items-center justify-center bg-black/40 backdrop-blur-sm cursor-pointer z-10 transition-opacity duration-300"
-              role="button"
-              tabIndex={0}
-              onClick={stream.dismissOverlay}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault()
-                  stream.dismissOverlay()
-                }
-              }}
-            >
-              <span className="relative flex h-3 w-3 mb-2">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
-                <span className="relative inline-flex rounded-full h-3 w-3 bg-blue-500"></span>
-              </span>
-              <span className="text-white text-sm font-medium mb-3">Your input needed</span>
-              <MousePointerClick className="h-6 w-6 text-white animate-pulse" />
-              <span className="text-white/70 text-xs mt-1">Click to interact</span>
-            </div>
-          )}
-
-          {/* Controls pill, floating over the bottom of the page. translateZ(0)
-              forces it onto its own compositing layer so it paints above the
-              screencast <canvas> (which sets will-change: transform); without
-              it Safari/WebKit composites the canvas over the pill. */}
-          <div
-            className="absolute bottom-2 left-1/2 z-20"
-            style={{ transform: 'translateX(-50%) translateZ(0)' }}
-            data-testid="browser-tray-pill"
-          >
-            <TooltipProvider delayDuration={300}>
-            <div className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-background px-2 py-1 shadow-md">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={stream.handleCloseClick}
-                    aria-label="Stop browser agent"
-                    data-testid="browser-tray-stop"
-                    className="p-1.5 rounded-full text-red-500 transition-colors hover:bg-muted hover:text-red-600"
-                  >
-                    <Square className="h-3.5 w-3.5 fill-current" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top">Stop browser agent</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={onToggleExpand}
-                    aria-label={isExpanded ? 'Collapse' : 'Expand'}
-                    data-testid="browser-tray-expand"
-                    className="p-1.5 rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                  >
-                    {isExpanded ? <Shrink className="h-3.5 w-3.5" /> : <Expand className="h-3.5 w-3.5" />}
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="top">{isExpanded ? 'Collapse' : 'Expand'}</TooltipContent>
-              </Tooltip>
-            </div>
-            </TooltipProvider>
           </div>
+
+          <BrowserViewport
+            canvasRef={canvasRef}
+            stream={stream}
+            isActive={isActive}
+            isExpanded={isExpanded}
+            onToggleExpand={onToggleExpand}
+          />
+
+          {/* Action bar */}
+          {stream.needsAttention && latestRequest && (
+            <div className="shrink-0 px-4 py-3 border-t border-border/40">
+              <div className="rounded-lg border border-border/60 bg-muted/30 p-3 flex items-center gap-2">
+                <span className="text-xs font-medium text-foreground flex-1 truncate">
+                  {latestRequest.message ? linkify(latestRequest.message) : 'Your input needed'}
+                </span>
+                <DeclineButton
+                  onDecline={(reason) => decline(latestRequest.toolUseId, reason)}
+                  disabled={submittingAction !== null}
+                  label="Decline"
+                  showIcon={false}
+                  size="sm"
+                  // Chevron sits inside the grey action bar; clear the bar's bottom edge
+                  // (plus a small gap) rather than offsetting from the chevron.
+                  popoverSideOffset={18}
+                  className="h-7 text-xs border-border text-foreground hover:bg-muted"
+                  data-testid="browser-tray-decline-btn"
+                />
+                <Button
+                  onClick={() => complete(latestRequest.toolUseId)}
+                  loading={submittingAction === 'completing'}
+                  disabled={submittingAction !== null}
+                  size="sm"
+                  className="h-7 text-xs bg-blue-600 text-white hover:bg-blue-700"
+                >
+                  Done
+                </Button>
+              </div>
+              {actionError && <p className="mt-1 px-1 text-2xs text-destructive">{actionError}</p>}
+            </div>
+          )}
         </div>
 
-        {/* Action bar */}
-        {stream.needsAttention && latestRequest && (
-          <div className="shrink-0 px-4 py-3 border-t border-border/40">
-            <div className="rounded-lg border border-border/60 bg-muted/30 p-3 flex items-center gap-2">
-              <span className="text-xs font-medium text-foreground flex-1 truncate">
-                {latestRequest.message ? linkify(latestRequest.message) : 'Your input needed'}
-              </span>
-              <DeclineButton
-                onDecline={(reason) => decline(latestRequest.toolUseId, reason)}
-                disabled={submittingAction !== null}
-                label="Decline"
-                showIcon={false}
-                size="sm"
-                // Chevron sits inside the grey action bar; clear the bar's bottom edge
-                // (plus a small gap) rather than offsetting from the chevron.
-                popoverSideOffset={18}
-                className="h-7 text-xs border-border text-foreground hover:bg-muted"
-                data-testid="browser-tray-decline-btn"
-              />
-              <Button
-                onClick={() => complete(latestRequest.toolUseId)}
-                loading={submittingAction === 'completing'}
-                disabled={submittingAction !== null}
-                size="sm"
-                className="h-7 text-xs bg-blue-600 text-white hover:bg-blue-700"
-              >
-                Done
-              </Button>
-            </div>
-            {actionError && (
-              <p className="mt-1 px-1 text-2xs text-destructive">{actionError}</p>
-            )}
-          </div>
-        )}
-
-      </div>
-
-      {/* Activity log, on the rail rather than in the card. The log pads its own
+        {/* Activity log, on the rail rather than in the card. The log pads its own
           rows 16px, so it is pulled back out to the rail's edge to line up with
           the heading and the card. */}
-      <div className="flex items-center gap-1 py-1.5 border-b border-border/60 shrink-0 mt-4">
-        <span className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">Activity</span>
-      </div>
-      <div className="flex flex-1 min-h-0 flex-col -mx-4">
-        <BrowserActivityLog sessionId={sessionId} agentSlug={agentSlug} />
-      </div>
+        <div className="flex items-center gap-1 py-1.5 border-b border-border/60 shrink-0 mt-4">
+          <span className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">Activity</span>
+        </div>
+        <div className="flex flex-1 min-h-0 flex-col -mx-4">
+          <BrowserActivityLog sessionId={sessionId} agentSlug={agentSlug} />
+        </div>
       </div>
 
       {/* Close confirmation dialog */}

--- a/src/renderer/components/browser/browser-viewport.tsx
+++ b/src/renderer/components/browser/browser-viewport.tsx
@@ -1,0 +1,114 @@
+import type { RefObject } from 'react'
+import { Expand, MousePointerClick, Shrink, Square } from 'lucide-react'
+import type { useBrowserStream } from '@renderer/hooks/use-browser-stream'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
+import { cn } from '@shared/lib/utils/cn'
+
+interface BrowserViewportProps {
+  canvasRef: RefObject<HTMLCanvasElement>
+  stream: ReturnType<typeof useBrowserStream>
+  isActive: boolean
+  isExpanded: boolean
+  onToggleExpand?: () => void
+}
+
+/** Keep the controls sticky to the visible rail even when a tall page overflows it. */
+export function BrowserViewport({ canvasRef, stream, isActive, isExpanded, onToggleExpand }: BrowserViewportProps) {
+  return (
+    <div className="grid shrink-0">
+      {/* Canvas viewport */}
+      <div
+        className={cn(
+          'col-start-1 row-start-1 relative overflow-hidden bg-background border-t border-border/40',
+          isActive && !stream.needsAttention && 'browser-glow-container',
+          !(stream.needsAttention && stream.pendingBrowserInputRequests.length > 0) && 'rounded-b-lg',
+        )}
+      >
+        <canvas
+          ref={canvasRef}
+          className={cn('block w-full', stream.isViewOnly ? 'cursor-not-allowed' : 'cursor-default')}
+          style={{ aspectRatio: stream.aspectRatio, willChange: 'transform' }}
+          tabIndex={stream.isViewOnly ? -1 : 0}
+          data-testid="browser-canvas"
+          onMouseDown={stream.isViewOnly ? undefined : stream.handleMouseDown}
+          onMouseUp={stream.isViewOnly ? undefined : stream.handleMouseUp}
+          onMouseMove={stream.isViewOnly ? undefined : stream.handleMouseMove}
+          onWheel={stream.isViewOnly ? undefined : stream.handleWheel}
+          onKeyDown={stream.isViewOnly ? undefined : stream.handleKeyDown}
+          onKeyUp={stream.isViewOnly ? undefined : stream.handleKeyUp}
+          onPaste={stream.isViewOnly ? undefined : stream.handlePaste}
+          onContextMenu={(e) => e.preventDefault()}
+        />
+        {!stream.connected && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+            <span className="text-white text-xs">Connecting to browser stream...</span>
+          </div>
+        )}
+        {stream.showOverlay && (
+          <div
+            className="absolute inset-0 flex flex-col items-center justify-center bg-black/40 backdrop-blur-sm cursor-pointer z-10 transition-opacity duration-300"
+            role="button"
+            tabIndex={0}
+            onClick={stream.dismissOverlay}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                stream.dismissOverlay()
+              }
+            }}
+          >
+            <span className="relative flex h-3 w-3 mb-2">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
+              <span className="relative inline-flex rounded-full h-3 w-3 bg-blue-500"></span>
+            </span>
+            <span className="text-white text-sm font-medium mb-3">Your input needed</span>
+            <MousePointerClick className="h-6 w-6 text-white animate-pulse" />
+            <span className="text-white/70 text-xs mt-1">Click to interact</span>
+          </div>
+        )}
+      </div>
+      {/* Controls pill, floating over the bottom of the page. translateZ(0)
+              forces it onto its own compositing layer so it paints above the
+              screencast <canvas> (which sets will-change: transform); without
+              it Safari/WebKit composites the canvas over the pill. */}
+      <div
+        className="sticky bottom-2 z-20 col-start-1 row-start-1 mb-2 self-end flex justify-center pointer-events-none"
+        style={{ transform: 'translateZ(0)' }}
+        data-testid="browser-tray-pill"
+      >
+        <TooltipProvider delayDuration={300}>
+          <div className="inline-flex items-center gap-1 pointer-events-auto rounded-full border border-border/60 bg-background px-2 py-1 shadow-md">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={stream.handleCloseClick}
+                  aria-label="Stop browser agent"
+                  data-testid="browser-tray-stop"
+                  className="p-1.5 rounded-full text-red-500 transition-colors hover:bg-muted hover:text-red-600"
+                >
+                  <Square className="h-3.5 w-3.5 fill-current" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">Stop browser agent</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={onToggleExpand}
+                  aria-label={isExpanded ? 'Collapse' : 'Expand'}
+                  data-testid="browser-tray-expand"
+                  className="p-1.5 rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                >
+                  {isExpanded ? <Shrink className="h-3.5 w-3.5" /> : <Expand className="h-3.5 w-3.5" />}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">{isExpanded ? 'Collapse' : 'Expand'}</TooltipContent>
+            </Tooltip>
+          </div>
+        </TooltipProvider>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/file-preview/file-tab-bar.tsx
+++ b/src/renderer/components/file-preview/file-tab-bar.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
-import { ChevronLeft, ChevronRight, X } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { X } from 'lucide-react'
 import { FileTypeIcon } from '@renderer/components/ui/file-type-icon'
+import { DrawerTabStrip, drawerTabClassName } from '@renderer/components/tray/drawer-tab-strip'
 import { cn } from '@shared/lib/utils/cn'
 import { getPreviewTabKey, type PreviewTab } from '@renderer/context/file-preview-context'
 
@@ -19,208 +20,81 @@ interface FileTabBarProps {
   trailing?: ReactNode
 }
 
-const TAB_GAP_PX = 1
-/** Sub-pixel slack: a scroller's scrollLeft rarely lands exactly on its maximum. */
-const EDGE_EPSILON_PX = 1
-
-/**
- * Chrome-style tab strip.
- *
- * Tabs share one 160px basis and shrink in lockstep down to a floor — except
- * the active one, which keeps enough width to read its own name. Past the floor
- * they overflow and the strip shows a pair of arrows that scroll it one tab at
- * a time.
- *
- * The strip is a real horizontal scroller, so a trackpad swipe, a touch drag
- * and the browser's own focus-reveal all work without us reimplementing them.
- * The reason it originally wasn't one is that the active tab hangs 1px below
- * the track to cover the body card's top border, and a scroll container clips
- * that overhang: `pb-px -mb-px` buys the overhang a pixel of padding to live
- * in, which keeps it visible and keeps the vertical axis from overflowing.
- */
-export function FileTabBar({ tabs, activeIndex, onTabClick, onCloseTab, onLeadingTabFlush, trailing }: FileTabBarProps) {
-  const groupRef = useRef<HTMLDivElement>(null)
-  const trackRef = useRef<HTMLDivElement>(null)
-  const [scrollLeft, setScrollLeft] = useState(0)
-  const [maxScroll, setMaxScroll] = useState(0)
-
-  /** How far the strip can scroll: the content width beyond the visible group. */
-  const measure = useCallback(() => {
-    const group = groupRef.current
-    if (!group) return
-    setMaxScroll(Math.max(0, group.scrollWidth - group.clientWidth))
-    setScrollLeft(group.scrollLeft)
-  }, [])
-
-  // The active tab is wider than the rest, so selecting one changes the content
-  // width as well as adding or removing a tab does.
-  useLayoutEffect(() => {
-    measure()
-  }, [measure, tabs.length, activeIndex])
-
-  useEffect(() => {
-    const group = groupRef.current
-    if (!group || typeof ResizeObserver === 'undefined') return
-    const observer = new ResizeObserver(() => measure())
-    observer.observe(group)
-    return () => observer.disconnect()
-  }, [measure])
-
-  /** Scroll just far enough to bring a tab fully into the strip. */
-  const reveal = useCallback((index: number) => {
-    const group = groupRef.current
-    const track = trackRef.current
-    const tab = track?.children[index] as HTMLElement | undefined
-    if (!group || !track || !tab) return
-    // offsetLeft is measured against the positioned strip, not the scroll
-    // content; subtracting the track's own offset puts both on the same axis
-    // as scrollLeft.
-    const left = tab.offsetLeft - track.offsetLeft
-    const right = left + tab.offsetWidth
-    if (left < group.scrollLeft) {
-      group.scrollTo({ left, behavior: 'smooth' })
-    } else if (right > group.scrollLeft + group.clientWidth) {
-      group.scrollTo({ left: right - group.clientWidth, behavior: 'smooth' })
-    }
-  }, [])
-
-  useLayoutEffect(() => {
-    reveal(activeIndex)
-  }, [reveal, activeIndex, tabs.length])
-
-  const atStart = scrollLeft <= EDGE_EPSILON_PX
-  const atEnd = scrollLeft >= maxScroll - EDGE_EPSILON_PX
-  const overflowing = maxScroll > 0
-
-  useEffect(() => {
-    onLeadingTabFlush?.(activeIndex === 0 && atStart)
-  }, [onLeadingTabFlush, activeIndex, atStart])
-
-  /**
-   * One tab's worth of travel. The active tab is deliberately wider than its
-   * neighbours, so a step measured off it would overshoot; sample another.
-   */
-  const step = () => {
-    const children = Array.from(trackRef.current?.children ?? []) as HTMLElement[]
-    const sample = children.find((_, index) => index !== activeIndex) ?? children[0]
-    return (sample?.offsetWidth ?? 160) + TAB_GAP_PX
-  }
-  const slide = (direction: -1 | 1) => {
-    groupRef.current?.scrollBy({ left: direction * step(), behavior: 'smooth' })
-  }
-
+export function FileTabBar({
+  tabs,
+  activeIndex,
+  onTabClick,
+  onCloseTab,
+  onLeadingTabFlush,
+  trailing,
+}: FileTabBarProps) {
   if (tabs.length === 0) return null
-
   return (
-    <div
-      // pl-4 matches the body card's 16px inset, so the first tab's left edge
-      // is flush with the card's (the card's top-left corner is square for this).
-      className="relative flex items-end bg-muted/60 pl-4 pr-2 pt-1.5 shrink-0"
-      data-testid="file-tab-bar"
-      data-overflowing={overflowing || undefined}
+    <DrawerTabStrip
+      tabCount={tabs.length}
+      activeIndex={activeIndex}
+      onLeadingTabFlush={onLeadingTabFlush}
+      trailing={trailing}
+      testId="file-tab"
     >
-      {/* Bounded to the space left after the arrows and trailing control.
-          pb-px/-mb-px holds the active tab's 1px overhang without letting the
-          vertical axis overflow (see the component comment). */}
-      <div
-        ref={groupRef}
-        onScroll={(e) => setScrollLeft(e.currentTarget.scrollLeft)}
-        className="file-tab-scroller min-w-0 flex-1 -mb-px overflow-x-auto overflow-y-hidden pb-px"
-        data-testid="file-tab-group"
-      >
-        <div ref={trackRef} className="flex w-full items-end gap-px">
-          {tabs.map((tab, index) => (
-            // The tab is a shell, not a control: it holds two buttons, and a
-            // <button> may not contain another interactive element. The close
-            // control used to be a role="button" span nested inside the tab's
-            // own button, which is invalid content either way round and left
-            // its Enter handling hand-rolled. Two real buttons side by side get
-            // keyboard activation from the browser.
-            <div
-              key={getPreviewTabKey(tab)}
-              data-testid="file-tab"
-              data-tab-kind={tab.kind}
+      {(reveal) =>
+        tabs.map((tab, index) => (
+          // The tab is a shell, not a control: it holds two buttons, and a
+          // <button> may not contain another interactive element. The close
+          // control used to be a role="button" span nested inside the tab's
+          // own button, which is invalid content either way round and left
+          // its Enter handling hand-rolled. Two real buttons side by side get
+          // keyboard activation from the browser.
+          <div
+            key={getPreviewTabKey(tab)}
+            data-testid="file-tab"
+            data-tab-kind={tab.kind}
+            data-file-name={tab.displayName}
+            data-path={tab.kind === 'file' ? tab.filePath : tab.rootPath}
+            data-active={index === activeIndex || undefined}
+            className={drawerTabClassName(index, activeIndex)}
+          >
+            <button
+              type="button"
+              onClick={() => onTabClick(index)}
+              // A clipped tab is still in the tab order, and the strip cannot
+              // rely on the browser to reveal it during a smooth scroll of its
+              // own; bring it in explicitly.
+              onFocus={() => reveal(index)}
+              data-testid="file-tab-select"
+              className="flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left"
+            >
+              {/* Follow the tab's own color so the icon darkens with the label on the
+                    active tab and on hover, instead of the icon's muted default. */}
+              <FileTypeIcon
+                filename={tab.displayName}
+                size="sm"
+                folder={tab.kind === 'folder'}
+                className="text-inherit"
+              />
+              {/* Overflowing names fade out at the right edge instead of ellipsizing, as in Chrome. */}
+              <span className="min-w-0 flex-1 overflow-hidden whitespace-nowrap [mask-image:linear-gradient(to_right,black_calc(100%-16px),transparent)]">
+                {tab.displayName}
+              </span>
+            </button>
+            <button
+              type="button"
+              data-testid="file-tab-close"
               data-file-name={tab.displayName}
               data-path={tab.kind === 'file' ? tab.filePath : tab.rootPath}
-              data-active={index === activeIndex || undefined}
+              aria-label={`Close ${tab.displayName}`}
+              onClick={() => onCloseTab(getPreviewTabKey(tab))}
               className={cn(
-                // Uniform tabs, like Chrome: every tab starts from the same 160px basis
-                // and shrinks in lockstep, down to a floor that still fits icon + close.
-                'group relative flex h-8 flex-[0_1_160px] items-center rounded-t-lg pr-2 text-left text-xs transition-colors',
-                index === activeIndex
-                  // The one tab whose name the user needs to read is the one
-                  // they are looking at, so it holds a floor wide enough for a
-                  // label while the rest collapse to icon + close.
-                  ? 'z-10 min-w-[9.5rem] -mb-px border border-b-0 border-black/5 bg-background text-foreground shadow-[0_-1px_2px_rgba(0,0,0,0.04)] dark:border-white/5'
-                  : 'min-w-[4.25rem] text-foreground hover:bg-background/60',
-                // hairline separator on the left of inactive tabs that don't touch the active card
-                index > 0 && index !== activeIndex && index - 1 !== activeIndex &&
-                  'before:absolute before:left-0 before:top-2 before:bottom-2 before:w-px before:bg-border/60',
+                'shrink-0 rounded p-0.5 text-muted-foreground transition-opacity hover:bg-muted-foreground/20 hover:text-foreground group-hover:opacity-100 touch:opacity-100',
+                // the selected tab keeps its close visible; the rest reveal it on hover
+                index === activeIndex ? 'opacity-100' : 'opacity-0',
               )}
             >
-              <button
-                type="button"
-                onClick={() => onTabClick(index)}
-                // A clipped tab is still in the tab order, and the strip cannot
-                // rely on the browser to reveal it during a smooth scroll of its
-                // own; bring it in explicitly.
-                onFocus={() => reveal(index)}
-                data-testid="file-tab-select"
-                className="flex h-full min-w-0 flex-1 items-center gap-1.5 pl-3 pr-1 text-left"
-              >
-                {/* Follow the tab's own color so the icon darkens with the label on the
-                    active tab and on hover, instead of the icon's muted default. */}
-                <FileTypeIcon filename={tab.displayName} size="sm" folder={tab.kind === 'folder'} className="text-inherit" />
-                {/* Overflowing names fade out at the right edge instead of ellipsizing, as in Chrome. */}
-                <span className="min-w-0 flex-1 overflow-hidden whitespace-nowrap [mask-image:linear-gradient(to_right,black_calc(100%-16px),transparent)]">
-                  {tab.displayName}
-                </span>
-              </button>
-              <button
-                type="button"
-                data-testid="file-tab-close"
-                data-file-name={tab.displayName}
-                data-path={tab.kind === 'file' ? tab.filePath : tab.rootPath}
-                aria-label={`Close ${tab.displayName}`}
-                onClick={() => onCloseTab(getPreviewTabKey(tab))}
-                className={cn(
-                  'shrink-0 rounded p-0.5 text-muted-foreground transition-opacity hover:bg-muted-foreground/20 hover:text-foreground group-hover:opacity-100 touch:opacity-100',
-                  // the selected tab keeps its close visible; the rest reveal it on hover
-                  index === activeIndex ? 'opacity-100' : 'opacity-0',
-                )}
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {overflowing && (
-        <div className="flex h-8 shrink-0 items-center pl-1 text-muted-foreground" data-testid="file-tab-arrows">
-          <button
-            type="button"
-            onClick={() => slide(-1)}
-            disabled={atStart}
-            aria-label="Earlier tabs"
-            className="rounded p-0.5 transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
-          >
-            <ChevronLeft className="h-4 w-4" />
-          </button>
-          <button
-            type="button"
-            onClick={() => slide(1)}
-            disabled={atEnd}
-            aria-label="Later tabs"
-            className="rounded p-0.5 transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
-          >
-            <ChevronRight className="h-4 w-4" />
-          </button>
-        </div>
-      )}
-
-      {/* ml-auto pins it right; pr-1.5 + the strip's pr-2 + the button's p-0.5 puts the icon's edge at 16px, flush with the body card. */}
-      {trailing && <div className="ml-auto flex h-8 shrink-0 items-center pl-1 pr-1.5 text-muted-foreground">{trailing}</div>}
-    </div>
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        ))
+      }
+    </DrawerTabStrip>
   )
 }

--- a/src/renderer/components/tray/drawer-tab-strip.tsx
+++ b/src/renderer/components/tray/drawer-tab-strip.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { cn } from '@shared/lib/utils/cn'
+
+interface DrawerTabStripProps {
+  tabCount: number
+  activeIndex: number
+  onLeadingTabFlush?: (flush: boolean) => void
+  trailing?: ReactNode
+  testId: string
+  children: (reveal: (index: number) => void) => ReactNode
+}
+
+/** Shared scrolling, focus reveal, overflow controls, and card alignment for drawer tabs. */
+const TAB_GAP_PX = 1
+/** Sub-pixel slack: a scroller's scrollLeft rarely lands exactly on its maximum. */
+const EDGE_EPSILON_PX = 1
+
+export function DrawerTabStrip({
+  tabCount,
+  activeIndex,
+  onLeadingTabFlush,
+  trailing,
+  testId,
+  children,
+}: DrawerTabStripProps) {
+  const groupRef = useRef<HTMLDivElement>(null)
+  const trackRef = useRef<HTMLDivElement>(null)
+  const [scrollLeft, setScrollLeft] = useState(0)
+  const [maxScroll, setMaxScroll] = useState(0)
+
+  /** How far the strip can scroll: the content width beyond the visible group. */
+  const measure = useCallback(() => {
+    const group = groupRef.current
+    if (!group) return
+    setMaxScroll(Math.max(0, group.scrollWidth - group.clientWidth))
+    setScrollLeft(group.scrollLeft)
+  }, [])
+
+  // The active tab is wider than the rest, so selecting one changes the content
+  // width as well as adding or removing a tab does.
+  useLayoutEffect(() => {
+    measure()
+  }, [measure, tabCount, activeIndex])
+
+  useEffect(() => {
+    const group = groupRef.current
+    if (!group || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(() => measure())
+    observer.observe(group)
+    return () => observer.disconnect()
+  }, [measure])
+
+  /** Scroll just far enough to bring a tab fully into the strip. */
+  const reveal = useCallback((index: number) => {
+    const group = groupRef.current
+    const track = trackRef.current
+    const tab = track?.children[index] as HTMLElement | undefined
+    if (!group || !track || !tab) return
+    // offsetLeft is measured against the positioned strip, not the scroll
+    // content; subtracting the track's own offset puts both on the same axis
+    // as scrollLeft.
+    const left = tab.offsetLeft - track.offsetLeft
+    const right = left + tab.offsetWidth
+    if (left < group.scrollLeft) {
+      group.scrollTo({ left, behavior: 'smooth' })
+    } else if (right > group.scrollLeft + group.clientWidth) {
+      group.scrollTo({ left: right - group.clientWidth, behavior: 'smooth' })
+    }
+  }, [])
+
+  useLayoutEffect(() => {
+    reveal(activeIndex)
+  }, [reveal, activeIndex, tabCount])
+
+  const atStart = scrollLeft <= EDGE_EPSILON_PX
+  const atEnd = scrollLeft >= maxScroll - EDGE_EPSILON_PX
+  const overflowing = maxScroll > 0
+
+  useEffect(() => {
+    onLeadingTabFlush?.(activeIndex === 0 && atStart)
+  }, [onLeadingTabFlush, activeIndex, atStart])
+
+  /**
+   * One tab's worth of travel. The active tab is deliberately wider than its
+   * neighbours, so a step measured off it would overshoot; sample another.
+   */
+  const step = () => {
+    const children = Array.from(trackRef.current?.children ?? []) as HTMLElement[]
+    const sample = children.find((_, index) => index !== activeIndex) ?? children[0]
+    return (sample?.offsetWidth ?? 160) + TAB_GAP_PX
+  }
+  const slide = (direction: -1 | 1) => {
+    groupRef.current?.scrollBy({ left: direction * step(), behavior: 'smooth' })
+  }
+
+  return (
+    <div
+      // pl-4 matches the body card's 16px inset, so the first tab's left edge
+      // is flush with the card's (the card's top-left corner is square for this).
+      className="relative flex items-end bg-muted/60 pl-4 pr-2 pt-1.5 shrink-0"
+      data-testid={`${testId}-bar`}
+      data-overflowing={overflowing || undefined}
+    >
+      {/* Bounded to the space left after the arrows and trailing control.
+          pb-px/-mb-px holds the active tab's 1px overhang without letting the
+          vertical axis overflow. */}
+      <div
+        ref={groupRef}
+        onScroll={(e) => setScrollLeft(e.currentTarget.scrollLeft)}
+        className="file-tab-scroller min-w-0 flex-1 -mb-px overflow-x-auto overflow-y-hidden pb-px"
+        data-testid={`${testId}-group`}
+      >
+        <div ref={trackRef} className="flex w-full items-end gap-px">
+          {children(reveal)}
+        </div>
+      </div>
+
+      {overflowing && (
+        <div className="flex h-8 shrink-0 items-center pl-1 text-muted-foreground" data-testid={`${testId}-arrows`}>
+          <button
+            type="button"
+            onClick={() => slide(-1)}
+            disabled={atStart}
+            aria-label="Earlier tabs"
+            className="rounded p-0.5 transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => slide(1)}
+            disabled={atEnd}
+            aria-label="Later tabs"
+            className="rounded p-0.5 transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
+      {/* ml-auto pins it right; pr-1.5 + the strip's pr-2 + the button's p-0.5 puts the icon's edge at 16px, flush with the body card. */}
+      {trailing && (
+        <div className="ml-auto flex h-8 shrink-0 items-center gap-1 pl-1 pr-1.5 text-muted-foreground">{trailing}</div>
+      )}
+    </div>
+  )
+}
+
+/** Shared tab geometry; icons, menus, and close behavior belong to each caller. */
+export function drawerTabClassName(index: number, activeIndex: number) {
+  return cn(
+    'group relative flex h-8 flex-[0_1_160px] items-center rounded-t-lg pr-2 text-left text-xs transition-colors',
+    index === activeIndex
+      ? 'z-10 min-w-[9.5rem] -mb-px border border-b-0 border-black/5 bg-background text-foreground shadow-[0_-1px_2px_rgba(0,0,0,0.04)] dark:border-white/5'
+      : 'min-w-[4.25rem] text-foreground hover:bg-background/60',
+    index > 0 &&
+      index !== activeIndex &&
+      index - 1 !== activeIndex &&
+      'before:absolute before:left-0 before:top-2 before:bottom-2 before:w-px before:bg-border/60',
+  )
+}


### PR DESCRIPTION
Restyles the browser tray to match the file drawer, with tabs on a gray rail and the page inside a rounded card. Stacked on #997; followed by #999 → #1000 → #1001.

Browser and file tabs share `DrawerTabStrip` for sizing, scrolling, focus reveal, overflow arrows, and alignment with the card. Their adapters retain their own icons, menus, and close actions; the agent's active browser tab remains protected. Favicons fall back to a globe if unavailable.

`BrowserViewport` owns the canvas, input overlay, and controls. Stop and Expand stay sticky within the visible rail, outside the canvas's clipping layer. The rail can scroll when a portrait page exceeds the drawer height.

The design removes the former Pause/Resume controls. Stop interrupts the session and closes the browser; it remains distinct from pausing a session while leaving the browser open.

## Validation

- Renderer type check and changed-area lint pass.
- Existing browser and file tab tests pass, including overflow scrolling, keyboard focus, context menus, and protected tabs.
- Chromium E2E checks verify live screencast rendering and hit-test Stop/Expand on a tall page in a short drawer, without scrolling the controls into view.
- Light and dark screenshots below are from an isolated mock instance. Electron/live-container visual testing remains separate.

## Screenshots

| Light | Dark |
| --- | --- |
| ![Browser drawer (light)](https://github.com/user-attachments/assets/f1a13a2e-253c-4937-997c-3d0ee195ba95) | ![Browser drawer (dark)](https://github.com/user-attachments/assets/1094b040-9e18-47e6-b4e5-5dc1fff920c5) |
