### PR TITLE
feat(composer): voice mode leads an empty composer, Send takes over once there is something to send

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -140,6 +140,7 @@ vi.mock('@renderer/components/agents/system-prompt-dialog', () => ({
 
 const mockComposer = {
   message: '',
+  hasContent: false,
   setMessage: vi.fn(),
   attachments: [] as any[],
   isDragOver: false,

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -8,6 +8,7 @@ import { useCreateSession, useSessions } from '@renderer/hooks/use-sessions'
 import { useScheduledTasks } from '@renderer/hooks/use-scheduled-tasks'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
 import { VoiceModeButton } from '@renderer/components/ui/voice-mode-button'
+import { useCanUseVoiceMode } from '@renderer/hooks/use-voice-input'
 import { readAloud } from '@renderer/hooks/use-read-aloud'
 import { VOICE_MODE_ENTERED_MESSAGE } from '@shared/lib/voice/voice-mode-messages'
 import { UploadError } from '@renderer/components/ui/upload-error'
@@ -284,6 +285,11 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   }, [createSession, agent.slug, composerOptions, onSessionCreated])
 
   const isFreshUntitled = agent.name === UNTITLED_AGENT_NAME && sessions.length === 0
+  // An empty composer leads with voice mode as its one live action; once there
+  // is something to send, Send takes the primary slot and voice mode steps back
+  // beside it. A fresh untitled agent keeps its "Create Agent" button instead.
+  const canUseVoiceMode = useCanUseVoiceMode()
+  const voiceModeIsPrimary = !isFreshUntitled && canUseVoiceMode && !composer.hasContent
   const typewriterPlaceholder = useTypewriterPlaceholder(
     isFreshUntitled ? DEFAULT_AGENT_PROMPT_EXAMPLES : TYPEWRITER_DISABLED,
   )
@@ -525,7 +531,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
                   rightActions={(
                     <>
                       <VoiceInputButton voiceInput={composer.voiceInput} message={composer.message} disabled={isDisabled} />
-                      {!isFreshUntitled && (
+                      {!isFreshUntitled && !voiceModeIsPrimary && (
                         <VoiceModeButton onClick={() => void startVoiceSession()} disabled={isDisabled} />
                       )}
                       {isFreshUntitled ? (
@@ -544,6 +550,8 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
                             'Create Agent'
                           )}
                         </Button>
+                      ) : voiceModeIsPrimary ? (
+                        <VoiceModeButton variant="default" onClick={() => void startVoiceSession()} disabled={isDisabled} />
                       ) : (
                         <Button
                           type="submit"

--- a/src/renderer/components/messages/composer-action-button.test.tsx
+++ b/src/renderer/components/messages/composer-action-button.test.tsx
@@ -30,6 +30,18 @@ describe('ComposerActionButton', () => {
     expect(send).toHaveAttribute('aria-label', 'Queue message')
   })
 
+  it('renders the primary slot in place of Send, beside Stop while active', () => {
+    const primary = <button type="button" data-testid="primary-slot" />
+    const { rerender } = render(<ComposerActionButton {...baseProps} primary={primary} />)
+    expect(screen.getByTestId('primary-slot')).toBeInTheDocument()
+    expect(screen.queryByTestId('send-button')).not.toBeInTheDocument()
+
+    rerender(<ComposerActionButton {...baseProps} isActive primary={primary} />)
+    expect(screen.getByTestId('stop-button')).toBeInTheDocument()
+    expect(screen.getByTestId('primary-slot')).toBeInTheDocument()
+    expect(screen.queryByTestId('send-button')).not.toBeInTheDocument()
+  })
+
   it('disables the send button when canSubmit is false', () => {
     render(<ComposerActionButton {...baseProps} canSubmit={false} />)
     expect(screen.getByTestId('send-button')).toBeDisabled()

--- a/src/renderer/components/messages/composer-action-button.tsx
+++ b/src/renderer/components/messages/composer-action-button.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import { ArrowUp, Loader2, Square } from 'lucide-react'
 import { Button } from '@renderer/components/ui/button'
 
@@ -8,6 +9,12 @@ interface ComposerActionButtonProps {
   isSending: boolean
   isInterrupting: boolean
   onInterrupt: () => void
+  /**
+   * Rendered in place of Send. The composer hands this slot to voice mode
+   * while there is nothing to send yet, so an empty composer leads with one
+   * live action instead of a disabled arrow.
+   */
+  primary?: ReactNode
 }
 
 export function ComposerActionButton({
@@ -17,58 +24,20 @@ export function ComposerActionButton({
   isSending,
   isInterrupting,
   onInterrupt,
+  primary,
 }: ComposerActionButtonProps) {
   // While the agent works (or background tasks linger) show Stop alongside
   // Send — messages sent mid-turn are queued and picked up by the agent loop.
-  if (isActive || isWaitingBackground) {
-    const stopLabel = isWaitingBackground ? 'Stop background processes' : 'Stop the agent'
-    const sendLabel = isWaitingBackground ? 'Send message' : 'Queue message'
-    return (
-      <div className="flex items-center gap-2">
-        <Button
-          type="button"
-          size="icon"
-          variant="outline"
-          className="h-[34px] w-[34px]"
-          onClick={onInterrupt}
-          disabled={isInterrupting}
-          aria-label={stopLabel}
-          title={stopLabel}
-          data-testid="stop-button"
-        >
-          {isInterrupting ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Square className="h-3.5 w-3.5 fill-current" />
-          )}
-        </Button>
-        <Button
-          type="submit"
-          size="icon"
-          className="h-[34px] w-[34px]"
-          disabled={!canSubmit || isSending}
-          aria-label={sendLabel}
-          title={sendLabel}
-          data-testid="send-button"
-        >
-          {isSending ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <ArrowUp className="h-4 w-4" />
-          )}
-        </Button>
-      </div>
-    )
-  }
-
-  return (
+  const inTurn = isActive || isWaitingBackground
+  const sendLabel = inTurn && !isWaitingBackground ? 'Queue message' : 'Send message'
+  const send = primary ?? (
     <Button
       type="submit"
       size="icon"
       className="h-[34px] w-[34px]"
       disabled={!canSubmit || isSending}
-      aria-label="Send message"
-      title="Send message"
+      aria-label={sendLabel}
+      title={sendLabel}
       data-testid="send-button"
     >
       {isSending ? (
@@ -77,5 +46,31 @@ export function ComposerActionButton({
         <ArrowUp className="h-4 w-4" />
       )}
     </Button>
+  )
+
+  if (!inTurn) return <>{send}</>
+
+  const stopLabel = isWaitingBackground ? 'Stop background processes' : 'Stop the agent'
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        type="button"
+        size="icon"
+        variant="outline"
+        className="h-[34px] w-[34px]"
+        onClick={onInterrupt}
+        disabled={isInterrupting}
+        aria-label={stopLabel}
+        title={stopLabel}
+        data-testid="stop-button"
+      >
+        {isInterrupting ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Square className="h-3.5 w-3.5 fill-current" />
+        )}
+      </Button>
+      {send}
+    </div>
   )
 }

--- a/src/renderer/components/messages/message-input.test.tsx
+++ b/src/renderer/components/messages/message-input.test.tsx
@@ -139,6 +139,7 @@ vi.mock('@renderer/hooks/use-settings', () => ({
 describe('MessageInput', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockCanUseVoiceMode = false
     mockStreamState.isActive = false
     mockStreamState.isWaitingBackground = false
     mockStreamState.backgroundTasks = []
@@ -192,12 +193,44 @@ describe('MessageInput', () => {
       await waitFor(() => expect(mockSendMessage.mutate).toHaveBeenCalledTimes(2))
     })
 
+    it('is the primary action while there is nothing to send, then yields that slot to Send', async () => {
+      mockCanUseVoiceMode = true
+      renderWithProviders(<MessageInput sessionId="s-1" agentSlug="agent-1" />)
+      // Empty: one live action — voice mode, filled — and no disabled Send beside it.
+      expect(screen.getByTestId('voice-mode-button')).toHaveClass('bg-primary')
+      expect(screen.queryByTestId('send-button')).not.toBeInTheDocument()
+
+      const input = screen.getByTestId('message-input')
+      await userEvent.type(input, 'Hello')
+      expect(screen.getByTestId('send-button')).toBeEnabled()
+      expect(screen.getByTestId('voice-mode-button')).not.toHaveClass('bg-primary')
+
+      await userEvent.clear(input)
+      expect(screen.queryByTestId('send-button')).not.toBeInTheDocument()
+      expect(screen.getByTestId('voice-mode-button')).toHaveClass('bg-primary')
+    })
+
+    it('stays secondary to Send while the agent works, next to Stop', async () => {
+      mockCanUseVoiceMode = true
+      mockStreamState.isActive = true
+      renderWithProviders(<MessageInput sessionId="s-1" agentSlug="agent-1" />)
+      expect(screen.getByTestId('stop-button')).toBeInTheDocument()
+      expect(screen.getByTestId('voice-mode-button')).toHaveClass('bg-primary')
+      expect(screen.queryByTestId('send-button')).not.toBeInTheDocument()
+
+      await userEvent.type(screen.getByTestId('message-input'), 'Hello')
+      expect(screen.getByTestId('send-button')).toHaveAttribute('aria-label', 'Queue message')
+      expect(screen.getByTestId('voice-mode-button')).not.toHaveClass('bg-primary')
+    })
+
     it('cannot be entered while a dictation is still recording', () => {
       mockCanUseVoiceMode = true
       mockDictating = true
       try {
         renderWithProviders(<MessageInput sessionId="s-1" agentSlug="agent-1" />)
+        // The dictation is what gets sent, so Send holds the primary slot.
         expect(screen.getByTestId('voice-mode-button')).toBeDisabled()
+        expect(screen.getByTestId('send-button')).toBeInTheDocument()
       } finally {
         mockDictating = false
       }

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -10,6 +10,7 @@ import { useUser } from '@renderer/context/user-context'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { VoiceInputButton, VoiceInputError } from '@renderer/components/ui/voice-input-button'
 import { VoiceModeButton } from '@renderer/components/ui/voice-mode-button'
+import { useCanUseVoiceMode } from '@renderer/hooks/use-voice-input'
 import { VoiceModeComposer } from './voice-mode-composer'
 import { VoiceModeControls, useHoldSoundPreference } from './voice-mode-controls'
 import { useVoiceMode } from '@renderer/hooks/use-voice-mode'
@@ -290,6 +291,14 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
 
   const isDisabled = sendMessage.isPending || composer.isUploading || isOffline || !isRuntimeReady
 
+  // An empty composer leads with voice mode as its one live action. Once there
+  // is something to send, Send takes the primary slot and voice mode steps
+  // back beside it as a secondary button.
+  const canUseVoiceMode = useCanUseVoiceMode()
+  const voiceModeIsPrimary = canUseVoiceMode && !composer.hasContent
+  // Not mid-dictation: that mic and socket would stay open under voice mode's own.
+  const voiceModeDisabled = isDisabled || composer.voiceInput.isRecording || composer.voiceInput.isConnecting
+
   // Voice mode. A session opened from the home page's voice button arrives
   // with the request already made (and the entry notice already sent as its
   // first message); otherwise it starts here, with the notice appended for
@@ -498,8 +507,9 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
               message={composer.message}
               disabled={isDisabled}
             />
-            {/* Not mid-dictation: that mic and socket would stay open under voice mode's own. */}
-            <VoiceModeButton onClick={enterVoiceMode} disabled={isDisabled || composer.voiceInput.isRecording || composer.voiceInput.isConnecting} />
+            {!voiceModeIsPrimary && (
+              <VoiceModeButton onClick={enterVoiceMode} disabled={voiceModeDisabled} />
+            )}
             <ComposerActionButton
               isActive={isActive}
               isWaitingBackground={isWaitingBackground}
@@ -507,6 +517,9 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
               isSending={sendMessage.isPending || composer.isUploading}
               isInterrupting={interruptSession.isPending}
               onInterrupt={handleInterrupt}
+              primary={voiceModeIsPrimary ? (
+                <VoiceModeButton variant="default" onClick={enterVoiceMode} disabled={voiceModeDisabled} />
+              ) : undefined}
             />
           </>
         )}

--- a/src/renderer/components/ui/voice-mode-button.tsx
+++ b/src/renderer/components/ui/voice-mode-button.tsx
@@ -6,6 +6,11 @@ interface VoiceModeButtonProps {
   onClick: () => void
   disabled?: boolean
   className?: string
+  /**
+   * `default` (filled) while voice mode is the composer's primary action —
+   * i.e. there is nothing to send yet. `outline` once Send takes that slot.
+   */
+  variant?: 'outline' | 'default'
 }
 
 /**
@@ -13,14 +18,14 @@ interface VoiceModeButtonProps {
  * when the configured voice provider can both transcribe and speak — a
  * dictation-only setup keeps just the mic.
  */
-export function VoiceModeButton({ onClick, disabled, className = 'h-[34px] w-[34px]' }: VoiceModeButtonProps) {
+export function VoiceModeButton({ onClick, disabled, className = 'h-[34px] w-[34px]', variant = 'outline' }: VoiceModeButtonProps) {
   const canUseVoiceMode = useCanUseVoiceMode()
   if (!canUseVoiceMode) return null
   return (
     <Button
       type="button"
       size="icon"
-      variant="outline"
+      variant={variant}
       className={className}
       onClick={onClick}
       disabled={disabled}

--- a/src/renderer/hooks/use-message-composer.ts
+++ b/src/renderer/hooks/use-message-composer.ts
@@ -354,7 +354,10 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     return true
   }
 
-  const canSubmit = (!!message.trim() || attachments.length > 0 || voiceInput.isRecording) && !uploadsInFlight && !isUploading && !submitDisabled
+  // Something to send: typed text, an attachment, or a dictation in flight
+  // (Send stops it and sends the transcript).
+  const hasContent = !!message.trim() || attachments.length > 0 || voiceInput.isRecording
+  const canSubmit = hasContent && !uploadsInFlight && !isUploading && !submitDisabled
 
   return {
     // Message state
@@ -392,6 +395,7 @@ export function useMessageComposer(options: UseMessageComposerOptions) {
     handleSubmit,
     submitMessage,
     handlePaste,
+    hasContent,
     canSubmit,
 
     // Upload error (surfaced to the user; cleared on next submit attempt)


### PR DESCRIPTION
## Summary

With nothing typed, the composer used to show voice mode as an outline button beside a greyed-out Send arrow. Now an empty composer leads with **voice mode as its single filled primary action**. As soon as there is something to send, Send takes the primary slot and voice mode steps back beside it as a secondary outline button. Clearing the text collapses it again.

Applies to the session composer and the agent home composer. A fresh untitled agent keeps its "Create Agent" button. The swap only happens when voice mode is actually offered (a provider that can both transcribe and speak); dictation-only setups look exactly as before.

## Changes

- `useMessageComposer` exposes `hasContent` — typed text, an attachment, or an in-flight dictation — the half of `canSubmit` that decides the swap. During a dictation Send stays primary, since the dictation is what gets sent.
- `ComposerActionButton` gains a `primary` slot rendered in place of Send. While the agent works it sits next to Stop exactly where Send did, so the row does not jump between states.
- `VoiceModeButton` takes a `variant` (`outline` by default, `default` when it holds the primary slot).
- `MessageInput` and `AgentHome` wire the swap.

## Tests

- New coverage for the primary slot, the empty → typed → cleared handoff, the mid-turn layout next to Stop, and Send staying primary during dictation.
- One fixture leak surfaced: the voice-mode tests set `mockCanUseVoiceMode` and never reset it, which now matters (it hides Send). Reset in the shared `beforeEach`.
- `npm run typecheck`, eslint on the changed files, and the four affected vitest files pass.

## Screenshots

Session composer, empty (voice mode is the primary button):

| Light | Dark |
| --- | --- |
| ![Session, empty composer (light)](https://github.com/user-attachments/assets/ac1527ca-eeb3-476d-a681-1e7f4eca86b9) | ![Session, empty composer (dark)](https://github.com/user-attachments/assets/21bb7545-8b3f-4189-915f-fd48e44b1141) |

Session composer, text typed (Send primary, voice mode secondary):

| Light | Dark |
| --- | --- |
| ![Session, text typed (light)](https://github.com/user-attachments/assets/e9c52e8b-75dd-468c-8e66-a819ecdd8782) | ![Session, text typed (dark)](https://github.com/user-attachments/assets/44968393-015e-4d73-88cb-35e8a2fee4a9) |

Agent home composer:

| Empty (light) | Typed (dark) |
| --- | --- |
| ![Agent home, empty composer (light)](https://github.com/user-attachments/assets/8d250f57-e322-4e18-9847-94f8de4a9347) | ![Agent home, text typed (dark)](https://github.com/user-attachments/assets/e4d55d4d-a5db-414d-ac20-29633345b3bc) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
