### PR TITLE
Let the runtime own the mount list (SUP-790)

### DIFF
--- a/src/shared/lib/config/data-dir.test.ts
+++ b/src/shared/lib/config/data-dir.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { getCacheDir, getDataDir, getDatabasePath } from './data-dir'
+import { getCacheDir, getDataDir, getDatabasePath, storageSubPath } from './data-dir'
 
 describe('getDataDir / getDatabasePath', () => {
   const prevDataDir = process.env.SUPERAGENT_DATA_DIR
@@ -55,5 +56,53 @@ describe('getDataDir / getDatabasePath', () => {
     process.env.SUPERAGENT_CACHE_DIR = '/tmp/sa-cache'
     expect(getCacheDir()).toBe(path.resolve('/tmp/sa-cache'))
     expect(getDataDir()).toBe(path.resolve('/tmp/sa-data'))
+  })
+})
+
+describe('storageSubPath', () => {
+  let dataDir: string
+  let outside: string
+  const prev = process.env.SUPERAGENT_DATA_DIR
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-data-'))
+    outside = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-outside-'))
+    fs.mkdirSync(path.join(dataDir, 'volumes', 'abc'), { recursive: true })
+    process.env.SUPERAGENT_DATA_DIR = dataDir
+  })
+
+  afterEach(() => {
+    if (prev === undefined) delete process.env.SUPERAGENT_DATA_DIR
+    else process.env.SUPERAGENT_DATA_DIR = prev
+    fs.rmSync(dataDir, { recursive: true, force: true })
+    fs.rmSync(outside, { recursive: true, force: true })
+  })
+
+  it('maps a shared volume dir to volumes/<id>', () => {
+    expect(storageSubPath(path.join(dataDir, 'volumes', 'abc'))).toBe('volumes/abc')
+  })
+
+  it('resolves a symlinked data dir to the same sub-path', () => {
+    const link = path.join(os.tmpdir(), `sa-link-${process.pid}`)
+    fs.symlinkSync(dataDir, link)
+    try {
+      process.env.SUPERAGENT_DATA_DIR = link
+      expect(storageSubPath(path.join(link, 'volumes', 'abc'))).toBe('volumes/abc')
+      expect(storageSubPath(path.join(dataDir, 'volumes', 'abc'))).toBe('volumes/abc')
+    } finally {
+      fs.unlinkSync(link)
+    }
+  })
+
+  it('refuses a path outside the data dir', () => {
+    expect(storageSubPath(outside)).toBeNull()
+  })
+
+  it('refuses the data dir itself', () => {
+    expect(storageSubPath(dataDir)).toBeNull()
+  })
+
+  it('refuses a path that does not exist', () => {
+    expect(storageSubPath(path.join(dataDir, 'volumes', 'missing'))).toBeNull()
   })
 })

--- a/src/shared/lib/config/data-dir.ts
+++ b/src/shared/lib/config/data-dir.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import fs from 'fs'
 import os from 'os'
+import { isPathWithinDir } from '@shared/lib/utils/path-safety'
 
 /**
  * Get the data directory for Superagent.
@@ -51,6 +52,36 @@ export function getCacheDir(): string {
  */
 export function getAgentsDataDir(): string {
   return path.join(getDataDir(), 'agents')
+}
+
+/**
+ * Where an app-managed folder under the data dir sits on the shared org disk,
+ * as a path relative to the disk root, or null when a cloud runtime cannot
+ * mount it.
+ *
+ * The host app and every cloud agent mount the same disk, and the host app's
+ * data dir is that disk's root (the provisioner sets both to the same access
+ * point at /data). So a path under the data dir maps to a sub-path by
+ * stripping the data dir: volumes/<id>. The database and the skillset cache
+ * are deliberately placed outside the data dir, so this is only correct for
+ * folders the app itself created under it.
+ *
+ * Both sides are resolved through symlinks before comparing. The data dir
+ * itself is never a mount.
+ */
+export function storageSubPath(hostPath: string): string | null {
+  let root: string
+  let target: string
+  try {
+    root = fs.realpathSync(getDataDir())
+    target = fs.realpathSync(hostPath)
+  } catch {
+    return null
+  }
+  if (!isPathWithinDir(root, target)) return null
+  const rel = path.relative(root, target)
+  if (rel === '') return null
+  return rel.split(path.sep).join('/')
 }
 
 /**

--- a/src/shared/lib/container/base-container-client.test.ts
+++ b/src/shared/lib/container/base-container-client.test.ts
@@ -1,13 +1,45 @@
-import { describe, it, expect, afterEach, vi } from 'vitest'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
 import { writeEnvFile, parseMemoryValue, shellQuote, isConnectionError, getEnhancedPath, BaseContainerClient } from './base-container-client'
 import type { ContainerInfo, ContainerConfig, StreamMessage } from './types'
+import type { AgentMount } from '@shared/lib/types/mount'
 
 const enableToolSearch = vi.fn((): boolean | undefined => true)
 vi.mock('@shared/lib/config/settings', () => ({
-  getSettings: () => ({ enableToolSearch: enableToolSearch() }),
+  getSettings: () => ({
+    enableToolSearch: enableToolSearch(),
+    container: { agentImage: 'img', resourceLimits: { cpu: 1, memory: '1g' }, containerRunner: 'docker' },
+  }),
+}))
+
+const startHarness = vi.hoisted(() => ({
+  runCommands: [] as string[],
+  pendingRunError: null as Error | null,
+  workspaceDir: '',
+}))
+
+vi.mock('child_process', async (orig) => ({
+  ...(await orig<typeof import('child_process')>()),
+  exec: (cmd: string, ...rest: unknown[]) => {
+    const cb = rest[rest.length - 1] as (err: Error | null, result?: { stdout: string; stderr: string }) => void
+    if (typeof cmd === 'string' && cmd.includes(' run -d ')) {
+      startHarness.runCommands.push(cmd)
+      if (startHarness.pendingRunError) {
+        const err = startHarness.pendingRunError
+        startHarness.pendingRunError = null
+        cb(err)
+        return
+      }
+    }
+    cb(null, { stdout: 'container-id\n', stderr: '' })
+  },
+}))
+
+vi.mock('@shared/lib/config/data-dir', async (orig) => ({
+  ...(await orig<typeof import('@shared/lib/config/data-dir')>()),
+  getAgentWorkspaceDir: () => startHarness.workspaceDir,
 }))
 const getContainerEnvVars = vi.fn(() => ({ ANTHROPIC_API_KEY: 'provider-key' }))
 const toolSearchEnv = vi.fn((): 'true' | undefined => 'true')
@@ -977,5 +1009,119 @@ describe('BaseContainerClient.observeUnexpectedDeath', () => {
       action: 'ignore',
       liveSessionIds: ['live'],
     })
+  })
+})
+
+function inaccessibleMountError(hostPath: string): Error {
+  return Object.assign(new Error(`failed to stat "${hostPath}": operation not permitted`), { stderr: '' })
+}
+
+function makeStartHarness() {
+  const envFiles: Record<string, string>[] = []
+  startHarness.runCommands.length = 0
+  startHarness.pendingRunError = null
+
+  class StartTestClient extends BaseContainerClient {
+    protected getRunnerCommand(): string {
+      return 'docker'
+    }
+    protected getRunnerShellCommand(): string {
+      return 'docker'
+    }
+    protected async ensureImageExistsWithRecovery(): Promise<void> {}
+    protected async getUsedPorts(): Promise<Set<number>> {
+      return new Set()
+    }
+    async getInfo(): Promise<ContainerInfo> {
+      return { status: 'stopped', port: null }
+    }
+    async waitForHealthy(): Promise<boolean> {
+      return true
+    }
+    // A runtime echoes the path in the form it was handed (hostPathForRuntime),
+    // so the extractor is a plain match; the loop compares in that form.
+    protected extractInaccessibleMountPath(error: unknown): string | null {
+      const message = error instanceof Error ? error.message : String(error)
+      return message.match(/stat "([^"]+)"/)?.[1] ?? null
+    }
+    public runtimeForm(hostPath: string): string {
+      return this.hostPathForRuntime(hostPath)
+    }
+    protected buildEnvFile(env?: Record<string, string>): { flag: string; cleanup: () => void } {
+      envFiles.push({ ...(env ?? {}) })
+      return { flag: '--env-file /dev/null', cleanup: () => {} }
+    }
+  }
+
+  const client = new StartTestClient({ agentId: 'agent-1' })
+  return {
+    client,
+    runCommands: startHarness.runCommands,
+    envFiles,
+    /** The runtime refuses `hostPath`, reporting it in runtime form. */
+    failFirstRunWith(hostPath: string) {
+      startHarness.pendingRunError = inaccessibleMountError(client.runtimeForm(hostPath))
+    },
+  }
+}
+
+describe('start() mounts', () => {
+  const projectMount: AgentMount = { id: 'm1', hostPath: '/host/project', containerPath: '/mounts/project', folderName: 'project', addedAt: '2026-01-01T00:00:00.000Z' }
+  const notesMount: AgentMount = { id: 'm2', hostPath: '/host/notes', containerPath: '/mounts/notes', folderName: 'notes', addedAt: '2026-01-01T00:00:00.000Z' }
+
+  beforeEach(() => {
+    startHarness.workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-ws-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(startHarness.workspaceDir, { recursive: true, force: true })
+  })
+
+  it('serialises every record and the workspace through buildVolumeFlag', async () => {
+    const { client, runCommands } = makeStartHarness()
+    await client.start({ mounts: [projectMount, notesMount] })
+    const cmd = runCommands[0]
+    expect(cmd).toContain(`-v ${client.buildVolumeFlag(startHarness.workspaceDir, '/workspace')}`)
+    expect(cmd).toContain(`-v ${client.buildVolumeFlag('/host/project', '/mounts/project')}`)
+    expect(cmd).toContain(`-v ${client.buildVolumeFlag('/host/notes', '/mounts/notes')}`)
+  })
+
+  it('writes SUPERAGENT_MOUNTS from the bound records into the env file', async () => {
+    const { client, envFiles } = makeStartHarness()
+    await client.start({ mounts: [projectMount, notesMount] })
+    expect(envFiles[0].SUPERAGENT_MOUNTS).toBe(JSON.stringify(['/mounts/project', '/mounts/notes']))
+  })
+
+  it('replaces a caller-supplied SUPERAGENT_MOUNTS rather than trusting it', async () => {
+    const { client, envFiles } = makeStartHarness()
+    await client.start({ envVars: { SUPERAGENT_MOUNTS: JSON.stringify(['/mounts/stale']) }, mounts: [projectMount] })
+    expect(envFiles[0].SUPERAGENT_MOUNTS).toBe(JSON.stringify(['/mounts/project']))
+  })
+
+  it('keeps a comma in a folder path as one env entry', async () => {
+    const { client, envFiles } = makeStartHarness()
+    await client.start({ mounts: [{ ...projectMount, containerPath: '/mounts/Acme, Inc' }] })
+    expect(envFiles[0].SUPERAGENT_MOUNTS).toBe(JSON.stringify(['/mounts/Acme, Inc']))
+  })
+
+  it('omits SUPERAGENT_MOUNTS when nothing is mounted', async () => {
+    const { client, envFiles } = makeStartHarness()
+    await client.start({ mounts: [] })
+    expect(envFiles[0]).not.toHaveProperty('SUPERAGENT_MOUNTS')
+  })
+
+  it.each([
+    ['a single quote', "/host/it's here"],
+    ['a backslash', '/host/back\\slash'],
+  ])('drops an inaccessible mount by host path (%s), rewrites the env, and retries', async (_label, hostPath) => {
+    const bad = { ...projectMount, hostPath }
+    const dropped: unknown[] = []
+    const { client, runCommands, envFiles, failFirstRunWith } = makeStartHarness()
+    failFirstRunWith(hostPath)
+    await client.start({ mounts: [bad, notesMount], onMountDropped: (m) => dropped.push(m) })
+    expect(dropped).toEqual([bad])
+    expect(runCommands).toHaveLength(2)
+    expect(runCommands[1]).not.toContain(client.buildVolumeFlag(hostPath, '/mounts/project'))
+    expect(envFiles[1].SUPERAGENT_MOUNTS).toBe(JSON.stringify(['/mounts/notes']))
   })
 })

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -6,6 +6,7 @@ import WebSocket from 'ws'
 import * as fs from 'fs'
 import os from 'os'
 import net from 'net'
