### PR TITLE
feat(browser): full screen for the browser tray

### DIFF
--- a/e2e/specs/browser-stream.spec.ts
+++ b/e2e/specs/browser-stream.spec.ts
@@ -9,8 +9,11 @@ test.describe('Browser Streaming', () => {
   let agentPage: AgentPage
   let sessionPage: SessionPage
   let testAgentName: string
+  let pageErrors: string[]
 
   test.beforeEach(async ({ page }, testInfo) => {
+    pageErrors = []
+    page.on('pageerror', (error) => pageErrors.push(error.message))
     appPage = new AppPage(page)
     agentPage = new AgentPage(page)
     sessionPage = new SessionPage(page)
@@ -22,15 +25,11 @@ test.describe('Browser Streaming', () => {
     await agentPage.createAgent(testAgentName)
   })
 
+  test.afterEach(() => {
+    expect(pageErrors).toEqual([])
+  })
+
   test('browser preview shows live screencast from host browser', async ({ page }) => {
-    // Skip if E2E_CHROMIUM_PATH is not set (no browser available)
-    // The dev server logs this, but we can also check by sending the message
-    // and seeing if the scenario falls back to the default text response.
-
-    // Capture page errors for debugging
-    const pageErrors: string[] = []
-    page.on('pageerror', (err) => pageErrors.push(err.message))
-
     // Send "browse" message to trigger BrowserScenario.
     // Uses a data: URL so the test doesn't depend on network access.
     await sessionPage.sendMessage(
@@ -61,9 +60,6 @@ test.describe('Browser Streaming', () => {
       },
       { timeout: 20000 },
     )
-
-    // Verify no page errors occurred during the flow
-    expect(pageErrors).toEqual([])
   })
 
   test('keeps the browser controls reachable for a tall page in a short drawer', async ({ page }) => {
@@ -74,10 +70,75 @@ test.describe('Browser Streaming', () => {
 
     const rail = page.getByTestId('browser-tray-rail')
     await expect.poll(() => rail.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(true)
-    for (const testId of ['browser-tray-stop', 'browser-tray-expand']) {
+    for (const testId of ['browser-tray-stop', 'browser-tray-fullscreen']) {
       await expect.poll(() => isControlReachable(page.getByTestId(testId))).toBe(true)
     }
     await page.getByTestId('browser-tray-stop').click()
     await expect(page.getByRole('alertdialog')).toBeVisible()
+  })
+
+  test('fits a portrait page and its controls in full screen as the window shrinks', async ({ page }) => {
+    await page.setViewportSize({ width: 1200, height: 600 })
+    await mockBrowserStream(page, 600, 800)
+    await sessionPage.sendMessage('browse data:text/html,<h1>Portrait page</h1>')
+    await expect(page.getByTestId('browser-canvas')).toHaveAttribute('height', '800')
+    await page.getByTestId('browser-tray-fullscreen').click()
+    await expect(page.getByTestId('tray-drawer')).toHaveAttribute('data-fullscreen')
+    await expect(page.getByTestId('browser-activity-region')).toBeHidden()
+
+    for (const height of [600, 360]) {
+      await page.setViewportSize({ width: 1200, height })
+      await expect
+        .poll(() =>
+          page.getByTestId('browser-tray-card').evaluate((card) => {
+            const rail = card.parentElement!.getBoundingClientRect()
+            const rect = card.getBoundingClientRect()
+            return rect.top >= rail.top && rect.bottom <= rail.bottom && rect.width > 100
+          }),
+        )
+        .toBe(true)
+      for (const testId of ['browser-tray-stop', 'browser-tray-fullscreen']) {
+        await expect.poll(() => isControlReachable(page.getByTestId(testId))).toBe(true)
+      }
+    }
+    await page.getByTestId('browser-tray-fullscreen').click()
+    await expect(page.getByTestId('tray-drawer')).not.toHaveAttribute('data-fullscreen')
+    await expect(page.getByTestId('browser-activity-region')).toBeVisible()
+  })
+
+  test('gives Escape to the focused remote page or local dialog before full screen', async ({ page }) => {
+    const stream = await mockBrowserStream(page, 800, 450)
+    await sessionPage.sendMessage('browse data:text/html,<h1>Keyboard ownership</h1>')
+    await expect(page.getByTestId('browser-canvas')).toHaveAttribute('width', '800')
+    await page.getByTestId('browser-tray-fullscreen').click()
+    await expect(page.getByTestId('tray-drawer')).toHaveAttribute('data-fullscreen')
+    const remoteEscapes = () =>
+      stream.messages
+        .map((message) => {
+          try {
+            return JSON.parse(message)
+          } catch {
+            throw new Error('Expected valid JSON from the browser stream')
+          }
+        })
+        .filter((message) => message.type === 'input_press' && message.key === 'Escape')
+
+    await page.getByTestId('browser-canvas').focus()
+    await page.keyboard.press('Escape')
+    await expect.poll(() => remoteEscapes().length).toBe(1)
+    await expect(page.getByTestId('tray-drawer')).toHaveAttribute('data-fullscreen')
+
+    await page.getByTestId('browser-tray-stop').click()
+    await expect(page.getByRole('alertdialog')).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('alertdialog')).toBeHidden()
+    await expect(page.getByTestId('tray-drawer')).toHaveAttribute('data-fullscreen')
+
+    // Move out of controls whose focus opens a tooltip (another Escape owner).
+    await page.getByTestId('browser-tray-url').click()
+    await expect(page.getByRole('tooltip')).toBeHidden()
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('tray-drawer')).not.toHaveAttribute('data-fullscreen')
+    expect(remoteEscapes()).toHaveLength(1)
   })
 })

--- a/src/renderer/components/browser/browser-tray-content.links.test.tsx
+++ b/src/renderer/components/browser/browser-tray-content.links.test.tsx
@@ -9,7 +9,7 @@ const CLAY_URL = 'https://app.clay.com/oauth/device?user_code=LCWW-PKKC'
 // does, but reaches it through the browser stream rather than RequestItemShell.
 // The shell's linkify call cannot cover it, so this pins its own call site.
 const stream = {
-  aspectRatio: 16 / 9,
+  aspectRatio: '16 / 9',
   tabs: [],
   viewingTargetId: null,
   autoFollow: true,

--- a/src/renderer/components/browser/browser-tray-content.tsx
+++ b/src/renderer/components/browser/browser-tray-content.tsx
@@ -6,6 +6,7 @@ import { BrowserActivityLog } from './browser-activity-log'
 import { BrowserTabBar } from './browser-tab-bar'
 import { FollowAgentToggle } from './follow-agent-toggle'
 import { useBrowserStream } from '@renderer/hooks/use-browser-stream'
+import { useBrowserCardSize } from '@renderer/hooks/use-browser-card-size'
 import { Button } from '@renderer/components/ui/button'
 import { DeclineButton } from '@renderer/components/messages/decline-button'
 import { linkify } from '@renderer/lib/linkify'
@@ -56,6 +57,11 @@ export function BrowserTrayContent({
   const [leadingTabFlush, setLeadingTabFlush] = useState(false)
   const onLeadingTabFlush = useCallback((flush: boolean) => setLeadingTabFlush(flush), [])
 
+  const { railRef, cardRef, viewportRef, maxCardWidth, maxStripWidth } = useBrowserCardSize(
+    isExpanded,
+    stream.aspectRatio,
+  )
+
   const latestRequest =
     stream.pendingBrowserInputRequests.length > 0
       ? stream.pendingBrowserInputRequests[stream.pendingBrowserInputRequests.length - 1]
@@ -80,30 +86,35 @@ export function BrowserTrayContent({
   return (
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden" data-testid="browser-drawer-panel">
       {/* Page tabs, with the drawer's own hide control at the strip's right end. */}
-      <BrowserTabBar
-        tabs={stream.tabs}
-        viewingTargetId={stream.viewingTargetId}
-        onTabClick={stream.handleTabClick}
-        onCloseTab={stream.handleCloseTab}
-        onLeadingTabFlush={onLeadingTabFlush}
-        trailing={
-          // The drawer's own control, at the strip's right end like the file drawer's.
-          <button
-            type="button"
-            className="inline-flex p-0.5 rounded hover:bg-muted transition-colors"
-            onClick={onClose}
-            title="Hide browser panel"
-            aria-label="Hide browser panel"
-          >
-            <PanelRight className="h-4 w-4" />
-          </button>
-        }
-      />
+      <div className="shrink-0 bg-muted/60">
+        <div className={cn(isExpanded && 'mx-auto')} style={isExpanded ? { maxWidth: maxStripWidth } : undefined}>
+          <BrowserTabBar
+            tabs={stream.tabs}
+            viewingTargetId={stream.viewingTargetId}
+            onTabClick={stream.handleTabClick}
+            onCloseTab={stream.handleCloseTab}
+            onLeadingTabFlush={onLeadingTabFlush}
+            trailing={
+              // The drawer's own control, at the strip's right end like the file drawer's.
+              <button
+                type="button"
+                className="inline-flex p-0.5 rounded hover:bg-muted transition-colors"
+                onClick={onClose}
+                title="Hide browser panel"
+                aria-label="Hide browser panel"
+              >
+                <PanelRight className="h-4 w-4" />
+              </button>
+            }
+          />
+        </div>
+      </div>
 
       {/* Browser body, on the same gray as the tab rail: the page card inset 16px
           on every side, with the activity log sitting directly on the rail below it. */}
       <div
         className="flex flex-1 min-h-0 flex-col overflow-y-auto bg-muted/60 px-4 pb-4"
+        ref={railRef}
         data-testid="browser-tray-rail"
       >
         <div
@@ -111,7 +122,10 @@ export function BrowserTrayContent({
             'flex w-full shrink-0 flex-col rounded-lg border border-black/5 bg-background shadow-[0_1px_3px_rgba(0,0,0,0.04),0_2px_8px_rgba(0,0,0,0.03)] dark:border-white/5 dark:shadow-[0_1px_3px_rgba(0,0,0,0.2),0_2px_8px_rgba(0,0,0,0.15)]',
             // Square only where a tab actually meets the corner.
             leadingTabFlush && 'rounded-tl-none',
+            isExpanded && 'self-center',
           )}
+          ref={cardRef}
+          style={isExpanded ? { maxWidth: maxCardWidth } : undefined}
           data-testid="browser-tray-card"
         >
           <BrowserToolbar
@@ -126,6 +140,7 @@ export function BrowserTrayContent({
           />
 
           <BrowserViewport
+            viewportRef={viewportRef}
             canvasRef={canvasRef}
             stream={stream}
             isActive={isActive}
@@ -167,16 +182,22 @@ export function BrowserTrayContent({
           )}
         </div>
 
-        {/* Activity log, on the rail rather than in the card. The log pads its own
+        {/* Preserve subscriptions, expanded rows, and scroll position across full screen. */}
+        <div
+          className={cn('flex flex-1 min-h-32 flex-col', isExpanded && 'hidden')}
+          data-testid="browser-activity-region"
+        >
+          {/* Activity log, on the rail rather than in the card. The log pads its own
           rows 16px, so it is pulled back out to the rail's edge to line up with
           the heading and the card. */}
-        <div className="flex items-center py-1 border-b border-border/60 shrink-0 mt-4">
-          <span className="flex-1 text-xs font-medium text-muted-foreground">Browser agent actions</span>
-          {/* Follow changes the viewed browser tab when the agent switches pages. */}
-          <FollowAgentToggle autoFollow={stream.autoFollow} onToggle={stream.toggleAutoFollow} className="-mr-1" />
-        </div>
-        <div className="flex flex-1 min-h-0 flex-col -mx-4">
-          <BrowserActivityLog sessionId={sessionId} agentSlug={agentSlug} />
+          <div className="flex items-center py-1 border-b border-border/60 shrink-0 mt-4">
+            <span className="flex-1 text-xs font-medium text-muted-foreground">Browser agent actions</span>
+            {/* Follow changes the viewed browser tab when the agent switches pages. */}
+            <FollowAgentToggle autoFollow={stream.autoFollow} onToggle={stream.toggleAutoFollow} className="-mr-1" />
+          </div>
+          <div className="flex flex-1 min-h-0 flex-col -mx-4">
+            <BrowserActivityLog sessionId={sessionId} agentSlug={agentSlug} />
+          </div>
         </div>
       </div>
 

--- a/src/renderer/components/browser/browser-viewport.tsx
+++ b/src/renderer/components/browser/browser-viewport.tsx
@@ -6,6 +6,7 @@ import { cn } from '@shared/lib/utils/cn'
 
 interface BrowserViewportProps {
   canvasRef: RefObject<HTMLCanvasElement>
+  viewportRef?: RefObject<HTMLDivElement>
   stream: ReturnType<typeof useBrowserStream>
   isActive: boolean
   isExpanded: boolean
@@ -13,9 +14,16 @@ interface BrowserViewportProps {
 }
 
 /** Keep the controls sticky to the visible rail even when a tall page overflows it. */
-export function BrowserViewport({ canvasRef, stream, isActive, isExpanded, onToggleExpand }: BrowserViewportProps) {
+export function BrowserViewport({
+  canvasRef,
+  viewportRef,
+  stream,
+  isActive,
+  isExpanded,
+  onToggleExpand,
+}: BrowserViewportProps) {
   return (
-    <div className="grid shrink-0">
+    <div ref={viewportRef} className="grid shrink-0">
       {/* Canvas viewport */}
       <div
         className={cn(
@@ -97,14 +105,14 @@ export function BrowserViewport({ canvasRef, stream, isActive, isExpanded, onTog
                 <button
                   type="button"
                   onClick={onToggleExpand}
-                  aria-label={isExpanded ? 'Collapse' : 'Expand'}
-                  data-testid="browser-tray-expand"
+                  aria-label={isExpanded ? 'Exit full screen' : 'Full screen'}
+                  data-testid="browser-tray-fullscreen"
                   className="p-1.5 rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                   {isExpanded ? <Shrink className="h-3.5 w-3.5" /> : <Expand className="h-3.5 w-3.5" />}
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="top">{isExpanded ? 'Collapse' : 'Expand'}</TooltipContent>
+              <TooltipContent side="top">{isExpanded ? 'Exit full screen' : 'Full screen'}</TooltipContent>
             </Tooltip>
           </div>
         </TooltipProvider>

--- a/src/renderer/components/tray/drawer-shell.tsx
+++ b/src/renderer/components/tray/drawer-shell.tsx
@@ -17,6 +17,8 @@ interface DrawerShellProps {
   responsiveFullWidth?: boolean
   /** Overlay the parent instead of participating in its wide-screen flex layout. */
   wideOverlay?: boolean
+  /** Cover the whole tray host, edge to edge, ignoring the persisted width. */
+  fullScreen?: boolean
   defaultWidth?: number
   minWidth?: number
   maxWidth?: number
@@ -30,6 +32,7 @@ export const DrawerShell = forwardRef<DrawerShellHandle, DrawerShellProps>(funct
   storageKey,
   responsiveFullWidth = false,
   wideOverlay = false,
+  fullScreen = false,
   defaultWidth = DEFAULT_WIDTH,
   minWidth = MIN_WIDTH,
   maxWidth = MAX_WIDTH,
@@ -94,18 +97,20 @@ export const DrawerShell = forwardRef<DrawerShellHandle, DrawerShellProps>(funct
         responsiveFullWidth && 'file-preview-responsive-overlay',
         responsiveFullWidth && !isOpen && 'file-preview-responsive-overlay-closed',
         wideOverlay && 'file-preview-wide-overlay',
+        fullScreen && 'tray-drawer-fullscreen',
         !isResizing && 'transition-[width] duration-300 ease-in-out',
         className
       )}
       style={{ width: isOpen ? drawerWidth : 0, maxWidth: '100%', contain: 'layout paint', willChange: 'transform' }}
       onTransitionEnd={onTransitionEnd}
       data-testid="tray-drawer"
+      data-fullscreen={fullScreen || undefined}
     >
       {/* Resize handle on left edge */}
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
       <div
         className={cn(
-          'absolute inset-y-0 left-0 z-20 w-1 cursor-col-resize hover:bg-border transition-colors',
+          'tray-drawer-resize-handle absolute inset-y-0 left-0 z-20 w-1 cursor-col-resize hover:bg-border transition-colors',
           responsiveFullWidth && 'file-preview-responsive-resize-handle',
         )}
         onMouseDown={handleResizeMouseDown}

--- a/src/renderer/components/tray/tray-manager.fullscreen.test.tsx
+++ b/src/renderer/components/tray/tray-manager.fullscreen.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// The tray manager owns full screen; the browser tray only asks for it.
+// Stand in for the content with the two controls the flow needs.
+vi.mock('@renderer/components/browser/browser-tray-content', () => ({
+  BrowserTrayContent: ({
+    onClose,
+    onToggleExpand,
+    isExpanded,
+  }: {
+    onClose: () => void
+    onToggleExpand: () => void
+    isExpanded: boolean
+  }) => (
+    <div data-testid="browser-drawer-panel">
+      <button onClick={onToggleExpand}>{isExpanded ? 'Exit full screen' : 'Full screen'}</button>
+      <button onClick={onClose}>Hide browser panel</button>
+    </div>
+  ),
+}))
+vi.mock('@renderer/components/file-preview/file-preview-tray-content', () => ({ FilePreviewTrayContent: () => null }))
+vi.mock('@renderer/components/workflow/workflow-tray-content', () => ({ WorkflowTrayContent: () => null }))
+vi.mock('@renderer/context/file-preview-context', () => ({
+  useFilePreview: () => ({ openTabs: [], isOpen: false, close: vi.fn() }),
+}))
+vi.mock('@renderer/context/workflow-context', () => ({
+  useWorkflow: () => ({ openWorkflows: [], isOpen: false, close: vi.fn(), selectedRunId: null }),
+}))
+
+const sidebar = {
+  open: true,
+  setOpen: vi.fn((open: boolean) => {
+    sidebar.open = open
+  }),
+}
+vi.mock('@renderer/components/ui/sidebar', () => ({
+  useSidebar: () => sidebar,
+}))
+
+import { TrayManager } from './tray-manager'
+
+function drawer() {
+  return screen.getByTestId('tray-drawer')
+}
+
+async function flushFrames() {
+  await act(async () => {
+    await new Promise((r) => requestAnimationFrame(() => r(null)))
+    await new Promise((r) => requestAnimationFrame(() => r(null)))
+  })
+}
+
+describe('TrayManager full screen', () => {
+  beforeEach(() => {
+    sidebar.open = true
+    sidebar.setOpen.mockClear()
+    localStorage.clear()
+  })
+
+  it('leaves full screen and restores the sidebar when the panel is hidden, and reopens at normal size', async () => {
+    const user = userEvent.setup()
+    render(<TrayManager agentSlug="a" sessionId="s" browserActive={true} />)
+    await flushFrames()
+
+    await user.click(screen.getByText('Full screen'))
+    expect(drawer()).toHaveAttribute('data-fullscreen')
+    expect(sidebar.setOpen).toHaveBeenLastCalledWith(false)
+
+    // Hide the drawer while in full screen: the sidebar must come back.
+    await user.click(screen.getByText('Hide browser panel'))
+    expect(screen.queryByTestId('tray-drawer')).toBeNull()
+    expect(sidebar.setOpen).toHaveBeenLastCalledWith(true)
+
+    // Reopen: a normal drawer, not a full-screen one.
+    await user.click(screen.getByTitle('Show panel'))
+    await flushFrames()
+    expect(drawer()).not.toHaveAttribute('data-fullscreen')
+    expect(screen.getByText('Full screen')).toBeInTheDocument()
+  })
+
+  it('leaves full screen and restores the sidebar when the browser goes idle', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<TrayManager agentSlug="a" sessionId="s" browserActive={true} />)
+    await flushFrames()
+    await user.click(screen.getByText('Full screen'))
+    expect(drawer()).toHaveAttribute('data-fullscreen')
+
+    rerender(<TrayManager agentSlug="a" sessionId="s" browserActive={false} />)
+    await flushFrames()
+    expect(screen.queryByTestId('tray-drawer')).toBeNull()
+    expect(sidebar.setOpen).toHaveBeenLastCalledWith(true)
+
+    // The browser comes back: normal drawer again.
+    rerender(<TrayManager agentSlug="a" sessionId="s" browserActive={true} />)
+    await flushFrames()
+    expect(drawer()).not.toHaveAttribute('data-fullscreen')
+  })
+
+  it('does not reopen the sidebar on exit if it was already closed before full screen', async () => {
+    sidebar.open = false
+    const user = userEvent.setup()
+    render(<TrayManager agentSlug="a" sessionId="s" browserActive={true} />)
+    await flushFrames()
+    await user.click(screen.getByText('Full screen'))
+    await user.click(screen.getByText('Exit full screen'))
+    expect(sidebar.setOpen).not.toHaveBeenCalledWith(true)
+  })
+
+  it('only exits on an Escape that has not already been handled', async () => {
+    const user = userEvent.setup()
+    render(<TrayManager agentSlug="a" sessionId="s" browserActive={true} />)
+    await flushFrames()
+    await user.click(screen.getByText('Full screen'))
+    const handled = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+    handled.preventDefault()
+    fireEvent(window, handled)
+    expect(drawer()).toHaveAttribute('data-fullscreen')
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(drawer()).not.toHaveAttribute('data-fullscreen')
+    expect(sidebar.setOpen).toHaveBeenLastCalledWith(true)
+  })
+})

--- a/src/renderer/components/tray/tray-manager.reopen.test.tsx
+++ b/src/renderer/components/tray/tray-manager.reopen.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+// The full-screen tests above stand in for the browser tray; this one mounts
+// the real tray content through the flow that was reported to break: full
+// screen, hide the panel, show it again.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ApiMessage } from '@shared/lib/types/api'
+
+const stream = {
+  aspectRatio: '16 / 9',
+  tabs: [{ targetId: 't1', index: 0, url: 'https://www.amazon.com/', title: 'Amazon.com', active: true }],
+  viewingTargetId: 't1',
+  autoFollow: true,
+  needsAttention: false,
+  showOverlay: false,
+  pendingBrowserInputRequests: [],
+  dismissBrowserInputRequest: vi.fn(),
+  latestRequestId: null,
+  connected: true,
+  pageLoading: false,
+  isViewOnly: false,
+  isClosing: false,
+  showCloseWarning: false,
+  setShowCloseWarning: vi.fn(),
+  dismissOverlay: vi.fn(),
+  closeBrowser: vi.fn(),
+  handleCloseClick: vi.fn(),
+  handleMouseDown: vi.fn(),
+  handleMouseUp: vi.fn(),
+  handleMouseMove: vi.fn(),
+  handleWheel: vi.fn(),
+  handleKeyDown: vi.fn(),
+  handleKeyUp: vi.fn(),
+  handlePaste: vi.fn(),
+  handleTabClick: vi.fn(),
+  handleCloseTab: vi.fn(),
+  toggleAutoFollow: vi.fn(),
+  canGoBack: false,
+  canGoForward: false,
+  pageUrl: 'https://www.amazon.com/',
+  navigate: vi.fn(),
+}
+vi.mock('@renderer/hooks/use-browser-stream', () => ({ useBrowserStream: () => stream }))
+vi.mock('@renderer/hooks/use-message-stream', () => ({
+  useMessageStream: () => ({ browserActive: true, isActive: true, streamingToolUses: [], activeSubagents: [] }),
+}))
+vi.mock('@renderer/hooks/use-browser-input-actions', () => ({
+  useBrowserInputActions: () => ({
+    status: 'idle',
+    submittingAction: null,
+    error: null,
+    complete: vi.fn(),
+    decline: vi.fn(),
+  }),
+}))
+const historyMessages: ApiMessage[] = []
+vi.mock('@renderer/hooks/use-messages', () => ({ useMessages: () => ({ data: historyMessages }) }))
+const mockApiFetch = vi.fn((_url: string) => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
+vi.mock('@renderer/lib/api', () => ({ apiFetch: (url: string) => mockApiFetch(url) }))
+vi.mock('@renderer/components/messages/tool-renderers', () => ({ getToolRenderer: () => undefined }))
+vi.mock('@renderer/components/file-preview/file-preview-tray-content', () => ({ FilePreviewTrayContent: () => null }))
+vi.mock('@renderer/components/workflow/workflow-tray-content', () => ({ WorkflowTrayContent: () => null }))
+vi.mock('@renderer/context/file-preview-context', () => ({
+  useFilePreview: () => ({ openTabs: [], isOpen: false, close: vi.fn() }),
+}))
+vi.mock('@renderer/context/workflow-context', () => ({
+  useWorkflow: () => ({ openWorkflows: [], isOpen: false, close: vi.fn(), selectedRunId: null }),
+}))
+const sidebar = {
+  open: true,
+  setOpen: vi.fn((open: boolean) => {
+    sidebar.open = open
+  }),
+}
+vi.mock('@renderer/components/ui/sidebar', () => ({ useSidebar: () => sidebar }))
+
+import { TrayManager } from './tray-manager'
+
+async function flushFrames() {
+  await act(async () => {
+    await new Promise((r) => requestAnimationFrame(() => r(null)))
+    await new Promise((r) => requestAnimationFrame(() => r(null)))
+  })
+}
+
+describe('TrayManager with the real browser tray', () => {
+  beforeEach(() => {
+    sidebar.open = true
+    sidebar.setOpen.mockClear()
+    localStorage.clear()
+    historyMessages.length = 0
+    mockApiFetch.mockClear()
+    Element.prototype.scrollIntoView = vi.fn()
+    // jsdom has no ResizeObserver; give it one so the full-screen measurement path runs.
+    class RO {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    }
+    vi.stubGlobal('ResizeObserver', RO)
+  })
+
+  it('survives full screen → hide panel → show panel with the real content', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const user = userEvent.setup()
+    render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <TrayManager agentSlug="a" sessionId="s" browserActive={true} />
+      </QueryClientProvider>,
+    )
+    await flushFrames()
+    expect(screen.getByTestId('browser-drawer-panel')).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Full screen'))
+    expect(screen.getByTestId('tray-drawer')).toHaveAttribute('data-fullscreen')
+    expect(screen.getByLabelText('Exit full screen')).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Hide browser panel'))
+    expect(screen.queryByTestId('tray-drawer')).toBeNull()
+
+    await user.click(screen.getByTitle('Show panel'))
+    await flushFrames()
+    expect(screen.getByTestId('tray-drawer')).not.toHaveAttribute('data-fullscreen')
+    expect(screen.getByTestId('browser-drawer-panel')).toBeInTheDocument()
+    expect(screen.getByLabelText('Full screen')).toBeInTheDocument()
+    expect(screen.getByText('Browser agent actions')).toBeInTheDocument()
+
+    const reactErrors = errors.mock.calls.filter((c) => /Cannot update|Warning|Error/.test(String(c[0])))
+    expect(reactErrors).toEqual([])
+    errors.mockRestore()
+  })
+
+  it('preserves log rows and avoids refetching historical transcripts after full screen', async () => {
+    historyMessages.push({
+      id: 'history',
+      type: 'assistant',
+      content: { text: '' },
+      createdAt: new Date(),
+      toolCalls: [
+        ...Array.from({ length: 40 }, (_, index) => ({
+          id: `task-${index}`,
+          name: 'Agent',
+          input: {},
+          subagent: { agentId: `sub-${index}`, status: 'completed' },
+        })),
+        { id: 'browser-click', name: 'mcp__browser__click', input: {}, result: 'Persistent browser result' },
+      ],
+    })
+    const user = userEvent.setup()
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: 5000 } } })
+    const view = render(
+      <QueryClientProvider client={client}>
+        <TrayManager agentSlug="a" sessionId="s" browserActive={true} />
+      </QueryClientProvider>,
+    )
+    await flushFrames()
+    await waitFor(() => expect(client.isFetching()).toBe(0))
+    expect(mockApiFetch).toHaveBeenCalledTimes(40)
+    await user.click(screen.getByRole('button', { name: 'click' }))
+    const detail = screen.getByText('Persistent browser result')
+    const scrollViewport = screen
+      .getByTestId('browser-activity-region')
+      .querySelector('[data-radix-scroll-area-viewport]')!
+    scrollViewport.scrollTop = 80
+
+    await user.click(screen.getByLabelText('Full screen'))
+    expect(screen.getByTestId('browser-activity-region')).toHaveClass('hidden')
+    // Exceed the application's five-second stale time without slowing the test.
+    const now = vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 6000)
+    try {
+      await user.click(screen.getByLabelText('Exit full screen'))
+      await waitFor(() => expect(client.isFetching()).toBe(0))
+      expect(mockApiFetch).toHaveBeenCalledTimes(40)
+      expect(screen.getByText('Persistent browser result')).toBe(detail)
+      expect(screen.getByTestId('browser-activity-region')).not.toHaveClass('hidden')
+      expect(scrollViewport.scrollTop).toBe(80)
+    } finally {
+      now.mockRestore()
+      view.unmount()
+      client.clear()
+    }
+  })
+})

--- a/src/renderer/components/tray/tray-manager.tsx
+++ b/src/renderer/components/tray/tray-manager.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Globe, FileText, PanelRightOpen, Workflow } from 'lucide-react'
-import { DrawerShell, type DrawerShellHandle } from './drawer-shell'
+import { DrawerShell } from './drawer-shell'
 import { useSidebar } from '@renderer/components/ui/sidebar'
 import { TrayTabStrip, type TrayDef } from './tray-tab-strip'
 import { BrowserTrayContent } from '@renderer/components/browser/browser-tray-content'
@@ -32,32 +32,54 @@ export function TrayManager({
   const [selectedTrayId, setSelectedTrayId] = useState<string>('browser')
   const [isOpen, setIsOpen] = useState(false)
   const [userClosed, setUserClosed] = useState(false)
-  const drawerRef = useRef<DrawerShellHandle>(null)
+  // Full screen: the drawer covers the tray host and the sidebar folds away,
+  // so the browser gets the whole window. Both come back on exit.
   const [isExpanded, setIsExpanded] = useState(false)
-  const preExpandWidthRef = useRef<number | null>(null)
   const sidebarWasOpenRef = useRef(false)
   const { open: sidebarOpen, setOpen: setSidebarOpen } = useSidebar()
 
+  // Leaving full screen restores the sidebar. It runs from the button, from
+  // Escape, and from every path that takes the drawer away underneath it —
+  // hiding the panel, the browser going idle, switching to another tray —
+  // otherwise the sidebar stays folded with nothing on screen to unfold it.
+  // Tracked in a ref as well as state so exit can read it without going
+  // through an updater: a sibling's setState must not run inside one.
+  const isExpandedRef = useRef(false)
+  const exitFullScreen = useCallback(() => {
+    if (!isExpandedRef.current) return
+    isExpandedRef.current = false
+    setIsExpanded(false)
+    if (sidebarWasOpenRef.current) setSidebarOpen(true)
+  }, [setSidebarOpen])
+
   const handleCloseTray = useCallback(() => {
+    exitFullScreen()
     setUserClosed(true)
     setIsOpen(false)
-  }, [])
+  }, [exitFullScreen])
 
   const handleToggleExpand = useCallback(() => {
     if (isExpanded) {
-      if (preExpandWidthRef.current != null && drawerRef.current) {
-        drawerRef.current.setWidth(preExpandWidthRef.current)
-      }
-      if (sidebarWasOpenRef.current) setSidebarOpen(true)
-      setIsExpanded(false)
+      exitFullScreen()
     } else {
-      preExpandWidthRef.current = drawerRef.current?.getWidth() ?? null
       sidebarWasOpenRef.current = sidebarOpen
-      drawerRef.current?.setWidth(800)
+      isExpandedRef.current = true
       setSidebarOpen(false)
       setIsExpanded(true)
     }
-  }, [isExpanded, sidebarOpen, setSidebarOpen])
+  }, [isExpanded, sidebarOpen, setSidebarOpen, exitFullScreen])
+
+  // Canvas input and local dialogs own their handled keys; only an unhandled Escape exits.
+  useEffect(() => {
+    if (!isExpanded) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || e.defaultPrevented) return
+      e.preventDefault()
+      exitFullScreen()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [isExpanded, exitFullScreen])
 
   const browserTrayContent = useMemo(() => (
     <BrowserTrayContent
@@ -155,10 +177,18 @@ export function TrayManager({
   // Close when no trays are available
   useEffect(() => {
     if (!anyAvailable) {
+      exitFullScreen()
       setIsOpen(false)
       setUserClosed(false)
     }
-  }, [anyAvailable])
+  }, [anyAvailable, exitFullScreen])
+
+  // Full screen belongs to the browser tray alone: losing it (the browser went
+  // idle) or leaving it (the user picked Files or Workflow) ends full screen.
+  const activeTrayId = trays.find(t => t.id === selectedTrayId && t.available)?.id ?? availableTrays[0]?.id
+  useEffect(() => {
+    if (activeTrayId !== 'browser') exitFullScreen()
+  }, [activeTrayId, exitFullScreen])
 
   // Switch away from unavailable tray
   useEffect(() => {
@@ -191,11 +221,11 @@ export function TrayManager({
 
   return (
     <DrawerShell
-      ref={drawerRef}
       isOpen={isOpen}
       storageKey={DRAWER_STORAGE_KEY}
       responsiveFullWidth={activeTray?.id === 'files'}
       wideOverlay={activeTray?.id === 'files' && filePreviewWideLayout === 'overlay'}
+      fullScreen={isExpanded && activeTray?.id === 'browser'}
     >
       <div className="flex flex-1 min-h-0">
         <div className="flex-1 flex flex-col min-w-0 min-h-0">

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -1012,6 +1012,21 @@ html[data-keyboard-open] [data-composer-footer] {
   z-index: 30;
 }
 
+/* Full screen: the drawer covers its whole tray host (the session body or the
+   agent home body, both `relative`), edge to edge. Width is forced over the
+   persisted inline value the same way the compact overlay does it. */
+.tray-drawer-fullscreen {
+  position: absolute;
+  inset: 0;
+  width: 100% !important;
+  z-index: 30;
+  border-left-width: 0;
+  box-shadow: none;
+}
+.tray-drawer-fullscreen .tray-drawer-resize-handle {
+  display: none;
+}
+
 @container (max-width: 767px) {
   .file-preview-responsive-overlay {
     position: absolute;

--- a/src/renderer/hooks/use-browser-card-size.ts
+++ b/src/renderer/hooks/use-browser-card-size.ts
@@ -1,0 +1,49 @@
+import { useLayoutEffect, useRef, useState } from 'react'
+
+function parseAspect(ratio: string): number {
+  const [width, height] = ratio.split('/').map(Number)
+  const aspect = width / height
+  return Number.isFinite(aspect) && aspect > 0 ? aspect : 16 / 9
+}
+
+/** Fit the whole browser card, including its toolbar and any input request, in the rail. */
+export function useBrowserCardSize(fullScreen: boolean, aspectRatio: string) {
+  const railRef = useRef<HTMLDivElement>(null)
+  const cardRef = useRef<HTMLDivElement>(null)
+  const viewportRef = useRef<HTMLDivElement>(null)
+  const [size, setSize] = useState<{ card: number; strip: number } | null>(null)
+  const aspect = parseAspect(aspectRatio)
+
+  useLayoutEffect(() => {
+    if (!fullScreen) {
+      setSize(null)
+      return
+    }
+    const rail = railRef.current
+    const card = cardRef.current
+    const viewport = viewportRef.current
+    if (!rail || !card || !viewport) return
+    const measure = () => {
+      const padding = getComputedStyle(rail)
+      const pixels = (value: string) => parseFloat(value) || 0
+      const chrome = card.offsetHeight - viewport.offsetHeight
+      const available = rail.clientHeight - pixels(padding.paddingTop) - pixels(padding.paddingBottom) - chrome
+      const cardWidth = Math.max(1, Math.floor(available * aspect))
+      const stripWidth = cardWidth + pixels(padding.paddingLeft) + pixels(padding.paddingRight)
+      setSize((previous) =>
+        previous?.card === cardWidth && previous.strip === stripWidth
+          ? previous
+          : { card: cardWidth, strip: stripWidth },
+      )
+    }
+    measure()
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measure)
+    observer.observe(rail)
+    // Input-request messages and errors can change the toolbar/action area's height.
+    observer.observe(card)
+    return () => observer.disconnect()
+  }, [fullScreen, aspect])
+
+  return { railRef, cardRef, viewportRef, maxCardWidth: size?.card, maxStripWidth: size?.strip }
+}


### PR DESCRIPTION
Adds fullscreen browser viewing over the session's tray host. Last in the stack, based on #1000.

The sidebar folds away on entry and restores its prior open state when exiting, hiding the panel, losing the browser, or switching trays. The normal drawer width is preserved.

`useBrowserCardSize` fits the card and tab strip to the available height, including the toolbar and pending-input actions. It preserves the page aspect ratio and has no 480px minimum that could push controls offscreen. Portrait pages and short windows retain reachable Stop and Exit controls.

The activity region is hidden while fullscreen and stays mounted, preserving transcript subscriptions, expanded rows, and scroll state. Returning does not refetch every historical subagent transcript. Short ordinary drawers retain a scrollable activity region.

Escape belongs to the focused remote page or a local dialog/tooltip when that layer handles it. Only an unhandled Escape exits fullscreen, so one key press does not both reach the remote page and exit the local view.

## Validation

- Renderer type check and changed-area lint pass; 62 affected renderer/hook tests pass.
- Lifecycle regression with 40 historical subagents: 40 initial requests, still 40 after returning beyond the five-second stale time; expanded detail and scroll position persist.
- Chromium E2E checks cover live frames, ordinary tall-page controls, portrait fullscreen at 600px and 360px window heights, and remote/dialog/fullscreen Escape ownership, with page-error assertions.
- Light and dark screenshots below are from an isolated mock instance. A live Electron/container performance benchmark was not run.

## Screenshots

| Light | Dark |
| --- | --- |
| ![Browser full screen (light)](https://github.com/user-attachments/assets/5a1ae2a2-dee3-4b39-92a8-97c7fedfd5ef) | ![Browser full screen (dark)](https://github.com/user-attachments/assets/b1cd5af8-5d56-4125-8b05-c4427435f8d3) |
