### PR TITLE
feat(browser): "Browser agent actions" heading with a Follow agent switch

### DIFF
--- a/src/renderer/components/browser/browser-tab-bar.test.tsx
+++ b/src/renderer/components/browser/browser-tab-bar.test.tsx
@@ -17,9 +17,7 @@ describe('BrowserTabBar', () => {
   const defaultProps = {
     tabs: makeTabs(3),
     viewingTargetId: 'target-0',
-    autoFollow: true,
     onTabClick: vi.fn(),
-    onToggleAutoFollow: vi.fn(),
   }
 
   it('renders all tabs', () => {
@@ -151,33 +149,5 @@ describe('BrowserTabBar', () => {
     fireEvent.error(screen.getByTestId('browser-tab-favicon'))
     expect(screen.queryByTestId('browser-tab-favicon')).toBeNull()
     expect(screen.getByTestId('browser-tab-globe')).toBeInTheDocument()
-  })
-  it('shows Eye icon and blue text when autoFollow is true', () => {
-    render(<BrowserTabBar {...defaultProps} autoFollow={true} />)
-    const toggleButton = screen.getByTitle('Auto-following agent (click to pin)')
-    expect(toggleButton.className).toContain('text-blue-500')
-  })
-
-  it('shows EyeOff icon when autoFollow is false', () => {
-    render(<BrowserTabBar {...defaultProps} autoFollow={false} />)
-    expect(screen.getByTitle('Not following agent (click to follow)')).toBeInTheDocument()
-  })
-
-  it('calls onToggleAutoFollow when toggle button is clicked', async () => {
-    const onToggleAutoFollow = vi.fn()
-    const user = userEvent.setup()
-    render(<BrowserTabBar {...defaultProps} onToggleAutoFollow={onToggleAutoFollow} />)
-    await user.click(screen.getByTitle('Auto-following agent (click to pin)'))
-    expect(onToggleAutoFollow).toHaveBeenCalledOnce()
-  })
-
-  it('shows loading spinner when loading is true', () => {
-    const { container } = render(<BrowserTabBar {...defaultProps} loading={true} />)
-    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
-  })
-
-  it('does not show loading spinner when loading is false', () => {
-    const { container } = render(<BrowserTabBar {...defaultProps} loading={false} />)
-    expect(container.querySelector('.animate-spin')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/browser/browser-tab-bar.tsx
+++ b/src/renderer/components/browser/browser-tab-bar.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import { useState } from 'react'
 import { DrawerTabStrip, drawerTabClassName } from '@renderer/components/tray/drawer-tab-strip'
-import { Eye, EyeOff, Globe, Loader2, X } from 'lucide-react'
+import { Globe, X } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
 import {
   ContextMenu,
@@ -38,11 +38,8 @@ function TabIcon({ faviconUrl, title }: { faviconUrl?: string; title: string }) 
 interface BrowserTabBarProps {
   tabs: BrowserTabInfo[]
   viewingTargetId: string | null
-  autoFollow: boolean
-  loading?: boolean
   onTabClick: (targetId: string) => void
   onCloseTab?: (targetId: string) => void
-  onToggleAutoFollow: () => void
   /**
    * Whether the viewed tab's left edge is flush with the strip's left inset —
    * true only for the first tab, unscrolled. The body card squares off its
@@ -57,24 +54,12 @@ function tabLabel(tab: BrowserTabInfo): string {
   return tab.title || tab.url || `Tab ${tab.index + 1}`
 }
 
-/**
- * The browser drawer's tab strip, in the same Chrome-style dress as the file
- * drawer's (`file-tab-bar.tsx`): tabs on a gray rail, the viewed tab raised as
- * a card whose open bottom hides the body's top border, labels that fade out
- * instead of ellipsizing.
- *
- * Unlike the file strip it always renders, even with no tabs: the drawer's own
- * controls (auto-follow, hide panel) live at its right end, and a browser that
- * is still connecting has a drawer to hide before it has a page to show.
- */
+/** The hide control remains available while the browser connects, before tabs arrive. */
 export function BrowserTabBar({
   tabs,
   viewingTargetId,
-  autoFollow,
-  loading,
   onTabClick,
   onCloseTab,
-  onToggleAutoFollow,
   onLeadingTabFlush,
   trailing,
 }: BrowserTabBarProps) {
@@ -85,24 +70,7 @@ export function BrowserTabBar({
       activeIndex={viewingIndex}
       onLeadingTabFlush={onLeadingTabFlush}
       testId="browser-tab"
-      trailing={
-        <>
-          {loading && <Loader2 className="h-3 w-3 animate-spin shrink-0" />}
-          <button
-            type="button"
-            className={cn(
-              'p-0.5 rounded transition-colors shrink-0',
-              autoFollow ? 'text-blue-500 hover:text-blue-600' : 'text-muted-foreground hover:text-foreground',
-            )}
-            onClick={onToggleAutoFollow}
-            title={autoFollow ? 'Auto-following agent (click to pin)' : 'Not following agent (click to follow)'}
-            aria-label={autoFollow ? 'Auto-following agent (click to pin)' : 'Not following agent (click to follow)'}
-          >
-            {autoFollow ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
-          </button>
-          {trailing}
-        </>
-      }
+      trailing={trailing}
     >
       {(reveal) =>
         tabs.map((tab, index) => {

--- a/src/renderer/components/browser/browser-tray-content.tsx
+++ b/src/renderer/components/browser/browser-tray-content.tsx
@@ -4,6 +4,7 @@ import { BrowserViewport } from './browser-viewport'
 import { BrowserToolbar } from './browser-toolbar'
 import { BrowserActivityLog } from './browser-activity-log'
 import { BrowserTabBar } from './browser-tab-bar'
+import { FollowAgentToggle } from './follow-agent-toggle'
 import { useBrowserStream } from '@renderer/hooks/use-browser-stream'
 import { Button } from '@renderer/components/ui/button'
 import { DeclineButton } from '@renderer/components/messages/decline-button'
@@ -82,11 +83,8 @@ export function BrowserTrayContent({
       <BrowserTabBar
         tabs={stream.tabs}
         viewingTargetId={stream.viewingTargetId}
-        autoFollow={stream.autoFollow}
-        loading={stream.pageLoading}
         onTabClick={stream.handleTabClick}
         onCloseTab={stream.handleCloseTab}
-        onToggleAutoFollow={stream.toggleAutoFollow}
         onLeadingTabFlush={onLeadingTabFlush}
         trailing={
           // The drawer's own control, at the strip's right end like the file drawer's.
@@ -172,8 +170,10 @@ export function BrowserTrayContent({
         {/* Activity log, on the rail rather than in the card. The log pads its own
           rows 16px, so it is pulled back out to the rail's edge to line up with
           the heading and the card. */}
-        <div className="flex items-center gap-1 py-1.5 border-b border-border/60 shrink-0 mt-4">
-          <span className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">Activity</span>
+        <div className="flex items-center py-1 border-b border-border/60 shrink-0 mt-4">
+          <span className="flex-1 text-xs font-medium text-muted-foreground">Browser agent actions</span>
+          {/* Follow changes the viewed browser tab when the agent switches pages. */}
+          <FollowAgentToggle autoFollow={stream.autoFollow} onToggle={stream.toggleAutoFollow} className="-mr-1" />
         </div>
         <div className="flex flex-1 min-h-0 flex-col -mx-4">
           <BrowserActivityLog sessionId={sessionId} agentSlug={agentSlug} />

--- a/src/renderer/components/browser/follow-agent-toggle.test.tsx
+++ b/src/renderer/components/browser/follow-agent-toggle.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FollowAgentToggle } from './follow-agent-toggle'
+
+describe('FollowAgentToggle', () => {
+  it('is a checked switch while following', () => {
+    render(<FollowAgentToggle autoFollow={true} onToggle={vi.fn()} />)
+    const toggle = screen.getByRole('switch', { name: 'Auto-following agent (click to pin)' })
+    expect(toggle).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('is an unchecked switch while pinned to a tab', () => {
+    render(<FollowAgentToggle autoFollow={false} onToggle={vi.fn()} />)
+    const toggle = screen.getByRole('switch', { name: 'Not following agent (click to follow)' })
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('toggles from the switch and from its label', async () => {
+    const onToggle = vi.fn()
+    const user = userEvent.setup()
+    render(<FollowAgentToggle autoFollow={true} onToggle={onToggle} />)
+    await user.click(screen.getByRole('switch'))
+    await user.click(screen.getByText('Follow agent'))
+    expect(onToggle).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/components/browser/follow-agent-toggle.tsx
+++ b/src/renderer/components/browser/follow-agent-toggle.tsx
@@ -1,0 +1,36 @@
+import { useId } from 'react'
+import { Switch } from '@renderer/components/ui/switch'
+import { cn } from '@shared/lib/utils/cn'
+
+interface FollowAgentToggleProps {
+  autoFollow: boolean
+  onToggle: () => void
+  className?: string
+}
+
+/**
+ * Whether the viewer tracks the agent's active tab. On, the screencast jumps
+ * with the agent; off, the viewer stays pinned to the tab they picked. A
+ * labelled switch, like the Compact View toggle in the home card menu, on the
+ * Activity row with the other session controls.
+ */
+export function FollowAgentToggle({ autoFollow, onToggle, className }: FollowAgentToggleProps) {
+  const id = useId()
+  const title = autoFollow ? 'Auto-following agent (click to pin)' : 'Not following agent (click to follow)'
+  return (
+    <div className={cn('inline-flex h-6 items-center gap-1.5 pl-1.5 pr-1', className)} title={title}>
+      <label htmlFor={id} className="cursor-pointer select-none text-xs text-muted-foreground">
+        Follow agent
+      </label>
+      <Switch
+        id={id}
+        checked={autoFollow}
+        onCheckedChange={onToggle}
+        aria-label={title}
+        data-testid="follow-agent-toggle"
+        // Compact for the row: a 16px track with the thumb scaled to fit.
+        className="h-4 w-7 [&>span]:h-3 [&>span]:w-3 [&>span]:data-[state=checked]:translate-x-3"
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
Moves Follow agent into the “Browser agent actions” heading. Stacked on #999; followed by #1001.

The labelled switch controls whether the browser view follows the agent's active tab. It uses the existing follow command. The shared tab strip now reserves its trailing area for Hide, and the toolbar's Reload button retains the loading indicator.

## Validation

- Renderer type check and changed-area lint pass.
- Follow-switch tests cover checked state and activation through both the switch and its label.
- Browser, hook, and shared file-tab tests pass.
- Light and dark screenshots below are from an isolated mock instance.

## Screenshots

| Light | Dark |
| --- | --- |
| ![Follow control (light)](https://github.com/user-attachments/assets/854814f3-63e3-4503-a9c6-ffe2570158c9) | ![Follow control (dark)](https://github.com/user-attachments/assets/90ef751e-aea8-4528-9264-91ad53c54f55) |