+import type { AgentMount } from '@shared/lib/types/mount'
 import type {
   ContainerClient,
   ContainerConfig,
@@ -458,6 +459,20 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   }
 
   /**
+   * The agent's prompt lists exactly the mounts this runtime bound. The
+   * runtime sets the variable, not the caller, because only the runtime knows
+   * what it could realise.
+   */
+  protected withMountsEnv(envVars: Record<string, string> | undefined, accepted: AgentMount[]): Record<string, string> {
+    const env = { ...(envVars ?? {}) }
+    delete env.SUPERAGENT_MOUNTS
+    if (accepted.length > 0) {
+      env.SUPERAGENT_MOUNTS = JSON.stringify(accepted.map((m) => m.containerPath))
+    }
+    return env
+  }
+
+  /**
    * Returns resource limit flags for the container.
    * Subclasses can override if the runtime uses different flag syntax.
    */
@@ -721,18 +736,20 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       // Find an available port
       let port = await this.findAvailablePort()
 
-      // Write env vars to a temp file (avoids command length limits on Windows)
-      const { flag: envFileFlag, cleanup: cleanupEnvFile } = this.buildEnvFile(options?.envVars)
+      // Every mount the caller asked for. An inaccessible one (e.g. a
+      // cloud-synced folder the VM helper is denied) is dropped from this list
+      // on retry so the container can still start without it.
+      let mounts = [...(options?.mounts ?? [])]
+
+      // The env file (a temp file, to dodge command length limits on Windows)
+      // carries SUPERAGENT_MOUNTS for the bound list, so it is rewritten
+      // whenever that list shrinks.
+      let envFile = this.buildEnvFile(this.withMountsEnv(options?.envVars, mounts))
       const containerName = this.getContainerName()
 
       // Build resource limit flags
       const resourceFlags = this.getResourceFlags(cpu, memory)
       const additionalFlags = this.getAdditionalRunFlags()
-
-      // Mutable copy of bind-mount flags — an inaccessible mount (e.g. a
-      // cloud-synced folder the VM helper is denied) is dropped from this list
-      // on retry so the container can still start without it.
-      let volumes = [...(options?.additionalVolumes || [])]
 
       const buildRunCmd = () =>
         [
@@ -740,10 +757,10 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
           '--name', containerName,
           '-p', `${port}:${CONTAINER_INTERNAL_PORT}`,
           '-v', shellEscape(`${this.hostPathForRuntime(workspaceDir)}:/workspace${this.getVolumeMountSuffix()}`),
-          ...volumes.flatMap(v => ['-v', v]),
+          ...mounts.flatMap((m) => ['-v', this.buildVolumeFlag(m.hostPath, m.containerPath)]),
           resourceFlags,
           additionalFlags,
-          envFileFlag,
+          envFile.flag,
           image,
         ].filter(Boolean).join(' ')
 
