### PR TITLE
Surface the session menu as a hover 3-dot button in the sidebar

### DIFF
--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -232,16 +232,28 @@ vi.mock('@renderer/components/agents/agent-context-menu', () => ({
   AgentContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
+// Stands in for the real Radix context menu: like the real asChild trigger it
+// adds no DOM of its own, it reports "opened" when a contextmenu reaches the
+// row (which is how the row's 3-dot button opens it), and it exposes the
+// activity the tests inspect.
 vi.mock('@renderer/components/sessions/session-context-menu', () => ({
   SessionContextMenu: ({
     children,
     activity,
+    onOpenChange,
   }: {
     children: React.ReactNode
     activity: { isActive: boolean; isAwaitingInput: boolean; isStreaming: boolean }
+    onOpenChange?: (open: boolean) => void
   }) => (
     isValidElement(children)
-      ? cloneElement(children as ReactElement, { 'data-is-active': String(activity.isActive || activity.isStreaming) } as any)
+      ? cloneElement(children as ReactElement, {
+          'data-is-active': String(activity.isActive || activity.isStreaming),
+          onContextMenu: (e: React.MouseEvent) => {
+            e.preventDefault()
+            onOpenChange?.(true)
+          },
+        } as any)
       : <>{children}</>
   ),
 }))
@@ -875,6 +887,44 @@ describe('AppSidebar — agent row indicator', () => {
     const status = screen.getByTestId('agent-status-running')
     expect(status).toHaveAttribute('data-awaiting', 'true')
     expect(screen.queryByLabelText('unread notifications')).not.toBeInTheDocument()
+  })
+})
+
+// ============================================================================
+// Session row 3-dot menu button
+// ----------------------------------------------------------------------------
+// Right-click was the only way into the session menu and nobody found it. The
+// button takes over the indicator slot on hover and opens that same menu, so
+// the two gestures can never drift apart.
+// ============================================================================
+describe('AppSidebar — session row menu button', () => {
+  function renderExpandedAgent() {
+    mockUseSessions.mockImplementation((slug: string | null) => ({
+      data: slug === 'test-agent' ? [makeSession({ isAwaitingInput: true })] : [],
+      isLoading: false,
+    }))
+    mockRouteParams = { slug: 'test-agent' }
+    renderWithProviders(<AppSidebar />)
+  }
+
+  it('opens the session context menu, hiding the session indicator behind it', async () => {
+    renderExpandedAgent()
+    // The awaiting dot owns the slot until the menu opens.
+    expect(screen.getByTestId('awaiting-dot').parentElement).not.toHaveClass('opacity-0')
+
+    await userEvent.click(screen.getByTestId('session-menu-button-session-1'))
+
+    expect(screen.getByTestId('awaiting-dot').parentElement).toHaveClass('opacity-0')
+  })
+
+  it('keeps the button a sibling of the session link, never nested inside it', () => {
+    renderExpandedAgent()
+    const row = screen.getByTestId('session-item-session-1')
+    const button = screen.getByTestId('session-menu-button-session-1')
+    // A <button> inside the row's <a> would be invalid markup and its click
+    // would navigate; the row must stay a single interactive element.
+    expect(row.contains(button)).toBe(false)
+    expect(button).toHaveAccessibleName('Options for Session 1')
   })
 })
 

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -61,6 +61,7 @@ import { AgentStatus } from '@renderer/components/agents/agent-status'
 import { WorkingDots, AwaitingDot } from '@renderer/components/agents/status-indicators'
 import { SIDEBAR_TREE_CONNECTORS } from '@renderer/components/ui/tree-connectors'
 import { AgentContextMenu } from '@renderer/components/agents/agent-context-menu'
+import { SessionMenuButton } from '@renderer/components/sessions/session-menu-button'
 import { SessionContextMenu } from '@renderer/components/sessions/session-context-menu'
 import { DashboardContextMenu } from '@renderer/components/dashboards/dashboard-context-menu'
 import { useQueryClient } from '@tanstack/react-query'
@@ -212,10 +213,26 @@ function SessionSubItem({
     disabled: isAwaitingInput,
   })
 
+  // Right-click on the row was the only way into the session menu, which
+  // nobody discovers. A 3-dot button takes over the indicator slot on hover
+  // and opens that same menu by replaying a contextmenu on the row (see
+  // SessionMenuButton) — one menu surface, not two.
+  const [menuOpen, setMenuOpen] = useState(false)
+  const rowRef = React.useRef<HTMLAnchorElement | null>(null)
+  const setRowRef = useCallback(
+    (element: HTMLAnchorElement | null) => {
+      rowRef.current = element
+      hintRef(element)
+    },
+    [hintRef]
+  )
+
   return (
+    // The <li> is the 3-dot's positioning box (the tree connectors already make
+    // it relative; spelled out so that stays true without them).
     <SidebarMenuSubItem
       {...dragHandlers}
-      className={cn('rounded-md', SIDEBAR_FILE_DROP_CUE)}
+      className={cn('relative rounded-md group/session-row', SIDEBAR_FILE_DROP_CUE)}
     >
       <SessionContextMenu
         sessionId={session.id}
@@ -226,13 +243,18 @@ function SessionSubItem({
           isAwaitingInput: !!session.isAwaitingInput,
           isStreaming,
         }}
+        onOpenChange={setMenuOpen}
       >
         <SidebarMenuSubButton
           asChild
           isActive={isSelected}
+          // The 3-dot is a sibling painted over the row (the row must stay a
+          // single <a>), so pointing at it un-hovers the row itself and its
+          // background would drop out; the wrapper holds the wash instead.
+          className="group-hover/session-row:bg-sidebar-accent group-hover/session-row:text-sidebar-accent-foreground"
         >
           <AppLink
-            ref={hintRef}
+            ref={setRowRef}
             to="/agents/$slug/sessions/$sessionId"
             params={{ slug: agentSlug, sessionId: session.id }}
             className="flex items-center gap-2 w-full"
@@ -248,7 +270,15 @@ function SessionSubItem({
             {hint !== null ? (
               <CmdHintBadge hint={hint} />
             ) : (
-              <span className="flex items-center justify-center gap-1 min-w-4 shrink-0">
+              // Yields the slot to the 3-dot button on hover (and for as long
+              // as the menu it opened stays open).
+              <span
+                className={cn(
+                  'flex items-center justify-center gap-1 min-w-4 shrink-0 transition-opacity',
+                  'group-hover/session-row:opacity-0',
+                  menuOpen && 'opacity-0'
+                )}
+              >
                 {showPendingWake && (
                   <span
                     className="flex items-center"
@@ -272,6 +302,35 @@ function SessionSubItem({
           </AppLink>
         </SidebarMenuSubButton>
       </SessionContextMenu>
+      {/*
+        Sibling of the row link (never nested inside it), sitting over the
+        indicator slot the row just faded out. Hidden while the cmd-hint
+        overlay owns that slot.
+      */}
+      {hint === null && (
+        <SessionMenuButton
+          triggerRef={rowRef}
+          sessionName={session.name}
+          menuOpen={menuOpen}
+          title="Session options"
+          // Spill to the right: a dropdown here would cover the rows below.
+          anchor="beside"
+          data-testid={`session-menu-button-${session.id}`}
+          iconClassName="h-3.5 w-3.5"
+          className={cn(
+            // right-1.5 + w-5 centers the icon on the min-w-4 indicator slot
+            // (the sub-button pads px-2), so the swap doesn't shift the row.
+            'absolute right-1.5 top-1/2 -translate-y-1/2 h-5 w-5 rounded-md',
+            'text-muted-foreground/60 opacity-0 transition-[opacity,background-color,color]',
+            // One step darker than the row wash it sits on; translucent so
+            // dark mode gets the same one-step contrast as a lighter chip.
+            'hover:bg-sidebar-foreground/10 hover:text-sidebar-foreground',
+            'group-hover/session-row:opacity-100 focus-visible:opacity-100',
+            'focus-visible:ring-2 focus-visible:ring-sidebar-ring outline-none',
+            menuOpen && 'opacity-100 text-sidebar-foreground'
+          )}
+        />
+      )}
     </SidebarMenuSubItem>
   )
 }

--- a/src/renderer/components/sessions/related-sessions.tsx
+++ b/src/renderer/components/sessions/related-sessions.tsx
@@ -1,9 +1,11 @@
 import { useMemo, useRef, useState } from 'react'
-import { MessageSquare, ChevronLeft, ChevronRight, MoreVertical, MoonStar } from 'lucide-react'
+import { MessageSquare, ChevronLeft, ChevronRight, MoonStar } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 import { WorkingDots, AwaitingDot } from '@renderer/components/agents/status-indicators'
 import { HighlightMatch } from '@renderer/components/ui/highlight-match'
-import { Button } from '@renderer/components/ui/button'
+import { Button, buttonVariants } from '@renderer/components/ui/button'
+import { SessionMenuButton } from '@renderer/components/sessions/session-menu-button'
+import { cn } from '@shared/lib/utils/cn'
 import {
   Select,
   SelectContent,
@@ -145,9 +147,15 @@ function SessionRow({ session, showIcon, formatDate, agentSlug: agentSlugProp, s
       void navigate({ to: '/agents/$slug/sessions/$sessionId', params: { slug: agentSlug, sessionId: id } })
     }
   }
+  // The row is the SessionContextMenu's trigger; its 3-dot replays a click as
+  // a contextmenu on it (see SessionMenuButton). menuOpen keeps the
+  // hover-revealed button on screen while the menu it opened is up.
+  const rowRef = useRef<HTMLDivElement>(null)
+  const [menuOpen, setMenuOpen] = useState(false)
 
   const row = (
     <div
+      ref={rowRef}
       role="button"
       tabIndex={0}
       className="group relative w-full flex items-center gap-3 py-3 px-1 hover:bg-muted/50 transition-colors text-left cursor-pointer"
@@ -199,33 +207,23 @@ function SessionRow({ session, showIcon, formatDate, agentSlug: agentSlugProp, s
         )}
       </div>
       {agentSlug && (
-        <div className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 touch:opacity-100 transition-opacity">
+        <div
+          className={cn(
+            'absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 touch:opacity-100 transition-opacity',
+            menuOpen && 'opacity-100'
+          )}
+        >
           {/* Three-dot = the same session menu a right-click on this row (or
-              the sidebar row) opens, so the two never drift apart. A click
-              replays as a contextmenu event that bubbles to the row's trigger,
-              anchored under this button. */}
-          <Button
-            type="button"
-            size="icon"
-            variant="outline"
-            className="h-6 w-6"
-            aria-label={`Actions for ${session.name}`}
+              the sidebar row) opens, so the two never drift apart. */}
+          <SessionMenuButton
+            triggerRef={rowRef}
+            sessionName={session.name}
+            menuOpen={menuOpen}
+            title="Session options"
             data-testid={`session-row-menu-${session.id}`}
-            onClick={(e) => {
-              e.stopPropagation()
-              const rect = e.currentTarget.getBoundingClientRect()
-              e.currentTarget.dispatchEvent(
-                new MouseEvent('contextmenu', {
-                  bubbles: true,
-                  cancelable: true,
-                  clientX: rect.left,
-                  clientY: rect.bottom + 4,
-                })
-              )
-            }}
-          >
-            <MoreVertical className="h-3.5 w-3.5" />
-          </Button>
+            iconClassName="h-3.5 w-3.5"
+            className={cn(buttonVariants({ variant: 'outline', size: 'icon' }), 'h-6 w-6')}
+          />
         </div>
       )}
     </div>
@@ -245,6 +243,7 @@ function SessionRow({ session, showIcon, formatDate, agentSlug: agentSlugProp, s
         // The list has no stream handle; a session mid-stream is also isActive.
         isStreaming: false,
       }}
+      onOpenChange={setMenuOpen}
     >
       {row}
     </SessionContextMenu>

--- a/src/renderer/components/sessions/session-context-menu.test.tsx
+++ b/src/renderer/components/sessions/session-context-menu.test.tsx
@@ -402,3 +402,22 @@ describe('Fork Session item', () => {
     err.mockRestore()
   })
 })
+
+describe('SessionContextMenu onOpenChange', () => {
+  it('reports the menu opening so a hover-revealed trigger can stay visible', async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ totalCost: 0, totalTokens: 0, priceMissing: false, usageIncomplete: false }),
+    })
+    const onOpenChange = vi.fn()
+    render(
+      <SessionContextMenu sessionId="session-1" sessionName="Session One" agentSlug="agent-1" activity={IDLE} onOpenChange={onOpenChange}>
+        <button type="button">Session One</button>
+      </SessionContextMenu>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open context menu' }))
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(true))
+  })
+})

--- a/src/renderer/components/sessions/session-context-menu.tsx
+++ b/src/renderer/components/sessions/session-context-menu.tsx
@@ -65,6 +65,13 @@ interface SessionContextMenuProps {
   agentSlug: string
   activity: SessionMenuActivity
   children: React.ReactNode
+  /**
+   * Reports the menu opening and closing. Call sites that reveal a trigger on
+   * hover (the 3-dot on a sidebar or list row) need this: once the menu is
+   * open Radix takes pointer events off the page, so `:hover` drops and a
+   * hover-only affordance would disappear out from under its own menu.
+   */
+  onOpenChange?: (open: boolean) => void
 }
 
 export function SessionContextMenu({
@@ -73,6 +80,7 @@ export function SessionContextMenu({
   agentSlug,
   activity,
   children,
+  onOpenChange,
 }: SessionContextMenuProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [showRenameDialog, setShowRenameDialog] = useState(false)
@@ -159,6 +167,7 @@ export function SessionContextMenu({
   }
 
   const handleMenuOpenChange = (open: boolean) => {
+    onOpenChange?.(open)
     if (!open) return
 
     const requestId = ++usageRequestRef.current

--- a/src/renderer/components/sessions/session-menu-button.test.tsx
+++ b/src/renderer/components/sessions/session-menu-button.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { createRef } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SessionMenuButton } from './session-menu-button'
+
+function renderButton(props: Partial<React.ComponentProps<typeof SessionMenuButton>> = {}) {
+  const triggerRef = createRef<HTMLAnchorElement>()
+  const onContextMenu = vi.fn((e: React.MouseEvent) => e.preventDefault())
+  const onTriggerClick = vi.fn()
+  // A link, like the sidebar row: the button's click must not navigate it.
+  render(
+    <a href="/agents/test-agent" ref={triggerRef} onContextMenu={onContextMenu} onClick={onTriggerClick}>
+      row
+      <SessionMenuButton triggerRef={triggerRef} sessionName="Session One" menuOpen={false} {...props} />
+    </a>
+  )
+  return { onContextMenu, onTriggerClick }
+}
+
+describe('SessionMenuButton', () => {
+  it('replays a click as a contextmenu event on the menu trigger', async () => {
+    const { onContextMenu, onTriggerClick } = renderButton()
+    await userEvent.click(screen.getByRole('button', { name: 'Options for Session One' }))
+    expect(onContextMenu).toHaveBeenCalledTimes(1)
+    // The click itself must not leak to the row (which may be a link).
+    expect(onTriggerClick).not.toHaveBeenCalled()
+  })
+
+  it('anchors the menu under the button by default and beside it on request', async () => {
+    const rect = { left: 100, right: 120, top: 10, bottom: 30 } as DOMRect
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(rect)
+
+    const below = renderButton()
+    await userEvent.click(screen.getByRole('button', { name: 'Options for Session One' }))
+    expect(below.onContextMenu.mock.calls[0][0]).toMatchObject({ clientX: 100, clientY: 34 })
+
+    const beside = renderButton({ anchor: 'beside', sessionName: 'Other' })
+    await userEvent.click(screen.getByRole('button', { name: 'Options for Other' }))
+    expect(beside.onContextMenu.mock.calls[0][0]).toMatchObject({ clientX: 120, clientY: 30 })
+
+    vi.restoreAllMocks()
+  })
+
+  it('reports the open menu through aria-expanded', () => {
+    renderButton({ menuOpen: true })
+    const button = screen.getByRole('button', { name: 'Options for Session One' })
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+    expect(button).toHaveAttribute('aria-haspopup', 'menu')
+  })
+})

--- a/src/renderer/components/sessions/session-menu-button.tsx
+++ b/src/renderer/components/sessions/session-menu-button.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react'
+import { MoreVertical } from 'lucide-react'
+import { cn } from '@shared/lib/utils/cn'
+
+/**
+ * Where the menu lands relative to the button.
+ *
+ * - `below`: top-left corner hangs 4px under the button's left edge — a
+ *   dropdown, for a button sitting in a row of a wide list (the agent home).
+ * - `beside`: top-left corner sits at the button's bottom-right — the menu
+ *   spills out to the right, for a button at the edge of a narrow column (a
+ *   sidebar row), where a dropdown would cover the rows beneath it.
+ */
+export type SessionMenuAnchor = 'below' | 'beside'
+
+export interface SessionMenuButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'children' | 'aria-label' | 'aria-haspopup' | 'aria-expanded'> {
+  /**
+   * The element the surface's `SessionContextMenu` wraps. A click on this
+   * button replays as a `contextmenu` event on it, anchored under the button.
+   */
+  triggerRef: React.RefObject<HTMLElement | null>
+  sessionName: string
+  /**
+   * Fed from the same `SessionContextMenu`'s `onOpenChange`. Drives `aria-expanded`,
+   * and lets a hover-revealed button stay visible while the menu it opened is
+   * up (Radix takes pointer events off the page, so `:hover` drops the moment
+   * the menu appears).
+   */
+  menuOpen: boolean
+  anchor?: SessionMenuAnchor
+  /** Sizing for the icon; the button's own box comes from `className`. */
+  iconClassName?: string
+}
+
+/**
+ * The 3-dot button that opens a session's menu. Every surface that shows one
+ * (the sidebar's session rows, the agent home's session list) renders this, so
+ * the way the menu is reached can't drift between them.
+ *
+ * It is deliberately not a menu trigger of its own: the surface already has a
+ * `SessionContextMenu` on right-click, and a second Radix menu next to it would
+ * be a second list to keep in sync. Instead the click synthesizes the
+ * `contextmenu` event the existing trigger listens for — the same trick
+ * `ui/context-menu.tsx` uses for its touch long-press — so right-click and the
+ * button open one and the same menu.
+ *
+ * Appearance belongs to the caller (a bare chip in the sidebar, an outline
+ * button on the agent home); behaviour and accessibility live here.
+ */
+export const SessionMenuButton = React.forwardRef<HTMLButtonElement, SessionMenuButtonProps>(
+  function SessionMenuButton(
+    { triggerRef, sessionName, menuOpen, anchor = 'below', iconClassName, className, ...rest },
+    ref
+  ) {
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+      // The button sits beside a link or inside a clickable row (the sidebar
+      // row is an <a>, the list row selects on click); neither the navigation
+      // nor the row's own click handler should fire.
+      event.preventDefault()
+      event.stopPropagation()
+      const trigger = triggerRef.current
+      if (!trigger) return
+      const rect = event.currentTarget.getBoundingClientRect()
+      const point =
+        anchor === 'beside'
+          ? { clientX: rect.right, clientY: rect.bottom }
+          : { clientX: rect.left, clientY: rect.bottom + 4 }
+      trigger.dispatchEvent(
+        new MouseEvent('contextmenu', { bubbles: true, cancelable: true, ...point })
+      )
+    }
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        onClick={handleClick}
+        aria-label={`Options for ${sessionName}`}
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        className={cn('inline-flex items-center justify-center', className)}
+        {...rest}
+      >
+        <MoreVertical className={cn('h-4 w-4', iconClassName)} />
+      </button>
+    )
+  }
+)

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -398,10 +398,16 @@ html[data-keyboard-open] [data-composer-footer] {
   background: rgba(0, 0, 0, 0.4) !important;
 }
 
-/* Semi-transparent hover/active states so vibrancy remains visible */
+/* Semi-transparent hover/active states so vibrancy remains visible.
+   The session row's ⋮ is a sibling painted over the row, so pointing at it
+   un-hovers the button itself. Without the `.group/session-row:hover` selector
+   below, this tint would drop out and the opaque Tailwind fallback
+   (bg-sidebar-accent, near-white) would paint instead — the row would flash
+   lighter the moment you reached for its menu. */
 .electron-vibrancy [data-sidebar="sidebar"] [data-sidebar="menu-button"]:hover,
 .electron-vibrancy [data-sidebar="sidebar"] [data-sidebar="menu-button"]:active,
 .electron-vibrancy [data-sidebar="sidebar"] [data-sidebar="menu-button"][data-active="true"],
+.electron-vibrancy [data-sidebar="sidebar"] .group\/session-row:hover [data-sidebar="menu-sub-button"],
 .electron-vibrancy [data-sidebar="sidebar"] [data-sidebar="menu-sub-button"]:hover,
 .electron-vibrancy [data-sidebar="sidebar"] [data-sidebar="menu-sub-button"]:active,
 .electron-vibrancy [data-sidebar="sidebar"] [data-sidebar="menu-sub-button"][data-active="true"],
@@ -412,6 +418,7 @@ html[data-keyboard-open] [data-composer-footer] {
 .electron-vibrancy.dark [data-sidebar="sidebar"] [data-sidebar="menu-button"]:hover,
 .electron-vibrancy.dark [data-sidebar="sidebar"] [data-sidebar="menu-button"]:active,
 .electron-vibrancy.dark [data-sidebar="sidebar"] [data-sidebar="menu-button"][data-active="true"],
+.electron-vibrancy.dark [data-sidebar="sidebar"] .group\/session-row:hover [data-sidebar="menu-sub-button"],
 .electron-vibrancy.dark [data-sidebar="sidebar"] [data-sidebar="menu-sub-button"]:hover,
 .electron-vibrancy.dark [data-sidebar="sidebar"] [data-sidebar="menu-sub-button"]:active,
 .electron-vibrancy.dark [data-sidebar="sidebar"] [data-sidebar="menu-sub-button"][data-active="true"],

--- a/src/renderer/test/setup.ts
+++ b/src/renderer/test/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { beforeEach, vi } from 'vitest'
-import { createElement } from 'react'
+import { createElement, forwardRef } from 'react'
 import { _resetApiTargetForTest, setActiveTarget } from '@renderer/lib/api-target'
 
 // Auth mode is now derived from the resolved API target, and reading it before
@@ -98,24 +98,34 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 // have neither, so stub it as a plain anchor that forwards the props tests
 // inspect (onClick, className, data-testid). A file-level vi.mock overrides this
 // where a test needs the real link.
-vi.mock('@renderer/components/ui/app-link', () => ({
+vi.mock('@renderer/components/ui/app-link', () => {
   // Strip the link-specific props so they don't land as DOM attributes; forward
-  // the rest (onClick/className/data-testid) to a plain anchor.
-  AppLink: ({ children, to, params, search, activeClassName: _ac, activeOptions: _ao, noDrag: _nd, ...props }: Record<string, unknown> & { children?: unknown }) =>
-    createElement(
-      'a',
-      {
-        href: '#',
-        // Expose the route target so tests can assert navigation (the real
-        // <a href> isn't built in jsdom; data-* attrs avoid React DOM warnings).
-        'data-to': to,
-        'data-params': params ? JSON.stringify(params) : undefined,
-        'data-search': search ? JSON.stringify(search) : undefined,
-        ...props,
-      },
-      children as never,
-    ),
-}))
+  // the rest (onClick/className/data-testid) to a plain anchor. forwardRef like
+  // the real AppLink: callers ref the anchor (the sidebar's cmd-hint targets and
+  // its row menu buttons both reach the row that way).
+  const AppLink = forwardRef(
+    (
+      { children, to, params, search, activeClassName: _ac, activeOptions: _ao, noDrag: _nd, ...props }: Record<string, unknown> & { children?: unknown },
+      ref,
+    ) =>
+      createElement(
+        'a',
+        {
+          ref,
+          href: '#',
+          // Expose the route target so tests can assert navigation (the real
+          // <a href> isn't built in jsdom; data-* attrs avoid React DOM warnings).
+          'data-to': to,
+          'data-params': params ? JSON.stringify(params) : undefined,
+          'data-search': search ? JSON.stringify(search) : undefined,
+          ...props,
+        },
+        children as never,
+      ),
+  )
+  AppLink.displayName = 'AppLink'
+  return { AppLink }
+})
 
 // DialogContext drives global settings via the router. Renderer unit
 // tests have no RouterProvider, so stub it — DialogProvider passes children


### PR DESCRIPTION
Right-click on a sidebar session row was the only way into the session menu, and nobody finds it. A 3-dot button now fades in on hover, takes over the indicator slot (working dots, awaiting dot, unread dot, pending-wake moon), and opens that same menu. Standalone; the agent-row counterpart is #782.

## How it works

**One menu surface, not two.** The button synthesizes the `contextmenu` event the row's Radix trigger already listens for — the same trick `ui/context-menu.tsx` uses for its touch long-press. Right-click and the button therefore can't drift apart in contents or behavior.

**One button component, not two.** The agent home's session list already had a 3-dot doing that replay by hand (#935). Both surfaces now render a shared `SessionMenuButton` (`src/renderer/components/sessions/session-menu-button.tsx`), which owns the replay, the aria wiring, and the icon. Each caller keeps its own look through `className` (a bare hover chip in the sidebar, an outline button in the list). The one real difference between them — where the menu lands — is an explicit `anchor` prop: `below` for the list row, `beside` for the sidebar, where a dropdown would cover the rows underneath. The list's button drops its one-off "Actions for {name}" label for the shared "Options for {name}"; its `session-row-menu-{id}` test id is unchanged, so the session-delete e2e still drives it.

**`SessionContextMenu` gains `onOpenChange`**, as `AgentContextMenu` already had: once the menu is open Radix takes pointer events off the page, so `:hover` drops and a hover-revealed button would vanish out from under its own menu. Both session-row buttons now stay put while their menu is up.

**The row keeps its background.** The 3-dot is a sibling painted over the row (the row must stay a single `<a>` — no nested interactive controls), so pointing at it un-hovers the row and its background drops out. The wash is driven from the `<li>` wrapper (`group/session-row`) instead, and the macOS vibrancy override in `globals.css` matches on that wrapper too, so the desktop row doesn't flash to the opaque fallback the moment you reach for the menu.

## Incidental

The shared `AppLink` test stub is now a `forwardRef` like the real component — it was silently swallowing refs, including the pre-existing cmd-hint target ref. (#782 carries the same fix; the hunks are identical, so whichever lands second merges clean.)

## Test plan

- `session-menu-button.test.tsx`: the click replays as a contextmenu on the trigger and does not leak to the row link; both anchor points; `aria-expanded` follows the menu.
- 2 new cases in `app-sidebar.test.tsx`: the button opens the menu and the indicator yields its slot; the button is never nested inside the session link.
- `session-context-menu.test.tsx`: `onOpenChange` fires when the menu opens.
- Full unit suite green (11540 tests); typecheck + lint clean.
- Verified on the web target — captures below. The vibrancy override is Electron-only and mirrors the agent-row selector verified by hand in #782.

## Screenshots

| Light | Dark |
| --- | --- |
| ![Sidebar session row hover (light)](https://github.com/user-attachments/assets/75b78e11-a945-4e81-9d63-45bb205b5380) | ![Sidebar session row hover (dark)](https://github.com/user-attachments/assets/a7ed16ac-784a-4051-a67b-7aec8133a189) |
| ![Sidebar session 3-dot menu (light)](https://github.com/user-attachments/assets/034ab40a-a377-423c-8f0d-a61613c5a712) | ![Sidebar session 3-dot menu (dark)](https://github.com/user-attachments/assets/d2ff5461-9ee5-436f-813b-9ddda593b743) |
| ![Agent home session list 3-dot menu (light)](https://github.com/user-attachments/assets/b2583440-2cc9-4945-a852-534793492caf) | ![Agent home session list 3-dot menu (dark)](https://github.com/user-attachments/assets/7ab1d3c1-1f08-4513-b271-a2c9669eca07) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
