### PR TITLE
fix(sidebar): show the agent-folder count only while collapsed

### DIFF
--- a/src/renderer/components/layout/agent-folder-block.test.tsx
+++ b/src/renderer/components/layout/agent-folder-block.test.tsx
@@ -98,17 +98,23 @@ beforeEach(() => {
 afterEach(cleanup)
 
 describe('AgentFolderBlock', () => {
-  it('shows the folder name and how many agents it holds', () => {
-    renderBlock()
+  it('shows the folder name, and how many agents it holds only while collapsed', () => {
+    // Expanded, the rows underneath already say how many there are, so the
+    // header drops the count; collapsed, the count is the only hint.
+    renderBlock({ isCollapsed: true })
     const row = screen.getByTestId('agent-folder-f1')
     expect(row).toHaveTextContent('Work')
-    expect(row).toHaveTextContent('2')
+    expect(screen.getByTestId('agent-folder-count-f1')).toHaveTextContent('2')
+    cleanup()
+    renderBlock({ isCollapsed: false })
+    expect(screen.getByTestId('agent-folder-f1')).toHaveTextContent('Work')
+    expect(screen.queryByTestId('agent-folder-count-f1')).not.toBeInTheDocument()
   })
 
   it('reveals the chevron only on hover, in the count’s slot', () => {
     // The header reads as a section label at rest (name + count, no icon);
     // hovering swaps the count for the expand/collapse affordance.
-    renderBlock()
+    renderBlock({ isCollapsed: true })
     expect(screen.getByTestId('agent-folder-count-f1').className).toContain(
       'group-hover/folder-header:hidden'
     )
@@ -354,10 +360,10 @@ describe('AgentFolderBlock — the default folder', () => {
   }
 
   it('renders like any folder header', () => {
-    renderRoot()
+    renderRoot({ isCollapsed: true })
     const row = screen.getByTestId('agent-folder-root')
     expect(row).toHaveTextContent('Your Agents')
-    expect(row).toHaveTextContent('2')
+    expect(screen.getByTestId('agent-folder-count-root')).toHaveTextContent('2')
   })
 
   it('offers no rename or delete — it is the fallback bucket', () => {

--- a/src/renderer/components/layout/agent-folder-block.tsx
+++ b/src/renderer/components/layout/agent-folder-block.tsx
@@ -106,8 +106,10 @@ const FolderHeader = React.memo(function FolderHeader({
   onDelete: () => void
 }) {
   // Styled like a section label rather than as a row of the list: small muted
-  // text, no icon. The member count sits at the right and yields to the
-  // expand/collapse chevron on hover.
+  // text, no icon. The member count sits at the right only while the folder is
+  // collapsed — the rows themselves say how many there are once it is open —
+  // and yields to the expand/collapse chevron on hover. The slot keeps its
+  // size either way so the chevron lands in the same spot.
   const header = (
         <SidebarMenuButton
           onClick={onToggle}
@@ -120,12 +122,14 @@ const FolderHeader = React.memo(function FolderHeader({
         >
           <span className="truncate">{folder.name}</span>
           <span className="relative flex h-4 w-4 shrink-0 items-center justify-center">
-            <span
-              className="text-[11px] tabular-nums text-muted-foreground/70 group-hover/folder-header:hidden"
-              data-testid={`agent-folder-count-${folder.id}`}
-            >
-              {agentCount}
-            </span>
+            {isCollapsed && (
+              <span
+                className="text-[11px] tabular-nums text-muted-foreground/70 group-hover/folder-header:hidden"
+                data-testid={`agent-folder-count-${folder.id}`}
+              >
+                {agentCount}
+              </span>
+            )}
             <ChevronRight
               aria-hidden
               data-testid={`agent-folder-chevron-${folder.id}`}

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -1157,17 +1157,28 @@ describe('AppSidebar — agent folders', () => {
     expect(screen.getByTestId('agent-folder-root')).toHaveTextContent('Your Agents')
   })
 
-  it('renders a folder with its name and how many agents are in it', () => {
+  it('renders a folder with its name, and how many agents are in it only while collapsed', () => {
     mockUserSettings.mockReturnValue({
       agentOrder: ['test-agent', 'other-agent'],
       agentFolders: [FOLDERS[0]],
       agentFolderAssignments: { 'test-agent': 'f1', 'other-agent': 'f1' },
     })
-    renderWithProviders(<AppSidebar />)
+    const { unmount } = renderWithProviders(<AppSidebar />)
 
-    const folder = screen.getByTestId('agent-folder-f1')
-    expect(folder).toHaveTextContent('Work')
-    expect(folder).toHaveTextContent('2')
+    // Expanded: the rows underneath say how many there are, so no count.
+    expect(screen.getByTestId('agent-folder-f1')).toHaveTextContent('Work')
+    expect(screen.queryByTestId('agent-folder-count-f1')).not.toBeInTheDocument()
+    unmount()
+
+    mockUserSettings.mockReturnValue({
+      agentOrder: ['test-agent', 'other-agent'],
+      agentFolders: [FOLDERS[0]],
+      agentFolderAssignments: { 'test-agent': 'f1', 'other-agent': 'f1' },
+      collapsedAgentFolders: ['f1'],
+    })
+    renderWithProviders(<AppSidebar />)
+    expect(screen.getByTestId('agent-folder-f1')).toHaveTextContent('Work')
+    expect(screen.getByTestId('agent-folder-count-f1')).toHaveTextContent('2')
   })
 
   it('defaults the default folder first before anything is arranged', () => {


### PR DESCRIPTION
## Summary

- Agent folder headers in the sidebar show the member count only while the folder is collapsed. Expanded, the rows underneath already say how many there are, so the header shows just the name.
- The fixed-size slot at the right of the header stays either way, so the hover chevron lands in the same spot in both states.
- Updated the three unit tests that asserted the count on an expanded folder to check both states.

## Screenshots

`Work` is expanded (no count); `Personal` is collapsed (count shown).

| Light | Dark |
| --- | --- |
| ![Sidebar folders (light)](https://github.com/user-attachments/assets/88fc954e-07ee-4297-a719-b22b64c9a290) | ![Sidebar folders (dark)](https://github.com/user-attachments/assets/b564343e-1c88-4389-a57a-ca3197c9a093) |

## Test plan

- [x] `npx vitest run src/renderer/components/layout/agent-folder-block.test.tsx src/renderer/components/layout/app-sidebar.test.tsx` — 116 passed
- [x] `npm run typecheck` clean
- [x] ESLint clean on the edited files
- [x] Verified in the Electron dev app and the mock web build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