@@ -768,17 +785,21 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
             break
           } catch (runError: any) {
             // 1. Inaccessible bind mount (e.g. iCloud/File Provider path the VM
-            //    can't stat). Drop that one mount and retry without it.
+            //    can't stat). The runtime reports the path in the form it was
+            //    given (hostPathForRuntime), so compare that form. Drop that
+            //    one mount, rewrite the env so the prompt matches, and retry.
             const badMountPath = this.extractInaccessibleMountPath(runError)
-            if (badMountPath) {
-              const before = volumes.length
-              volumes = volumes.filter((v) => !v.includes(badMountPath))
-              if (volumes.length < before) {
-                console.warn(`[Container] Dropping inaccessible mount and retrying: ${badMountPath}`)
-                addErrorBreadcrumb({ category: 'container', message: 'Dropped inaccessible mount, retrying', data: { hostPath: badMountPath, agentId: this.config.agentId } })
-                options?.onMountDropped?.(badMountPath)
-                continue
-              }
+            const dropped = badMountPath
+              ? mounts.find((m) => this.hostPathForRuntime(m.hostPath) === badMountPath)
+              : undefined
+            if (dropped) {
+              mounts = mounts.filter((m) => m !== dropped)
+              envFile.cleanup()
+              envFile = this.buildEnvFile(this.withMountsEnv(options?.envVars, mounts))
+              console.warn(`[Container] Dropping inaccessible mount and retrying: ${dropped.hostPath}`)
+              addErrorBreadcrumb({ category: 'container', message: 'Dropped inaccessible mount, retrying', data: { hostPath: dropped.hostPath, agentId: this.config.agentId } })
+              options?.onMountDropped?.(dropped)
+              continue
             }
 
             // 2. Host-port allocation race — re-pick a port (bounded).
@@ -831,7 +852,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
           }
         }
       } finally {
-        cleanupEnvFile()
+        envFile.cleanup()
       }
 
       console.log(`Started container ${stdout.trim()} on port ${port}`)

--- a/src/shared/lib/container/cloud-mounts.ts
+++ b/src/shared/lib/container/cloud-mounts.ts
@@ -1,0 +1,41 @@
+import type { AgentMount } from '@shared/lib/types/mount'
+import { storageSubPath } from '@shared/lib/config/data-dir'
+
+/**
+ * The MicroVM supervisor validates the whole volumes list and refuses the run
+ * hook on one bad entry, so every rule it applies is applied here first and a
+ * record that would fail there is dropped and reported instead. Same values
+ * as supervisor.py: _VOLUME_NAME_RE, _SUBPATH_RE, _MAX_VOLUMES.
+ */
+const VOLUME_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/
+const SUBPATH_RE = /^[A-Za-z0-9._/-]{1,256}$/
+const MAX_CLOUD_MOUNTS = 32
+
+/**
+ * What a cloud runtime (k8s, MicroVM) may bind: an app-managed record under
+ * /volumes/<name> whose host path sits in the shared volumes area of the org
+ * disk. Anything else (a host folder from a desktop install, a path outside
+ * the data dir, another agent's workspace inside it, a name or sub-path the
+ * supervisor refuses, a second record with the same name, one past the count
+ * limit) is dropped and reported. Both ends are checked because neither alone
+ * proves ownership: the container path is what the record claims, the host
+ * path is what it would actually expose.
+ */
+export function acceptCloudMounts(mounts: AgentMount[]): { accepted: Array<AgentMount & { subPath: string }>; dropped: AgentMount[] } {
+  const accepted: Array<AgentMount & { subPath: string }> = []
+  const dropped: AgentMount[] = []
+  const names = new Set<string>()
+  for (const mount of mounts) {
+    const name = mount.containerPath.startsWith('/volumes/') ? mount.containerPath.slice('/volumes/'.length) : null
+    const subPath = name && VOLUME_NAME_RE.test(name) && !names.has(name) && accepted.length < MAX_CLOUD_MOUNTS
+      ? storageSubPath(mount.hostPath)
+      : null
+    if (subPath?.startsWith('volumes/') && SUBPATH_RE.test(subPath)) {
+      names.add(name!)
+      accepted.push({ ...mount, subPath })
+    } else {
+      dropped.push(mount)
+    }
+  }
+  return { accepted, dropped }
+}

