### PR TITLE
feat(browser): back, forward, reload, and a read-only address bar

### DIFF
--- a/src/renderer/components/browser/browser-toolbar.test.tsx
+++ b/src/renderer/components/browser/browser-toolbar.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { BrowserToolbar } from './browser-toolbar'
+
+const props = {
+  url: 'https://example.test/current',
+  canGoBack: true,
+  canGoForward: true,
+  connected: true,
+  isViewOnly: false,
+  loading: false,
+  needsAttention: false,
+}
+
+describe('BrowserToolbar', () => {
+  it('sends the selected navigation command and displays the current URL', () => {
+    const onNavigate = vi.fn()
+    render(<BrowserToolbar {...props} onNavigate={onNavigate} />)
+    for (const label of ['Back', 'Forward', 'Reload']) fireEvent.click(screen.getByRole('button', { name: label }))
+    expect(onNavigate.mock.calls).toEqual([['back'], ['forward'], ['reload']])
+    expect(screen.getByTestId('browser-tray-url')).toHaveTextContent(props.url)
+  })
+
+  it.each([
+    { connected: false, isViewOnly: false },
+    { connected: true, isViewOnly: true },
+  ])('disables navigation when control is unavailable: %j', (state) => {
+    const onNavigate = vi.fn()
+    render(<BrowserToolbar {...props} {...state} onNavigate={onNavigate} />)
+    for (const label of ['Back', 'Forward', 'Reload']) {
+      const button = screen.getByRole('button', { name: label })
+      expect(button).toBeDisabled()
+      fireEvent.click(button)
+    }
+    expect(onNavigate).not.toHaveBeenCalled()
+  })
+
+  it('disables unavailable history directions while allowing reload', () => {
+    render(<BrowserToolbar {...props} canGoBack={false} canGoForward={false} onNavigate={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Back' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Forward' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeEnabled()
+  })
+})

--- a/src/renderer/components/browser/browser-toolbar.tsx
+++ b/src/renderer/components/browser/browser-toolbar.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from 'react'
+import { ArrowLeft, ArrowRight, Lock, RotateCw } from 'lucide-react'
+import type { BrowserNavigateAction } from '@shared/lib/browser-stream-protocol'
+import { cn } from '@shared/lib/utils/cn'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
+
+interface BrowserToolbarProps {
+  url: string
+  canGoBack: boolean
+  canGoForward: boolean
+  connected: boolean
+  isViewOnly: boolean
+  loading: boolean
+  needsAttention: boolean
+  onNavigate: (action: BrowserNavigateAction) => void
+}
+
+interface HeaderActionProps {
+  label: string
+  onClick?: () => void
+  disabled?: boolean
+  className?: string
+  children: ReactNode
+}
+
+/** An accessible toolbar button with a tooltip. */
+function HeaderAction({ label, onClick, disabled, className, children }: HeaderActionProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={onClick}
+          disabled={disabled}
+          aria-label={label}
+          className={cn(
+            'p-0.5 rounded hover:bg-muted transition-colors disabled:pointer-events-none disabled:opacity-30',
+            className,
+          )}
+        >
+          {children}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+export function BrowserToolbar({
+  url,
+  canGoBack,
+  canGoForward,
+  connected,
+  isViewOnly,
+  loading,
+  needsAttention,
+  onNavigate,
+}: BrowserToolbarProps) {
+  const canNavigate = connected && !isViewOnly
+  const isHttps = url.startsWith('https://')
+  return (
+    <div className="flex shrink-0 items-center gap-2 px-3 py-2" data-testid="browser-tray-toolbar">
+      <TooltipProvider delayDuration={300}>
+        <div className="flex shrink-0 items-center gap-0.5 text-muted-foreground">
+          <HeaderAction label="Back" onClick={() => onNavigate('back')} disabled={!canNavigate || !canGoBack}>
+            <ArrowLeft className="h-4 w-4" />
+          </HeaderAction>
+          <HeaderAction label="Forward" onClick={() => onNavigate('forward')} disabled={!canNavigate || !canGoForward}>
+            <ArrowRight className="h-4 w-4" />
+          </HeaderAction>
+          <HeaderAction label="Reload" onClick={() => onNavigate('reload')} disabled={!canNavigate}>
+            <RotateCw className={cn('h-4 w-4', loading && 'animate-spin')} />
+          </HeaderAction>
+        </div>
+        {/* Read-only: the page is the agent's to steer; this only says where it is. */}
+        <div
+          className="flex min-w-0 flex-1 items-center gap-1.5 rounded-full border border-black/5 bg-muted/60 px-3 py-1 dark:border-white/5"
+          title={url || undefined}
+          data-testid="browser-tray-url"
+        >
+          {isHttps && <Lock className="h-3 w-3 shrink-0 text-muted-foreground" />}
+          <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+            {url || (connected ? 'about:blank' : 'Connecting…')}
+          </span>
+          {needsAttention && <span className="shrink-0 text-xs text-blue-600 dark:text-blue-400">Input needed</span>}
+        </div>
+      </TooltipProvider>
+    </div>
+  )
+}

--- a/src/renderer/components/browser/browser-tray-content.tsx
+++ b/src/renderer/components/browser/browser-tray-content.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback } from 'react'
 import { PanelRight } from 'lucide-react'
 import { BrowserViewport } from './browser-viewport'
+import { BrowserToolbar } from './browser-toolbar'
 import { BrowserActivityLog } from './browser-activity-log'
 import { BrowserTabBar } from './browser-tab-bar'
 import { useBrowserStream } from '@renderer/hooks/use-browser-stream'
@@ -27,15 +28,6 @@ interface BrowserTrayContentProps {
   onClose: () => void
   isExpanded?: boolean
   onToggleExpand?: () => void
-}
-
-/** The host of a page URL, for the title row's secondary text; nothing for a URL that will not parse. */
-function hostOf(url: string): string | null {
-  try {
-    return new URL(url).host || null
-  } catch {
-    return null
-  }
 }
 
 export function BrowserTrayContent({
@@ -80,11 +72,9 @@ export function BrowserTrayContent({
     onResolved: (toolUseId) => stream.dismissBrowserInputRequest(toolUseId),
   })
 
-  // The card is headed by the page the user is looking at, the way the file
-  // card is headed by its filename. Before any tab exists it is just "Browser".
-  const viewingTab = stream.tabs.find((tab) => tab.targetId === stream.viewingTargetId) ?? null
-  const title = viewingTab?.title || 'Browser'
-  const host = viewingTab ? hostOf(viewingTab.url) : null
+  // History is authoritative once received; older containers only provide tab URLs.
+  const viewingTab = stream.tabs.find((tab) => tab.targetId === stream.viewingTargetId)
+  const pageUrl = stream.pageUrl || viewingTab?.url || ''
 
   return (
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden" data-testid="browser-drawer-panel">
@@ -126,21 +116,16 @@ export function BrowserTrayContent({
           )}
           data-testid="browser-tray-card"
         >
-          {/* Title row: the viewed page and its state. */}
-          <div className="flex shrink-0 items-center gap-2 px-4 pt-4 pb-2" data-testid="browser-tray-title">
-            <div className="flex min-w-0 flex-1 items-baseline gap-2">
-              <h2 className="truncate text-sm font-medium text-foreground">{title}</h2>
-              {stream.needsAttention ? (
-                <span className="shrink-0 text-xs font-normal text-blue-600 dark:text-blue-400">Input needed</span>
-              ) : !stream.connected ? (
-                <span className="shrink-0 text-xs font-normal text-muted-foreground">Connecting…</span>
-              ) : host ? (
-                <span className="truncate text-xs font-normal text-muted-foreground" data-testid="browser-tray-host">
-                  {host}
-                </span>
-              ) : null}
-            </div>
-          </div>
+          <BrowserToolbar
+            url={pageUrl}
+            canGoBack={stream.canGoBack}
+            canGoForward={stream.canGoForward}
+            connected={stream.connected}
+            isViewOnly={stream.isViewOnly}
+            loading={stream.pageLoading}
+            needsAttention={stream.needsAttention}
+            onNavigate={stream.navigate}
+          />
 
           <BrowserViewport
             canvasRef={canvasRef}


### PR DESCRIPTION
Adds Back, Forward, Reload, and a read-only address bar to the browser card. Stacked on #998; followed by #1000 → #1001.

The extracted `BrowserToolbar` displays the current history URL, falling back to the viewed tab's URL for older containers. Back/Forward reflect history availability, Reload shows loading state, and navigation controls are disabled for viewers and disconnected streams. The address includes the HTTPS indicator and pending-input status.

Navigation uses #997's typed protocol and requires its rebuilt container image. These controls navigate the viewed page during an agent session.

## Validation

- Renderer type check and changed-area lint pass.
- Toolbar tests cover all navigation commands, history bounds, disconnected state, and viewer restrictions.
- Browser, hook, and shared file-tab tests pass.
- Light and dark screenshots below are from an isolated mock instance.

## Screenshots

| Light | Dark |
| --- | --- |
| ![Browser toolbar (light)](https://github.com/user-attachments/assets/202d79f9-f08a-4cac-9f5f-1b082f3c2c5b) | ![Browser toolbar (dark)](https://github.com/user-attachments/assets/ff79229f-ab17-4f3c-a19c-7d18d5c341ae) |