--- a/src/shared/lib/container/container-manager-concurrency.test.ts
+++ b/src/shared/lib/container/container-manager-concurrency.test.ts
@@ -22,7 +22,6 @@ const mockStart = vi.fn().mockImplementation(() => {
 const mockStop = vi.fn().mockResolvedValue({ forceStopUsed: false })
 const mockGetInfoFromRuntime = vi.fn()
 const mockGetStats = vi.fn()
-const mockBuildVolumeFlag = vi.fn((hostPath: string, containerPath: string) => `"${hostPath}:${containerPath}"`)
 
 vi.mock('./client-factory', () => ({
   createContainerClient: () => ({
@@ -33,7 +32,6 @@ vi.mock('./client-factory', () => ({
     getStats: mockGetStats,
     fetch: vi.fn(),
     getHostApiBaseUrl: () => 'http://127.0.0.1:3000',
-    buildVolumeFlag: (...args: unknown[]) => mockBuildVolumeFlag(...args as [string, string]),
     createSession: vi.fn(),
     onFatalResult: () => 'settle',
     observeUnexpectedDeath: async () => ({ action: 'settle' as const }),

--- a/src/shared/lib/container/container-manager.reserved-env.sup210.test.ts
+++ b/src/shared/lib/container/container-manager.reserved-env.sup210.test.ts
@@ -14,9 +14,6 @@ const mockStopSync = vi.fn()
 const mockGetInfoFromRuntime = vi.fn()
 const mockGetStats = vi.fn()
 const mockIsHealthy = vi.fn()
-const mockBuildVolumeFlag = vi.fn(
-  (hostPath: string, containerPath: string) => `"${hostPath}:${containerPath}"`
-)
 
 vi.mock('./client-factory', () => ({
   createContainerClient: () => ({
@@ -31,7 +28,6 @@ vi.mock('./client-factory', () => ({
     getRuntimeGenerationId: () => null,
     fetch: vi.fn(),
     getHostApiBaseUrl: () => `http://${mockGetContainerHostUrl()}:${mockGetAppPort()}`,
-    buildVolumeFlag: (...args: unknown[]) => mockBuildVolumeFlag(...(args as [string, string])),
   }),
   checkAllRunnersAvailability: vi.fn().mockResolvedValue([]),
   checkImageExists: vi.fn().mockResolvedValue(true),

--- a/src/shared/lib/container/container-manager.test.ts
+++ b/src/shared/lib/container/container-manager.test.ts
@@ -13,8 +13,6 @@ const mockIsHealthy = vi.fn()
 
 const mockClearRunnerAvailabilityCache = vi.fn()
 
-const mockBuildVolumeFlag = vi.fn((hostPath: string, containerPath: string) => `"${hostPath}:${containerPath}"`)
-
 vi.mock('./client-factory', () => ({
   createContainerClient: () => ({
     start: mockStart,
@@ -28,7 +26,6 @@ vi.mock('./client-factory', () => ({
     getRuntimeGenerationId: () => null,
     fetch: vi.fn(),
     getHostApiBaseUrl: () => `http://${mockGetContainerHostUrl()}:${mockGetAppPort()}`,
-    buildVolumeFlag: (...args: unknown[]) => mockBuildVolumeFlag(...args as [string, string]),
   }),
   getContainerClientClass: () => ({ requiresLocalImage: true }),
   checkAllRunnersAvailability: vi.fn().mockResolvedValue([]),
@@ -473,55 +470,26 @@ describe('containerManager.ensureRunning — mount volumes', () => {
     mockMcpWhere.mockResolvedValue([])
   })
 
-  it('passes additionalVolumes from healthy mounts to client.start()', async () => {
-    mockGetMountsWithHealth.mockReturnValue([
-      { id: 'm1', hostPath: '/host/project', containerPath: '/mounts/project', folderName: 'project', addedAt: '2025-01-01', health: 'ok' },
-    ])
+  const ok = { id: 'm1', hostPath: '/host/ok', containerPath: '/mounts/ok', folderName: 'ok', addedAt: '2025-01-01' }
+  const gone = { id: 'm2', hostPath: '/host/gone', containerPath: '/mounts/gone', folderName: 'gone', addedAt: '2025-01-01' }
+
+  it('hands healthy records to client.start() and leaves SUPERAGENT_MOUNTS to the runtime', async () => {
+    mockGetMountsWithHealth.mockReturnValue([{ ...ok, health: 'ok' }, { ...gone, health: 'missing' }])
 
     await containerManager.ensureRunning('test-agent')
 
     expect(mockStart).toHaveBeenCalledOnce()
     const opts = mockStart.mock.calls[0][0]
-    expect(opts.additionalVolumes).toHaveLength(1)
-    // The volume flag is produced by buildVolumeFlag which we can't inspect exactly
-    // since the client is mocked, but it should be an array of strings
-    expect(typeof opts.additionalVolumes[0]).toBe('string')
-  })
-
-  it('tells the agent about mounted folders through SUPERAGENT_MOUNTS, healthy ones only', async () => {
-    mockGetMountsWithHealth.mockReturnValue([
-      { id: 'm1', hostPath: '/host/ok', containerPath: '/mounts/ok', folderName: 'ok', addedAt: '2025-01-01', health: 'ok' },
-      { id: 'm2', hostPath: '/host/gone', containerPath: '/mounts/gone', folderName: 'gone', addedAt: '2025-01-01', health: 'missing' },
-    ])
-
-    await containerManager.ensureRunning('test-agent')
-
-    const opts = mockStart.mock.calls[0][0]
-    expect(opts.envVars.SUPERAGENT_MOUNTS).toBe(JSON.stringify(['/mounts/ok']))
-  })
-
-  it('sets no SUPERAGENT_MOUNTS when nothing is mounted', async () => {
-    mockGetMountsWithHealth.mockReturnValue([])
-
-    await containerManager.ensureRunning('test-agent')
-
-    const opts = mockStart.mock.calls[0][0]
+    expect(opts.mounts).toEqual([{ ...ok, health: 'ok' }])
     expect(opts.envVars).not.toHaveProperty('SUPERAGENT_MOUNTS')
+    expect(opts).not.toHaveProperty('additionalVolumes')
   })
 
   it('skips missing mounts and broadcasts warning', async () => {
-    mockGetMountsWithHealth.mockReturnValue([
-      { id: 'm1', hostPath: '/host/ok', containerPath: '/mounts/ok', folderName: 'ok', addedAt: '2025-01-01', health: 'ok' },
-      { id: 'm2', hostPath: '/host/gone', containerPath: '/mounts/gone', folderName: 'gone', addedAt: '2025-01-01', health: 'missing' },
-    ])
+    mockGetMountsWithHealth.mockReturnValue([{ ...ok, health: 'ok' }, { ...gone, health: 'missing' }])
 
     await containerManager.ensureRunning('test-agent')
 
-    const opts = mockStart.mock.calls[0][0]
-    // Only healthy mount should be in volumes
-    expect(opts.additionalVolumes).toHaveLength(1)
-
-    // Should broadcast mount health warning
     const broadcasts = vi.mocked(messagePersister.broadcastGlobal).mock.calls
     const mountWarnings = broadcasts.filter(([msg]: any) => msg.type === 'mount_health_warning')
     expect(mountWarnings).toHaveLength(1)
@@ -532,13 +500,55 @@ describe('containerManager.ensureRunning — mount volumes', () => {
     })
   })
 
-  it('passes empty additionalVolumes when no mounts exist', async () => {
+  it('shows every record the runtime dropped together with the missing ones in one banner', async () => {
+    const ok2 = { ...ok, id: 'm3', hostPath: '/host/ok2', containerPath: '/mounts/ok2', folderName: 'ok2' }
+    mockGetMountsWithHealth.mockReturnValue([{ ...ok, health: 'ok' }, { ...ok2, health: 'ok' }, { ...gone, health: 'missing' }])
+    mockStart.mockImplementationOnce(async (opts: { onMountDropped: (m: unknown) => void }) => {
+      opts.onMountDropped({ ...ok, health: 'ok' })
+      opts.onMountDropped({ ...ok2, health: 'ok' })
+      return { status: 'running', port: 3000 }
+    })
+
+    await containerManager.ensureRunning('test-agent')
+
+    const broadcasts = vi.mocked(messagePersister.broadcastGlobal).mock.calls
+    const mountWarnings = broadcasts.filter(([msg]: any) => msg.type === 'mount_health_warning')
+    // The renderer keeps only the latest banner, so the last one carries everything.
+    expect(mountWarnings).toHaveLength(2)
+    expect(mountWarnings[1][0]).toMatchObject({
+      missingMounts: [
+        { folderName: 'gone', hostPath: '/host/gone' },
+        { folderName: 'ok', hostPath: '/host/ok' },
+        { folderName: 'ok2', hostPath: '/host/ok2' },
+      ],
+    })
+  })
+
+  it('still reports what the runtime dropped when the start then fails', async () => {
+    mockGetMountsWithHealth.mockReturnValue([{ ...ok, health: 'ok' }])
+    mockStart.mockImplementationOnce(async (opts: { onMountDropped: (m: unknown) => void }) => {
+      opts.onMountDropped({ ...ok, health: 'ok' })
+      throw new Error('health check timed out')
+    })
+
+    await expect(containerManager.ensureRunning('test-agent')).rejects.toThrow('health check timed out')
+
+    const broadcasts = vi.mocked(messagePersister.broadcastGlobal).mock.calls
+    const mountWarnings = broadcasts.filter(([msg]: any) => msg.type === 'mount_health_warning')
+    expect(mountWarnings).toHaveLength(1)
+    expect(mountWarnings[0][0]).toMatchObject({
+      missingMounts: [{ folderName: 'ok', hostPath: '/host/ok' }],
+    })
+  })
+
+  it('passes an empty mounts list when no mounts exist', async () => {
     mockGetMountsWithHealth.mockReturnValue([])
 
     await containerManager.ensureRunning('test-agent')
 
     const opts = mockStart.mock.calls[0][0]
-    expect(opts.additionalVolumes).toEqual([])
+    expect(opts.mounts).toEqual([])
+    expect(opts.envVars).not.toHaveProperty('SUPERAGENT_MOUNTS')
   })
 })
 

--- a/src/shared/lib/container/container-manager.ts
+++ b/src/shared/lib/container/container-manager.ts
@@ -692,52 +692,48 @@ class ContainerManager {
 
       envVars['CLAUDE_CODE_ATTRIBUTION_HEADER'] = '0'
 
-      // Load mounts and build volume flags for healthy ones
-      const mountsWithHealth = await getMountsWithHealth(agentId)
-      const healthyMounts = mountsWithHealth.filter((m) => m.health === 'ok')
-      const missingMounts = mountsWithHealth.filter((m) => m.health === 'missing')
-
-      if (missingMounts.length > 0) {
-        console.warn(`[ContainerManager] Skipping ${missingMounts.length} missing mount(s) for ${agentId}:`, missingMounts.map((m) => m.hostPath))
+      // Every mount record, health stamped once. A record whose host folder is
+      // missing is skipped here; one whose folder exists but the runtime cannot
+      // realise (a cloud-synced folder the VM helper is denied) is dropped by
+      // the runtime and reported back through onMountDropped. The runtime also
+      // owns SUPERAGENT_MOUNTS, so the prompt lists only what was bound. The
+      // container starts in both cases.
+      const records = await getMountsWithHealth(agentId)
+      const mounts = records.filter((m) => m.health === 'ok')
+      const missing = records.filter((m) => m.health === 'missing')
+      const warn = (dropped: Array<{ folderName: string; hostPath: string }>, hint?: string) => {
         messagePersister.broadcastGlobal({
           type: 'mount_health_warning',
           agentSlug: agentId,
-          missingMounts: missingMounts.map((m) => ({ folderName: m.folderName, hostPath: m.hostPath })),
+          missingMounts: dropped.map((m) => ({ folderName: m.folderName, hostPath: m.hostPath })),
+          ...(hint ? { hint } : {}),
         })
       }
 
-      const additionalVolumes = healthyMounts.map((m) =>
-        client.buildVolumeFlag(m.hostPath, m.containerPath)
-      )
-
-      // The prompt lists the mounted folders. A mount the runtime drops at run
-      // time (below) is still listed; the warning banner covers that case.
-      if (healthyMounts.length > 0) {
-        envVars['SUPERAGENT_MOUNTS'] = JSON.stringify(healthyMounts.map((m) => m.containerPath))
+      if (missing.length > 0) {
+        console.warn(`[ContainerManager] Skipping ${missing.length} missing mount(s) for ${agentId}:`, missing.map((m) => m.hostPath))
+        warn(missing)
       }
 
       // Start container (user secrets are in .env file in workspace).
-      // If a mount turns out to be inaccessible to the container runtime at run
-      // time (e.g. a cloud-synced folder the Lima VM helper is denied — passes
-      // the host health check but fails EPERM-on-stat inside the VM), start()
-      // drops that one mount and the container still comes up. Surface the same
-      // mount-health warning banner with a macOS-specific hint instead of
-      // failing the whole agent.
+      // The renderer keeps one banner per agent, so records the runtime drops
+      // are collected and shown together with the missing ones once start
+      // settles, rather than one banner per drop replacing the last. A start
+      // that fails after dropping still reports what it dropped.
+      const dropped: Array<{ folderName: string; hostPath: string }> = []
       const startedInfo = await client.start({
         envVars,
-        additionalVolumes,
-        onMountDropped: (hostPath) => {
-          const dropped = healthyMounts.find((m) => m.hostPath === hostPath)
-          console.warn(`[ContainerManager] Mount inaccessible to runtime, dropped for ${agentId}: ${hostPath}`)
-          messagePersister.broadcastGlobal({
-            type: 'mount_health_warning',
-            agentSlug: agentId,
-            missingMounts: [{ folderName: dropped?.folderName ?? hostPath, hostPath }],
-            hint: process.platform === 'darwin'
-              ? 'This folder is in iCloud Drive or a cloud-synced location, which can’t be shared into the agent sandbox. Move it to a regular local folder.'
-              : undefined,
-          })
+        mounts,
+        onMountDropped: (mount) => {
+          console.warn(`[ContainerManager] Mount inaccessible to runtime, dropped for ${agentId}: ${mount.hostPath}`)
+          dropped.push(mount)
         },
+      }).finally(() => {
+        if (dropped.length > 0) {
+          warn([...missing, ...dropped], process.platform === 'darwin'
+            ? 'This folder is in iCloud Drive or a cloud-synced location, which can’t be shared into the agent sandbox. Move it to a regular local folder.'
+            : undefined)
+        }
       })
 
       // Stop won the race: do not cache/broadcast running for a port about to die.

--- a/src/shared/lib/container/lambda-microvm-runtime.test.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.test.ts
@@ -29,6 +29,11 @@ vi.mock('@aws-sdk/client-lambda-microvms', () => {
   }
 })
 
+const { mockStorageSubPath } = vi.hoisted(() => ({ mockStorageSubPath: vi.fn((_p: string): string | null => null) }))
+vi.mock('@shared/lib/config/data-dir', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@shared/lib/config/data-dir')>()),
+  storageSubPath: (p: string) => mockStorageSubPath(p),
+}))
 vi.mock('@shared/lib/error-reporting', () => ({ captureException: vi.fn(), addErrorBreadcrumb: vi.fn() }))
 // Inert: the env builder reaches for the active provider; we don't assert its
 // output here (that's the builder's concern), we only verify the runtime
@@ -85,6 +90,7 @@ beforeEach(() => {
   for (const k of TOUCHED) delete process.env[k]
   for (const k in responses) delete responses[k]
   autoSleepTimeoutMinutes.mockReturnValue(30)
+  mockStorageSubPath.mockImplementation((p) => p.startsWith('/data/') ? p.slice('/data/'.length) : null)
   sendMock.mockReset()
   tlsConnectMock.mockReset()
   sendMock.mockImplementation(async (cmd: { type: string }) => {
@@ -391,6 +397,72 @@ describe('LambdaMicroVmRuntimeClient lifecycle', () => {
     await newClient().start()
     const input = sendMock.mock.calls.find((c) => c[0].type === 'Run')![0].input
     expect(JSON.parse(input.runHookPayload).mount).toBeUndefined()
+  })
+
+  it('rides accepted records on the mount object and sets SUPERAGENT_MOUNTS in the stashed env', async () => {
+    Object.assign(process.env, { MICROVM_FS_ID: 'fs-1', MICROVM_ACCESS_POINT: 'fsap-1', MICROVM_MOUNT_TARGET_IP: '10.0.0.5' })
+    resetMicrovmRuntimeForTests()
+    await newClient().start({
+      envVars: { PROXY_TOKEN: 't', SUPERAGENT_MOUNTS: JSON.stringify(['/mounts/stale']) },
+      mounts: [{ id: 'vol-1', hostPath: '/data/volumes/vol-1', containerPath: '/volumes/team-brain', folderName: 'Team brain', addedAt: '2026-01-01' }],
+    })
+    const input = sendMock.mock.calls.find((c) => c[0].type === 'Run')![0].input
+    const payload = JSON.parse(input.runHookPayload)
+    expect(payload.mount.volumes).toEqual([{ subPath: 'volumes/vol-1', name: 'team-brain' }])
+    expect(readBootstrapEnv('agent-xyz')!.SUPERAGENT_MOUNTS).toBe(JSON.stringify(['/volumes/team-brain']))
+  })
+
+  it('drops a /mounts record and reports it', async () => {
+    Object.assign(process.env, { MICROVM_FS_ID: 'fs-1', MICROVM_ACCESS_POINT: 'fsap-1', MICROVM_MOUNT_TARGET_IP: '10.0.0.5' })
+    resetMicrovmRuntimeForTests()
+    const dropped: unknown[] = []
+    const folder = { id: 'm1', hostPath: '/data/agents/other/workspace', containerPath: '/mounts/other', folderName: 'other', addedAt: '2026-01-01' }
+    await newClient().start({ envVars: { PROXY_TOKEN: 't' }, mounts: [folder], onMountDropped: (m) => dropped.push(m) })
+    expect(dropped).toEqual([folder])
+    const input = sendMock.mock.calls.find((c) => c[0].type === 'Run')![0].input
+    expect(JSON.parse(input.runHookPayload).mount).not.toHaveProperty('volumes')
+    expect(readBootstrapEnv('agent-xyz')).not.toHaveProperty('SUPERAGENT_MOUNTS')
+  })
+
+  it('drops every record and lists none when storage is unconfigured', async () => {
+    Object.assign(process.env, { MICROVM_FS_ID: 'fs-1' })
+    resetMicrovmRuntimeForTests()
+    const dropped: unknown[] = []
+    const shared = { id: 'vol-1', hostPath: '/data/volumes/vol-1', containerPath: '/volumes/team-brain', folderName: 'Team brain', addedAt: '2026-01-01' }
+    await newClient().start({ envVars: { PROXY_TOKEN: 't' }, mounts: [shared], onMountDropped: (m) => dropped.push(m) })
+    expect(dropped).toEqual([shared])
+    expect(readBootstrapEnv('agent-xyz')).not.toHaveProperty('SUPERAGENT_MOUNTS')
+  })
+
+  it('omits mount.volumes when no volumes are attached (old-host shape)', async () => {
+    Object.assign(process.env, { MICROVM_FS_ID: 'fs-1', MICROVM_ACCESS_POINT: 'fsap-1', MICROVM_MOUNT_TARGET_IP: '10.0.0.5' })
+    resetMicrovmRuntimeForTests()
+    await newClient().start()
+    const input = sendMock.mock.calls.find((c) => c[0].type === 'Run')![0].input
+    expect(JSON.parse(input.runHookPayload).mount).not.toHaveProperty('volumes')
+  })
+
+  it('fits the admitted maximum of 19 max-length names under the payload budget', async () => {
+    Object.assign(process.env, { MICROVM_FS_ID: 'fs-1', MICROVM_ACCESS_POINT: 'fsap-1', MICROVM_MOUNT_TARGET_IP: '10.0.0.5' })
+    resetMicrovmRuntimeForTests()
+    const mounts = Array.from({ length: 19 }, (_, i) => {
+      const id = `00000000-0000-4000-8000-${String(i).padStart(12, '0')}`
+      const name = `v${i.toString().padStart(63, 'x')}`
+      return { id, hostPath: `/data/volumes/${id}`, containerPath: `/volumes/${name}`, folderName: name, addedAt: '2026-01-01' }
+    })
+    await expect(newClient().start({ envVars: { PROXY_TOKEN: 't' }, mounts })).resolves.toMatchObject({ status: 'running' })
+  })
+
+  it('throws a readable mounts error when the payload exceeds the budget', async () => {
+    Object.assign(process.env, { MICROVM_FS_ID: 'fs-1', MICROVM_ACCESS_POINT: 'fsap-1', MICROVM_MOUNT_TARGET_IP: '10.0.0.5' })
+    resetMicrovmRuntimeForTests()
+    const mounts = Array.from({ length: 50 }, (_, i) => {
+      const id = `00000000-0000-4000-8000-${String(i).padStart(12, '0')}`
+      const name = `v${i.toString().padStart(63, 'x')}`
+      return { id, hostPath: `/data/volumes/${id}`, containerPath: `/volumes/${name}`, folderName: name, addedAt: '2026-01-01' }
+    })
+    // The list rule caps at the supervisor's 32 before the byte gate runs.
+    await expect(newClient().start({ mounts })).rejects.toThrow(/\(32 mounts\)/)
   })
 
   it('getInfoFromRuntime reports running with the proxy port after start', async () => {

--- a/src/shared/lib/container/lambda-microvm-runtime.ts
+++ b/src/shared/lib/container/lambda-microvm-runtime.ts
@@ -29,6 +29,7 @@ import type {
   StopResult,
 } from './types'
 import { getSettings, isAutoResumeOnUnexpectedDeathEnabled } from '@shared/lib/config/settings'
+import { acceptCloudMounts } from './cloud-mounts'
 import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 import { setBootstrapEnv, clearBootstrapEnv } from './agent-bootstrap-env-store'
 import {
@@ -944,17 +945,31 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     }
 
     const config = getMicrovmRuntimeConfig()
+    // Storage must be fully configured for any mount to exist. When it is not,
+    // every record is dropped and reported, and the prompt lists none.
+    const storageConfigured = Boolean(config.fsId && config.accessPoint && config.mountTargetIp)
+    const filtered = acceptCloudMounts(options?.mounts ?? [])
+    const accepted = storageConfigured ? filtered.accepted : []
+    const dropped = storageConfigured ? filtered.dropped : [...(options?.mounts ?? [])]
+    dropped.forEach((m) => options?.onMountDropped?.(m))
+
     // Full env exceeds the 4096-byte payload cap, so stash it host-side and pass the
     // VM only a small bootstrap credential to fetch it at boot via /api/agent-bootstrap.
-    const env = this.buildAgentEnv(options?.envVars)
+    const env = this.buildAgentEnv(this.withMountsEnv(options?.envVars, accepted))
     const hasEnv = Object.keys(env).length > 0
+    // Shared volumes ride the mount object; the key is absent when none was
+    // accepted so an old host and a new host send the same shape.
+    const volumes = accepted.length > 0
+      ? accepted.map((mount) => ({ subPath: mount.subPath, name: mount.containerPath.slice('/volumes/'.length) }))
+      : undefined
     // Mount the same per-agent workspace path the k8s runtime uses.
-    const mount = config.fsId && config.accessPoint && config.mountTargetIp
+    const mount = storageConfigured
       ? {
-          fsId: config.fsId,
-          accessPoint: config.accessPoint,
-          mountTargetIp: config.mountTargetIp,
+          fsId: config.fsId!,
+          accessPoint: config.accessPoint!,
+          mountTargetIp: config.mountTargetIp!,
           subPath: `${process.env.K8S_WORKSPACES_SUBPATH_PREFIX || 'agents'}/${this.config.agentId}/workspace`,
+          ...(volumes ? { volumes } : {}),
         }
       : undefined
     const hostApiBaseUrl = await this.getHostApiBaseUrl()
@@ -972,10 +987,12 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
     const hookToken = randomUUID()
     const payloadObj = { ...(bootstrap ? { bootstrap } : {}), ...(mount ? { mount } : {}), hookToken }
     const runHookPayload = JSON.stringify(payloadObj)
-    const payloadBytes = runHookPayload ? Buffer.byteLength(runHookPayload, 'utf8') : 0
+    const payloadBytes = Buffer.byteLength(runHookPayload, 'utf8')
     if (payloadBytes > RUN_HOOK_PAYLOAD_MAX_BYTES) {
       throw new Error(
-        `MicroVM runHookPayload is ${payloadBytes} bytes, over the ${RUN_HOOK_PAYLOAD_MAX_BYTES} limit.`,
+        accepted.length > 0
+          ? `MicroVM runHookPayload is ${payloadBytes} bytes, over the ${RUN_HOOK_PAYLOAD_MAX_BYTES} limit (${accepted.length} mounts).`
+          : `MicroVM runHookPayload is ${payloadBytes} bytes, over the ${RUN_HOOK_PAYLOAD_MAX_BYTES} limit.`,
       )
     }
 
@@ -1113,11 +1130,6 @@ export class LambdaMicroVmRuntimeClient extends BaseContainerClient {
   async getStats(): Promise<ContainerStats | null> {
     // lambda-microvms exposes no per-VM resource metrics; surface none.
     return null
-  }
-
-  public buildVolumeFlag(_hostPath: string, _containerPath: string): string {
-    // Workspace is an S3 Files mount performed inside the VM, not a host bind.
-    return ''
   }
 
   public getHostApiBaseUrl(): Promise<string> {

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -2459,11 +2459,6 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     })
   }
 
-  // Volume flag builder (no-op in mock — mounts are not simulated)
-  buildVolumeFlag(hostPath: string, containerPath: string): string {
-    return `"${hostPath}:${containerPath}"`
-  }
-
   // No real host networking in mock mode — report loopback-direct (no proxy).
   getHostBridgeIp(): string | null {
     return null
@@ -2478,15 +2473,21 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
 
   async start(options?: StartOptions): Promise<ContainerInfo> {
     this.running = true
-    // Surface the container env that carries the proxy credentials so E2E
-    // specs can call the API/MCP proxies the way a real container would
-    // (there is deliberately no HTTP endpoint that returns the proxy token).
-    if (options?.envVars?.['PROXY_TOKEN']) {
+    const mounts = options?.mounts ?? []
+    const env = { ...(options?.envVars ?? {}) }
+    delete env.SUPERAGENT_MOUNTS
+    if (mounts.length > 0) env.SUPERAGENT_MOUNTS = JSON.stringify(mounts.map((m) => m.containerPath))
+    // Surface the container env and the mount list so E2E specs can see what
+    // the full API path actually sent to the runtime (there is deliberately no
+    // HTTP endpoint that returns either).
+    if (env['PROXY_TOKEN']) {
       this.writeMockRecord({
         type: 'container_start',
         agentSlug: this.config.agentId,
-        proxyToken: options.envVars['PROXY_TOKEN'],
-        remoteMcps: options.envVars['REMOTE_MCPS'] ?? null,
+        proxyToken: env['PROXY_TOKEN'],
+        remoteMcps: env['REMOTE_MCPS'] ?? null,
+        mounts: mounts.map((m) => m.containerPath),
+        mountsEnv: env['SUPERAGENT_MOUNTS'] ?? null,
         timestamp: new Date().toISOString(),
       })
     }

--- a/src/shared/lib/container/platform-k8s-runtime.test.ts
+++ b/src/shared/lib/container/platform-k8s-runtime.test.ts
@@ -6,8 +6,13 @@ import { EventEmitter } from 'events'
 
 const mockGetSettings = vi.fn()
 const mockCaptureException = vi.fn()
+const { mockStorageSubPath } = vi.hoisted(() => ({ mockStorageSubPath: vi.fn((_p: string): string | null => null) }))
 vi.mock('@shared/lib/config/settings', () => ({
   getSettings: (...args: unknown[]) => mockGetSettings(...args),
+}))
+vi.mock('@shared/lib/config/data-dir', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@shared/lib/config/data-dir')>()),
+  storageSubPath: (p: string) => mockStorageSubPath(p),
 }))
 
 vi.mock('@shared/lib/llm-provider', () => ({
@@ -37,6 +42,12 @@ import {
   type KubeConfig,
   type OwnerReference,
 } from './platform-k8s-runtime'
+import { acceptCloudMounts } from './cloud-mounts'
+import type { AgentMount } from '@shared/lib/types/mount'
+
+const record = (over: Partial<AgentMount>): AgentMount => ({
+  id: 'v1', hostPath: '/data/volumes/v1', containerPath: '/volumes/team-brain', folderName: 'Team brain', addedAt: '2026-01-01', ...over,
+})
 
 const kube: KubeConfig = {
   namespace: 'org-abc123',
@@ -247,6 +258,46 @@ describe('PlatformK8sRuntimeClient manifests', () => {
     const pod = buildAgentPodManifest(kube, 'superagent-a', { agentId: 'a', envVars: {} }, {}, null)
     expect(pod.metadata.ownerReferences).toBeUndefined()
   })
+
+  it('mounts accepted records as PVC subPaths beside the workspace', () => {
+    mockStorageSubPath.mockImplementation((p) => p.startsWith('/data/') ? p.slice('/data/'.length) : null)
+    const { accepted } = acceptCloudMounts([record({})])
+    const pod = buildAgentPodManifest(kube, 'superagent-a', { agentId: 'a', envVars: {} }, {}, null, accepted)
+    const container = (pod.spec?.containers as Array<{ volumeMounts: Array<{ name: string; mountPath: string; subPath: string }> }>)[0]
+    expect(container.volumeMounts).toEqual([
+      { name: 'workspaces', mountPath: '/workspace', subPath: 'staging-usw2/org-abc123/superagent-data/agents/a/workspace' },
+      { name: 'workspaces', mountPath: '/volumes/team-brain', subPath: 'volumes/v1' },
+    ])
+  })
+
+  it('acceptCloudMounts keeps /volumes records on the disk and drops the rest', () => {
+    mockStorageSubPath.mockImplementation((p) => p.startsWith('/data/') ? p.slice('/data/'.length) : null)
+    const folder = record({ id: 'm1', hostPath: '/data/agents/other/workspace', containerPath: '/mounts/other', folderName: 'other' })
+    const offDisk = record({ id: 'v2', hostPath: '/sqlite/x', containerPath: '/volumes/x', folderName: 'x' })
+    // A /volumes/ claim on another agent's workspace: the host path is on the
+    // disk and under the data dir, but not in the volumes area.
+    const stolen = record({ id: 'v3', hostPath: '/data/agents/other/workspace', containerPath: '/volumes/stolen', folderName: 'stolen' })
+    // A name the MicroVM supervisor refuses (it would reject the whole list).
+    const badName = record({ id: 'v4', hostPath: '/data/volumes/v4', containerPath: '/volumes/Team Brain', folderName: 'Team Brain' })
+    const { accepted, dropped } = acceptCloudMounts([record({}), folder, offDisk, stolen, badName])
+    expect(accepted.map((m) => m.subPath)).toEqual(['volumes/v1'])
+    expect(dropped).toEqual([folder, offDisk, stolen, badName])
+  })
+
+  it('acceptCloudMounts applies the rest of the supervisor list rules: sub-path charset, unique names, count', () => {
+    mockStorageSubPath.mockImplementation((p) => p.startsWith('/data/') ? p.slice('/data/'.length) : null)
+    const spaced = record({ id: 'v5', hostPath: '/data/volumes/team brain', containerPath: '/volumes/team', folderName: 'team' })
+    const dup = record({ id: 'v6', hostPath: '/data/volumes/v6', containerPath: '/volumes/team-brain', folderName: 'again' })
+    const many = Array.from({ length: 33 }, (_, i) => record({ id: `n${i}`, hostPath: `/data/volumes/n${i}`, containerPath: `/volumes/n${i}`, folderName: `n${i}` }))
+
+    expect(acceptCloudMounts([spaced]).dropped).toEqual([spaced])
+    const { accepted, dropped } = acceptCloudMounts([record({}), dup])
+    expect(accepted.map((m) => m.id)).toEqual(['v1'])
+    expect(dropped).toEqual([dup])
+    const capped = acceptCloudMounts(many)
+    expect(capped.accepted).toHaveLength(32)
+    expect(capped.dropped).toEqual([many[32]])
+  })
 })
 
 describe('withRetry', () => {
@@ -427,6 +478,49 @@ describe('PlatformK8sRuntimeClient operability', () => {
     const client = new PlatformK8sRuntimeClient({ agentId: 'agent-a', envVars: {} })
 
     await expect(client.start()).resolves.toEqual({ status: 'running', port: 3000 })
+  })
+
+  it('start() reports dropped records and creates the pod with only the accepted mounts and SUPERAGENT_MOUNTS', async () => {
+    mockStorageSubPath.mockImplementation((p) => p.startsWith('/data/') ? p.slice('/data/'.length) : null)
+    mockGetSettings.mockReturnValue({ container: { agentImage: 'img', resourceLimits: { cpu: 1, memory: '1g' } }, enableToolSearch: true })
+    const bodies: string[] = []
+    vi.spyOn(https, 'request').mockImplementation(((_opts, callback) => {
+      const res = new EventEmitter() as EventEmitter & { statusCode: number; setEncoding: ReturnType<typeof vi.fn> }
+      res.statusCode = 200
+      res.setEncoding = vi.fn()
+      const req = new EventEmitter() as EventEmitter & { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+      req.write = vi.fn((chunk: unknown) => { bodies.push(String(chunk)) })
+      req.end = vi.fn(() => {
+        process.nextTick(() => {
+          res.emit('data', JSON.stringify({ status: { phase: 'Running', containerStatuses: [{ name: 'agent', ready: true }] } }))
+          res.emit('end')
+        })
+      })
+      if (typeof callback === 'function') callback(res as any)
+      return req as any
+    }) as typeof https.request)
+    const client = new PlatformK8sRuntimeClient({ agentId: 'agent-a', envVars: {} })
+    // Not running yet, so start() creates the pod instead of returning early;
+    // health is the agent's own HTTP probe, out of scope here.
+    vi.spyOn(client, 'getInfoFromRuntime')
+      .mockResolvedValueOnce({ status: 'stopped', port: null })
+      .mockResolvedValue({ status: 'running', port: 3000 })
+    vi.spyOn(client, 'waitForHealthy').mockResolvedValue(true)
+
+    const dropped: AgentMount[] = []
+    const folder = record({ id: 'm1', hostPath: '/data/agents/other/workspace', containerPath: '/mounts/other', folderName: 'other' })
+    await client.start({
+      envVars: { SUPERAGENT_MOUNTS: JSON.stringify(['/mounts/stale']) },
+      mounts: [record({}), folder],
+      onMountDropped: (m) => dropped.push(m),
+    })
+
+    expect(dropped).toEqual([folder])
+    const pod = bodies.map((b) => { try { return JSON.parse(b) } catch { return null } }).find((b) => b?.kind === 'Pod')
+    expect(pod).toBeTruthy()
+    const container = pod.spec.containers[0] as { volumeMounts: Array<{ mountPath: string }>; env: Array<{ name: string; value: string }> }
+    expect(container.volumeMounts.map((v) => v.mountPath)).toEqual(['/workspace', '/volumes/team-brain'])
+    expect(container.env).toContainEqual({ name: 'SUPERAGENT_MOUNTS', value: JSON.stringify(['/volumes/team-brain']) })
   })
 
   it('fetches pod logs via the Kubernetes log API', async () => {

--- a/src/shared/lib/container/platform-k8s-runtime.ts
+++ b/src/shared/lib/container/platform-k8s-runtime.ts
@@ -4,6 +4,8 @@ import https from 'https'
 import { z } from 'zod'
 import { BaseContainerClient, CONTAINER_INTERNAL_PORT } from './base-container-client'
 import type { ContainerConfig, ContainerInfo, ContainerStats, StartOptions, StopOptions, StopResult } from './types'
+import type { AgentMount } from '@shared/lib/types/mount'
+import { acceptCloudMounts } from './cloud-mounts'
 import { getSettings } from '@shared/lib/config/settings'
 import { captureException } from '@shared/lib/error-reporting'
 import { isRunningInKubernetes } from './runtime-env'
@@ -116,8 +118,11 @@ export class PlatformK8sRuntimeClient extends BaseContainerClient {
     const ownerRef = await resolveOwnerReference(kube.namespace)
     await deleteResource(`/api/v1/namespaces/${kube.namespace}/pods/${this.podName()}`)
     await deleteResource(`/api/v1/namespaces/${kube.namespace}/services/${this.serviceName()}`)
+    const { accepted, dropped } = acceptCloudMounts(options?.mounts ?? [])
+    dropped.forEach((m) => options?.onMountDropped?.(m))
+    const env = this.buildAgentEnv(this.withMountsEnv(options?.envVars, accepted))
     await createResource(`/api/v1/namespaces/${kube.namespace}/services`, buildAgentServiceManifest(kube, this.serviceName(), this.podName(), ownerRef))
-    await createResource(`/api/v1/namespaces/${kube.namespace}/pods`, buildAgentPodManifest(kube, this.podName(), this.config, this.buildAgentEnv(options?.envVars), ownerRef))
+    await createResource(`/api/v1/namespaces/${kube.namespace}/pods`, buildAgentPodManifest(kube, this.podName(), this.config, env, ownerRef, accepted))
 
     await waitForPodReady(kube.namespace, this.podName(), 300_000)
 
@@ -227,10 +232,6 @@ export class PlatformK8sRuntimeClient extends BaseContainerClient {
     }
   }
 
-  public buildVolumeFlag(_hostPath: string, _containerPath: string): string {
-    return ''
-  }
-
   protected getBaseUrl(port: number): string {
     const { namespace } = getKubeConfig()
     return `http://${this.serviceName()}.${namespace}.svc.cluster.local:${port}`
@@ -283,6 +284,7 @@ export function buildAgentPodManifest(
   config: ContainerConfig,
   envVars: Record<string, string>,
   ownerRef?: OwnerReference | null,
+  mounts?: Array<AgentMount & { subPath: string }>,
 ): KubeResource {
   const settings = getSettings()
   const image = process.env.K8S_AGENT_IMAGE || settings.container.agentImage
@@ -314,11 +316,18 @@ export function buildAgentPodManifest(
         allowPrivilegeEscalation: false,
         capabilities: { drop: ['ALL'] },
       },
-      volumeMounts: [{
-        name: 'workspaces',
-        mountPath: '/workspace',
-        subPath: workspaceSubPath(kube.workspaceSubPathPrefix, config.agentId),
-      }],
+      volumeMounts: [
+        {
+          name: 'workspaces',
+          mountPath: '/workspace',
+          subPath: workspaceSubPath(kube.workspaceSubPathPrefix, config.agentId),
+        },
+        ...(mounts ?? []).map((mount) => ({
+          name: 'workspaces',
+          mountPath: mount.containerPath,
+          subPath: mount.subPath,
+        })),
+      ],
     }],
     volumes: [{
       name: 'workspaces',

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -1,3 +1,4 @@
+import type { AgentMount } from '@shared/lib/types/mount'
 import type { RuntimeOptions } from './runtime-options'
 import type { ObserveUnexpectedDeathInput, RuntimeFatalKind, UnexpectedDeathPlan } from './runtime-death'
 
@@ -135,14 +136,13 @@ export interface CreateSessionOptions {
 
 export interface StartOptions {
   envVars?: Record<string, string>
-  additionalVolumes?: string[] // Extra -v flag values for bind mounts
   /**
-   * Called when a bind mount is dropped at run time because the container
-   * runtime can't access it (e.g. a cloud-synced folder the Lima VM helper is
-   * denied). Receives the host path so the caller can warn the user. The
-   * container is still started without that one mount.
+   * Every mount the agent should have. The runtime decides which it can
+   * realise, sets SUPERAGENT_MOUNTS from that subset, and reports the rest
+   * through onMountDropped. The container still starts.
    */
-  onMountDropped?: (hostPath: string) => void
+  mounts?: AgentMount[]
+  onMountDropped?: (mount: AgentMount) => void
 }
 
 // Container resource usage stats
@@ -203,9 +203,6 @@ export interface ContainerClient {
   start(options?: StartOptions): Promise<ContainerInfo | void>
   stop(options?: StopOptions): Promise<StopResult>
   stopSync(): void // Synchronous stop for exit handlers
-
-  // Build a -v flag value for a volume mount (hostPath:containerPath with runtime-specific suffix)
-  buildVolumeFlag(hostPath: string, containerPath: string): string
 
   // Host-internal bridge IP that a host-side service must bind to so THIS runner's
   // containers can reach it via host.docker.internal, or null when containers reach


### PR DESCRIPTION
Container start now hands every runtime the agent's mount records instead of Docker `-v` strings, and the runtime decides what it binds, writes `SUPERAGENT_MOUNTS` from that subset, and reports the rest so the prompt names only folders that are really there. Kubernetes and MicroVM gain the rule for what they may bind at all, an app-managed `/volumes/<name>` record whose host path sits in the data dir's volumes area, and drop everything else with a banner instead of silence. This is its own PR because it changes the contract between the manager and all five runtimes, and every later Shared Volumes slice writes into that contract. Nothing produces a `/volumes/` record yet, so the cloud path lands dark.

Closes https://linear.app/datawizz/issue/SUP-790/runtimes-own-the-mount-list-and-accept-volumes-records-on-cloud
Related to https://linear.app/datawizz/issue/SUP-739/shared-volumes-opt-in-shared-readwrite-folders-for-cloud-agents

15 files, +617 / -144 (8 production, 7 test).

```
manager start(agent)
 → read records, stamp health, skip missing (banner, unchanged)
 → client.start({envVars, mounts, onMountDropped})     no SUPERAGENT_MOUNTS set here any more
runtime
 → accept(mounts) → {accepted, dropped}
     docker family → every record
     k8s, microvm  → /volumes/<name>, name matches the supervisor's rule, host path resolves under volumes/,
                     sub-path charset the supervisor accepts, names unique, at most 32
 → dropped → onMountDropped(record) → manager shows one banner: missing + dropped, after start settles
 → SUPERAGENT_MOUNTS = accepted container paths, or unset
 → bind
     docker family → -v per record; Lima EPERM → drop that record, rewrite the env file, retry
     k8s           → one pod volumeMount per record on the workspaces PVC
     microvm       → mount.volumes in the run-hook payload, byte gate after filtering, key absent when empty
```

- The MicroVM supervisor validates the whole volumes list and refuses the run hook on one bad entry, so every rule it applies is applied here first. A record that would fail there is dropped and reported, and the agent still boots.
- Both ends of a cloud record are checked because neither alone proves ownership: the container path is what the record claims, the host path is what it would expose. `$DATA_DIR/agents/other/workspace` behind a `/volumes/` name is dropped.
- The workspace sub-path and `K8S_WORKSPACES_SUBPATH_PREFIX` are untouched. Known limit: if that prefix is ever set to `<parent>/agents`, volumes must move to `<parent>/volumes`. Nothing sets it today.
- `buildVolumeFlag` leaves the client interface. The base class was its only caller, and the Kubernetes, MicroVM, and mock stubs returned empty strings.
- Existing desktop installs: no data change. Lima is the one runtime that drops-and-retries on EPERM, and its prompt now matches what was bound. Existing cloud orgs: the run-hook payload is byte-identical until a volume is accepted, so an old image and a new host agree. gamut-infra#212 may land before or after. It is exercised only once slice 2 can create a record.

No UI change.
