### PR TITLE
fix(automation): release settled streams and safely roll back failed sends

### DIFF
--- a/agent-container/src/session-manager-idle-eviction.test.ts
+++ b/agent-container/src/session-manager-idle-eviction.test.ts
@@ -176,6 +176,43 @@ describe('SessionManager idle eviction', () => {
     expect(mockReleaseBrowserLock).toHaveBeenCalledWith(id)
   })
 
+  it('announces eviction only after the process stops and before a racing send resumes', async () => {
+    const { id, proc } = await createIdleSession()
+    const processInstance = manager.getProcessInstanceId(id)
+    const events: unknown[] = []
+    manager.subscribe(id, (message) => events.push(message))
+    let finishStop!: () => void
+    const stopStarted = vi.spyOn(proc, 'stop').mockImplementation(async () => {
+      await new Promise<void>((resolve) => { finishStop = resolve })
+      proc.running = false
+    })
+    await pastThreshold()
+    const eviction = manager.evictIdleSessions()
+    expect(stopStarted).toHaveBeenCalledOnce()
+    expect(events).toEqual([])
+    const sentBefore = proc.sendMessageCalls
+    const send = manager.sendMessage(id, 'continue the same conversation')
+    expect(proc.sendMessageCalls).toBe(sentBefore)
+    finishStop()
+    await Promise.all([eviction, send])
+    expect(events[0]).toMatchObject({ type: 'system', subtype: 'process_evicted', process_instance: processInstance })
+    expect(proc.sendMessageCalls).toBe(sentBefore + 1)
+    expect(proc.sentContents.at(-1)).toBe('continue the same conversation')
+    expect(manager.hasActiveSession(id)).toBe(true)
+    stopStarted.mockRestore()
+  })
+
+  it('does not announce eviction if stopping fails', async () => {
+    const { id, proc } = await createIdleSession()
+    const events: unknown[] = []
+    manager.subscribe(id, (message) => events.push(message))
+    vi.spyOn(proc, 'stop').mockRejectedValueOnce(new Error('stop failed'))
+    await pastThreshold()
+    await manager.evictIdleSessions()
+    expect(events).toEqual([])
+    expect(proc.isRunning()).toBe(true)
+  })
+
   it('does not evict a session that is still busy', async () => {
     const { proc } = await createIdleSession()
     proc.emit('message', { type: 'system', subtype: 'session_state_changed', state: 'running' })

--- a/agent-container/src/session-manager.ts
+++ b/agent-container/src/session-manager.ts
@@ -1025,7 +1025,15 @@ export class SessionManager extends EventEmitter {
           // Graceful: let the CLI exit on stdin EOF and flush its transcript —
           // a hard abort here races the flush and can truncate the session
           // JSONL tail, silently losing the latest turns on the next resume.
+          const processInstance = data.processInstanceId;
           await data.process.stop({ graceful: true });
+          if (!data.process.isRunning() && data.processInstanceId === processInstance) {
+            this.broadcast(sessionId, {
+              type: 'system',
+              subtype: 'process_evicted',
+              process_instance: processInstance,
+            });
+          }
           console.log(
             `[Session ${sessionId}] Evicted idle session process (idle ${Math.round((Date.now() - data.session.lastActivity.getTime()) / 60_000)}m)`
           );

--- a/src/api/routes/scheduled-tasks.test.ts
+++ b/src/api/routes/scheduled-tasks.test.ts
@@ -70,6 +70,7 @@ vi.mock('@shared/lib/container/container-manager', () => ({
 }))
 
 const mockMessagePersister = vi.hoisted(() => ({
+  withSessionSend: vi.fn(async (_agentSlug: string, _sessionId: string, _client: unknown, send: () => Promise<unknown>) => send()),
   isSessionActive: vi.fn(),
   subscribeToSession: vi.fn(),
   markSessionActive: vi.fn(),

--- a/src/api/routes/scheduled-tasks.ts
+++ b/src/api/routes/scheduled-tasks.ts
@@ -335,8 +335,9 @@ scheduledTasksRouter.post('/:taskId/run-now', TaskAgentRole('user'), async (c) =
       scheduledTaskName: task.name || undefined,
     })
 
-    await messagePersister.subscribeToSession(task.agentSlug, sessionId, client, sessionId)
+    // createSession already started the turn; replay may finish it during attachment.
     messagePersister.markSessionActive(task.agentSlug, sessionId)
+    await messagePersister.subscribeToSession(task.agentSlug, sessionId, client, sessionId)
 
     if (task.isRecurring) {
       // Recurring: keep schedule, just record the manual execution

--- a/src/api/routes/x-agent-policies.test.ts
+++ b/src/api/routes/x-agent-policies.test.ts
@@ -96,6 +96,9 @@ vi.mock('@shared/lib/container/container-manager', () => ({
 
 vi.mock('@shared/lib/container/message-persister', () => ({
   messagePersister: {
+    withSessionSend: async (_agentSlug: string, _sessionId: string, _client: unknown, send: () => Promise<unknown>) => {
+      return send()
+    },
     isSessionActive: vi.fn(() => false),
     isSessionAwaitingInput: vi.fn(() => false),
     hasActiveSessionsForAgent: vi.fn(() => false),

--- a/src/api/routes/x-agent.test.ts
+++ b/src/api/routes/x-agent.test.ts
@@ -148,6 +148,10 @@ const mockMarkSessionActive = vi.fn()
 const mockBroadcastGlobal = vi.fn()
 vi.mock('@shared/lib/container/message-persister', () => ({
   messagePersister: {
+    withSessionSend: async (agentSlug: string, sessionId: string, _client: unknown, send: () => Promise<unknown>) => {
+      mockMarkSessionActive(agentSlug, sessionId)
+      return send()
+    },
     isSessionActive: (agentSlug?: string, sessionId?: string) => mockIsSessionActive(agentSlug, sessionId),
     isSessionAwaitingInput: (agentSlug: string, sessionId?: string,) => mockIsSessionAwaitingInput(agentSlug, sessionId),
     waitForIdle: (...args: unknown[]) => mockWaitForIdle(...args),

--- a/src/api/routes/x-agent.ts
+++ b/src/api/routes/x-agent.ts
@@ -779,29 +779,30 @@ xAgent.post('/invoke', zValidator('json', invokeBodySchema), async (c) => {
           })
           return c.json({ error: deliveryCutoffError() }, 504)
         }
-        messagePersister.markSessionActive(targetSlug, existingSessionId)
         stage = 'send_message'
-        let messageUuid: string | undefined
-        if (isAuthMode() && attributedUserId) {
-          const candidateUuid = randomUUID()
-          const recorded = await insertMessageAuthorBestEffort({
-            id: candidateUuid,
-            sessionId: existingSessionId,
-            agentSlug: targetSlug,
-            userId: attributedUserId,
-          })
-          if (recorded) messageUuid = candidateUuid
-        }
-        try {
-          if (messageUuid) {
-            await client.sendMessage(existingSessionId, prompt, messageUuid, { isAutomated: true })
-          } else {
-            await client.sendMessage(existingSessionId, prompt, undefined, { isAutomated: true })
+        await messagePersister.withSessionSend(targetSlug, existingSessionId, client, async () => {
+          let messageUuid: string | undefined
+          if (isAuthMode() && attributedUserId) {
+            const candidateUuid = randomUUID()
+            const recorded = await insertMessageAuthorBestEffort({
+              id: candidateUuid,
+              sessionId: existingSessionId,
+              agentSlug: targetSlug,
+              userId: attributedUserId,
+            })
+            if (recorded) messageUuid = candidateUuid
           }
-        } catch (sendError) {
-          if (messageUuid) await deleteMessageAuthorBestEffort(messageUuid)
-          throw sendError
-        }
+          try {
+            if (messageUuid) {
+              await client.sendMessage(existingSessionId, prompt, messageUuid, { isAutomated: true })
+            } else {
+              await client.sendMessage(existingSessionId, prompt, undefined, { isAutomated: true })
+            }
+          } catch (sendError) {
+            if (messageUuid) await deleteMessageAuthorBestEffort(messageUuid)
+            throw sendError
+          }
+        })
 
         if (sync) {
           stage = 'wait_for_idle'

--- a/src/shared/lib/chat-integrations/chat-integration-manager-idle-stream.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager-idle-stream.test.ts
@@ -3,21 +3,15 @@ import type { ChatIntegration } from '@shared/lib/db/schema'
 import type { IncomingMessage } from './base-connector'
 
 const mocks = vi.hoisted(() => ({
-  active: false,
-  subscribed: false,
   send: vi.fn(),
-  subscribe: vi.fn(),
+  withSessionSend: vi.fn(),
   notice: vi.fn().mockResolvedValue(undefined),
-  idle: vi.fn(),
 }))
 
 vi.mock('@shared/lib/container/message-persister', () => ({
   messagePersister: {
-    isSessionActive: () => mocks.active,
-    markSessionActive: () => { mocks.active = true },
-    markSessionIdle: (...args: unknown[]) => { mocks.active = false; mocks.idle(...args) },
-    isSubscribed: () => mocks.subscribed,
-    subscribeToSession: (...args: unknown[]) => mocks.subscribe(...args),
+    isSubscribed: () => true,
+    withSessionSend: (...args: unknown[]) => mocks.withSessionSend(...args),
   },
 }))
 vi.mock('@shared/lib/container/container-manager', () => ({
@@ -45,83 +39,55 @@ const manager = chatIntegrationManager as unknown as {
   deriveDisplayName(): string
   buildMessageContent(): Promise<{ text: string; failedFiles: string[] }>
 }
-
 const message: IncomingMessage = {
   chatId: 'chat', text: 'continue', externalMessageId: 'message', userId: 'user', timestamp: new Date(),
 }
-
 function integration(provider: ChatIntegration['provider']): ChatIntegration {
   return { id: 'integration', agentSlug: 'agent', provider, sessionTimeout: null } as ChatIntegration
 }
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mocks.active = false
-  mocks.subscribed = false
-  mocks.subscribe.mockImplementation(async () => { mocks.subscribed = true })
+  mocks.withSessionSend.mockImplementation((_slug, _session, _client, send: () => Promise<void>) => send())
   mocks.send.mockResolvedValue(undefined)
   manager.connections.set('integration', { connector: { sendMessage: mocks.notice } })
   vi.spyOn(manager, 'subscribeChatSession').mockImplementation(() => {})
   vi.spyOn(manager, 'deriveDisplayName').mockReturnValue('Chat')
   vi.spyOn(manager, 'buildMessageContent').mockResolvedValue({ text: 'continue', failedFiles: [] })
 })
-
 afterEach(() => {
   manager.connections.delete('integration')
   manager.lastSessionTouch.clear()
   vi.restoreAllMocks()
 })
 
-describe('chat session reconnect after idle eviction', () => {
-  it.each(['slack', 'telegram', 'imessage'] as const)('awaits reconnect before sending into the same %s session', async (provider) => {
-    let ready!: () => void
-    mocks.subscribe.mockImplementation(() => new Promise<void>((resolve) => {
-      ready = () => { mocks.subscribed = true; resolve() }
-    }))
-    const delivery = manager.handleIncomingMessageInner('integration', message, integration(provider))
-    await vi.waitFor(() => expect(mocks.subscribe).toHaveBeenCalledOnce())
-    expect(mocks.send).not.toHaveBeenCalled()
-    ready()
-    await delivery
+describe('chat session delivery', () => {
+  it.each(['slack', 'telegram', 'imessage'] as const)('uses the shared send lifecycle for the same %s session', async (provider) => {
+    await manager.handleIncomingMessageInner('integration', message, integration(provider))
+    expect(mocks.withSessionSend).toHaveBeenCalledExactlyOnceWith(
+      'agent', 'existing-session', expect.objectContaining({ sendMessage: mocks.send }), expect.any(Function),
+    )
     expect(mocks.send).toHaveBeenCalledExactlyOnceWith('existing-session', 'continue')
-    expect(mocks.active).toBe(true)
   })
 
-  it('rechecks the subscription after attachment preparation, before sending', async () => {
-    mocks.subscribed = true
+  it('enters the shared send lifecycle after attachment preparation', async () => {
+    let prepared = false
     vi.mocked(manager.buildMessageContent).mockImplementation(async () => {
-      mocks.subscribed = false
+      prepared = true
       return { text: 'continue', failedFiles: [] }
     })
-    mocks.send.mockImplementation(async () => {
-      expect(mocks.active).toBe(true)
-      expect(mocks.subscribed).toBe(true)
+    mocks.withSessionSend.mockImplementation(async (_slug, _session, _client, send: () => Promise<void>) => {
+      expect(prepared).toBe(true)
+      await send()
     })
     await manager.handleIncomingMessageInner('integration', message, integration('slack'))
-    expect(mocks.subscribe).toHaveBeenCalledOnce()
     expect(mocks.send).toHaveBeenCalledOnce()
   })
 
-  it('clears provisional activity when reconnect fails without sending the message', async () => {
-    mocks.subscribed = true
-    vi.mocked(manager.buildMessageContent).mockImplementation(async () => {
-      mocks.subscribed = false
-      return { text: 'continue', failedFiles: [] }
-    })
-    mocks.subscribe.mockRejectedValueOnce(new Error('connection unavailable'))
+  it('reports a shared reconnect failure without sending', async () => {
+    mocks.withSessionSend.mockRejectedValueOnce(new Error('connection unavailable'))
     await manager.handleIncomingMessageInner('integration', message, integration('slack'))
     expect(mocks.send).not.toHaveBeenCalled()
-    expect(mocks.idle).toHaveBeenCalledExactlyOnceWith('agent', 'existing-session')
-    expect(mocks.active).toBe(false)
     expect(mocks.notice).toHaveBeenCalledWith('chat', expect.objectContaining({ text: expect.stringContaining('Failed to send') }))
-  })
-
-  it('does not settle an already-active turn when a follow-up send fails', async () => {
-    mocks.active = true
-    mocks.subscribed = true
-    mocks.send.mockRejectedValueOnce(new Error('connection unavailable'))
-    await manager.handleIncomingMessageInner('integration', message, integration('slack'))
-    expect(mocks.idle).not.toHaveBeenCalled()
-    expect(mocks.active).toBe(true)
   })
 })

--- a/src/shared/lib/chat-integrations/chat-integration-manager-idle-stream.test.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager-idle-stream.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ChatIntegration } from '@shared/lib/db/schema'
+import type { IncomingMessage } from './base-connector'
+
+const mocks = vi.hoisted(() => ({
+  active: false,
+  subscribed: false,
+  send: vi.fn(),
+  subscribe: vi.fn(),
+  notice: vi.fn().mockResolvedValue(undefined),
+  idle: vi.fn(),
+}))
+
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    isSessionActive: () => mocks.active,
+    markSessionActive: () => { mocks.active = true },
+    markSessionIdle: (...args: unknown[]) => { mocks.active = false; mocks.idle(...args) },
+    isSubscribed: () => mocks.subscribed,
+    subscribeToSession: (...args: unknown[]) => mocks.subscribe(...args),
+  },
+}))
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: { ensureRunning: async () => ({ sendMessage: mocks.send }) },
+}))
+vi.mock('@shared/lib/services/agent-service', () => ({ agentExists: async () => true }))
+vi.mock('@shared/lib/services/chat-integration-access-service', () => ({
+  decideInboundAccess: () => ({ action: 'allowed' }),
+  isChatAllowed: () => true,
+}))
+vi.mock('@shared/lib/services/chat-integration-session-service', () => ({
+  resolveActiveSession: () => ({ id: 'mapping', sessionId: 'existing-session', displayName: 'Chat' }),
+  touchChatIntegrationSession: vi.fn(),
+}))
+vi.mock('./resolve-awaiting-input', () => ({ consumeOrCancelAwaitingInput: async () => false }))
+vi.mock('@shared/lib/error-reporting', () => ({ captureException: vi.fn(), addErrorBreadcrumb: vi.fn() }))
+
+import { chatIntegrationManager } from './chat-integration-manager'
+
+const manager = chatIntegrationManager as unknown as {
+  connections: Map<string, unknown>
+  lastSessionTouch: Map<string, number>
+  handleIncomingMessageInner(id: string, message: IncomingMessage, integration: ChatIntegration): Promise<void>
+  subscribeChatSession(integrationId: string, chatId: string, sessionId: string): void
+  deriveDisplayName(): string
+  buildMessageContent(): Promise<{ text: string; failedFiles: string[] }>
+}
+
+const message: IncomingMessage = {
+  chatId: 'chat', text: 'continue', externalMessageId: 'message', userId: 'user', timestamp: new Date(),
+}
+
+function integration(provider: ChatIntegration['provider']): ChatIntegration {
+  return { id: 'integration', agentSlug: 'agent', provider, sessionTimeout: null } as ChatIntegration
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.active = false
+  mocks.subscribed = false
+  mocks.subscribe.mockImplementation(async () => { mocks.subscribed = true })
+  mocks.send.mockResolvedValue(undefined)
+  manager.connections.set('integration', { connector: { sendMessage: mocks.notice } })
+  vi.spyOn(manager, 'subscribeChatSession').mockImplementation(() => {})
+  vi.spyOn(manager, 'deriveDisplayName').mockReturnValue('Chat')
+  vi.spyOn(manager, 'buildMessageContent').mockResolvedValue({ text: 'continue', failedFiles: [] })
+})
+
+afterEach(() => {
+  manager.connections.delete('integration')
+  manager.lastSessionTouch.clear()
+  vi.restoreAllMocks()
+})
+
+describe('chat session reconnect after idle eviction', () => {
+  it.each(['slack', 'telegram', 'imessage'] as const)('awaits reconnect before sending into the same %s session', async (provider) => {
+    let ready!: () => void
+    mocks.subscribe.mockImplementation(() => new Promise<void>((resolve) => {
+      ready = () => { mocks.subscribed = true; resolve() }
+    }))
+    const delivery = manager.handleIncomingMessageInner('integration', message, integration(provider))
+    await vi.waitFor(() => expect(mocks.subscribe).toHaveBeenCalledOnce())
+    expect(mocks.send).not.toHaveBeenCalled()
+    ready()
+    await delivery
+    expect(mocks.send).toHaveBeenCalledExactlyOnceWith('existing-session', 'continue')
+    expect(mocks.active).toBe(true)
+  })
+
+  it('rechecks the subscription after attachment preparation, before sending', async () => {
+    mocks.subscribed = true
+    vi.mocked(manager.buildMessageContent).mockImplementation(async () => {
+      mocks.subscribed = false
+      return { text: 'continue', failedFiles: [] }
+    })
+    mocks.send.mockImplementation(async () => {
+      expect(mocks.active).toBe(true)
+      expect(mocks.subscribed).toBe(true)
+    })
+    await manager.handleIncomingMessageInner('integration', message, integration('slack'))
+    expect(mocks.subscribe).toHaveBeenCalledOnce()
+    expect(mocks.send).toHaveBeenCalledOnce()
+  })
+
+  it('clears provisional activity when reconnect fails without sending the message', async () => {
+    mocks.subscribed = true
+    vi.mocked(manager.buildMessageContent).mockImplementation(async () => {
+      mocks.subscribed = false
+      return { text: 'continue', failedFiles: [] }
+    })
+    mocks.subscribe.mockRejectedValueOnce(new Error('connection unavailable'))
+    await manager.handleIncomingMessageInner('integration', message, integration('slack'))
+    expect(mocks.send).not.toHaveBeenCalled()
+    expect(mocks.idle).toHaveBeenCalledExactlyOnceWith('agent', 'existing-session')
+    expect(mocks.active).toBe(false)
+    expect(mocks.notice).toHaveBeenCalledWith('chat', expect.objectContaining({ text: expect.stringContaining('Failed to send') }))
+  })
+
+  it('does not settle an already-active turn when a follow-up send fails', async () => {
+    mocks.active = true
+    mocks.subscribed = true
+    mocks.send.mockRejectedValueOnce(new Error('connection unavailable'))
+    await manager.handleIncomingMessageInner('integration', message, integration('slack'))
+    expect(mocks.idle).not.toHaveBeenCalled()
+    expect(mocks.active).toBe(true)
+  })
+})

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -1099,18 +1099,9 @@ class ChatIntegrationManager {
       })
       if (consumed) return
 
-      const wasActive = messagePersister.isSessionActive(integration.agentSlug, sessionId)
-      // Pin the upcoming turn before reconnecting so a racing eviction cannot detach its stream.
-      messagePersister.markSessionActive(integration.agentSlug, sessionId)
-      try {
-        if (!messagePersister.isSubscribed(integration.agentSlug, sessionId)) {
-          await messagePersister.subscribeToSession(integration.agentSlug, sessionId, client, sessionId)
-        }
-        await client.sendMessage(sessionId, messageText)
-      } catch (error) {
-        if (!wasActive) messagePersister.markSessionIdle(integration.agentSlug, sessionId)
-        throw error
-      }
+      await messagePersister.withSessionSend(integration.agentSlug, sessionId, client, () =>
+        client.sendMessage(sessionId, messageText),
+      )
       const now = Date.now()
       const lastTouch = this.lastSessionTouch.get(chatSession.id) ?? 0
       if (now - lastTouch > 60_000) {

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -1099,8 +1099,18 @@ class ChatIntegrationManager {
       })
       if (consumed) return
 
-      await client.sendMessage(sessionId, messageText)
+      const wasActive = messagePersister.isSessionActive(integration.agentSlug, sessionId)
+      // Pin the upcoming turn before reconnecting so a racing eviction cannot detach its stream.
       messagePersister.markSessionActive(integration.agentSlug, sessionId)
+      try {
+        if (!messagePersister.isSubscribed(integration.agentSlug, sessionId)) {
+          await messagePersister.subscribeToSession(integration.agentSlug, sessionId, client, sessionId)
+        }
+        await client.sendMessage(sessionId, messageText)
+      } catch (error) {
+        if (!wasActive) messagePersister.markSessionIdle(integration.agentSlug, sessionId)
+        throw error
+      }
       const now = Date.now()
       const lastTouch = this.lastSessionTouch.get(chatSession.id) ?? 0
       if (now - lastTouch > 60_000) {

--- a/src/shared/lib/chat-integrations/chat-integration-manager.ts
+++ b/src/shared/lib/chat-integrations/chat-integration-manager.ts
@@ -1224,9 +1224,11 @@ class ChatIntegrationManager {
       displayName,
     })
 
-    await messagePersister.subscribeToSession(integration.agentSlug, sessionId, client, sessionId)
+    // createSession already started this turn. Observe it and wire chat delivery
+    // before attaching, so even a fast turn's replay is consumed and forwarded.
     messagePersister.markSessionActive(integration.agentSlug, sessionId)
     this.subscribeChatSession(integration.id, chatId, sessionId)
+    await messagePersister.subscribeToSession(integration.agentSlug, sessionId, client, sessionId)
   }
 
   /**

--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -278,6 +278,7 @@ const interruptResponseSchema = z.object({
 export abstract class BaseContainerClient extends EventEmitter implements ContainerClient {
   protected config: ContainerConfig
   private wsConnections: Map<string, WebSocket> = new Map()
+  private wsReadyRejectors = new WeakMap<WebSocket, (error: Error) => void>()
 
   /** Whether this runner is eligible on the current platform. Override for platform-specific runners. */
   static isEligible(): boolean {
@@ -900,7 +901,9 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
   protected terminateWebSocketConnections(): void {
     for (const ws of this.wsConnections.values()) {
+      this.wsReadyRejectors.get(ws)?.(new Error('Session stream stopped before initialization'))
       ws.removeAllListeners()
+      ws.on('error', () => {})
       try {
         ws.terminate()
       } catch {
@@ -1522,6 +1525,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   private closeTrackedWebSocket(sessionId: string): void {
     const ws = this.wsConnections.get(sessionId)
     if (!ws) return
+    this.wsReadyRejectors.get(ws)?.(new Error('Session stream closed before initialization'))
     ws.removeAllListeners()
     // close() on CONNECTING emits 'error'; zero listeners is an uncaughtException.
     ws.on('error', () => {})
@@ -1535,13 +1539,22 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   ): { unsubscribe: () => void; ready: Promise<void> } {
     let resolveReady: () => void
     let rejectReady: (error: Error) => void
+    let socket: WebSocket | undefined
+    let cancelled = false
     const ready = new Promise<void>((resolve, reject) => {
-      resolveReady = resolve
-      rejectReady = reject
+      resolveReady = () => {
+        if (socket) this.wsReadyRejectors.delete(socket)
+        resolve()
+      }
+      rejectReady = (error) => {
+        if (socket) this.wsReadyRejectors.delete(socket)
+        reject(error)
+      }
     })
 
     const setupWebSocket = async () => {
       const port = await this.getPortOrThrow()
+      if (cancelled) return
 
       if (this.wsConnections.has(sessionId)) {
         this.closeTrackedWebSocket(sessionId)
@@ -1552,9 +1565,11 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
         { headers: this.getHostAuthHeaders() }
       )
 
+      socket = ws
+      this.wsReadyRejectors.set(ws, rejectReady)
+
       ws.on('open', () => {
         console.log(`WebSocket connected for session ${sessionId}`)
-        resolveReady()
       })
 
       ws.on('message', (data) => {
@@ -1568,6 +1583,13 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
           }
           callback(streamMessage)
           this.emit('message', sessionId, message)
+          // The guest sends this acknowledgement AFTER attaching its listener
+          // and replaying terminal frames. Socket open precedes both: allowing
+          // a send then lets the previous result + idle settle the new turn.
+          // This existing status frame also works with older container images.
+          if (message.type === 'status' && message.data?.message === 'Connected to session stream') {
+            resolveReady()
+          }
         } catch (error) {
           console.error('Failed to parse WebSocket message:', error)
         }
@@ -1590,6 +1612,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
       ws.on('close', () => {
         console.log(`WebSocket closed for session ${sessionId}`)
+        rejectReady(new Error('Session stream closed before initialization'))
         this.wsConnections.delete(sessionId)
         // Notify the callback that the connection was lost
         // This allows the message persister to handle the disconnection
@@ -1606,6 +1629,7 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     }
 
     setupWebSocket().catch((error) => {
+      if (cancelled) return
       console.error('Failed to set up WebSocket:', error)
       this.safeEmitError(error)
       // Notify the callback so the consumer (e.g. MessagePersister) can react to
@@ -1623,7 +1647,11 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
     })
 
     const unsubscribe = () => {
-      this.closeTrackedWebSocket(sessionId)
+      cancelled = true
+      rejectReady(new Error('Session stream unsubscribed before initialization'))
+      if (socket && this.wsConnections.get(sessionId) === socket) {
+        this.closeTrackedWebSocket(sessionId)
+      }
     }
 
     return { unsubscribe, ready }

--- a/src/shared/lib/container/base-container-client.unsubscribe.test.ts
+++ b/src/shared/lib/container/base-container-client.unsubscribe.test.ts
@@ -5,17 +5,23 @@ import { BaseContainerClient } from './base-container-client'
 const { FakeWebSocket, sockets } = vi.hoisted(() => {
   class FakeWebSocket {
     static OPEN = 1
+    static autoHandshake = true
     url: string
-    private listeners = new Map<string, Array<() => void>>()
+    private listeners = new Map<string, Array<(...args: unknown[]) => void>>()
     closed = false
 
     constructor(url: string) {
       this.url = url
       sockets.push(this)
-      queueMicrotask(() => this.emit('open'))
+      queueMicrotask(() => {
+        this.emit('open')
+        if (FakeWebSocket.autoHandshake) {
+          this.receive({ type: 'status', data: { message: 'Connected to session stream' } })
+        }
+      })
     }
 
-    on(event: string, fn: () => void): this {
+    on(event: string, fn: (...args: unknown[]) => void): this {
       const list = this.listeners.get(event) ?? []
       list.push(fn)
       this.listeners.set(event, list)
@@ -31,8 +37,16 @@ const { FakeWebSocket, sockets } = vi.hoisted(() => {
       queueMicrotask(() => this.emit('close'))
     }
 
-    emit(event: string): void {
-      for (const fn of [...(this.listeners.get(event) ?? [])]) fn()
+    terminate(): void {
+      this.close()
+    }
+
+    receive(message: Record<string, unknown>): void {
+      this.emit('message', Buffer.from(JSON.stringify(message)))
+    }
+
+    emit(event: string, ...args: unknown[]): void {
+      for (const fn of [...(this.listeners.get(event) ?? [])]) fn(...args)
     }
   }
 
@@ -52,6 +66,9 @@ vi.mock('@shared/lib/llm-provider', () => ({
 }))
 
 class RunningTestClient extends BaseContainerClient {
+  terminateConnections(): void {
+    this.terminateWebSocketConnections()
+  }
   protected getRunnerCommand(): string {
     return 'docker'
   }
@@ -67,6 +84,71 @@ function makeClient(): RunningTestClient {
 describe('subscribeToStream unsubscribe', () => {
   beforeEach(() => {
     sockets.length = 0
+    FakeWebSocket.autoHandshake = true
+  })
+
+  it('resolves ready only after delayed replay and the guest acknowledgement', async () => {
+    FakeWebSocket.autoHandshake = false
+    const messages: StreamMessage[] = []
+    const { ready, unsubscribe } = makeClient().subscribeToStream('sess-1', m => messages.push(m))
+    let initialized = false
+    void ready.then(() => { initialized = true })
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(initialized).toBe(false)
+    const socket = sockets[0]
+    socket.receive({ type: 'system', subtype: 'capabilities', session_state_events: true })
+    socket.receive({ type: 'result', subtype: 'success', replayed: true })
+    socket.receive({ type: 'system', subtype: 'session_state_changed', state: 'idle', replayed: true })
+    socket.receive({ type: 'status', data: { message: 'Still initializing' } })
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(initialized).toBe(false)
+    socket.receive({ type: 'status', data: { message: 'Connected to session stream' } })
+    await ready
+    expect(initialized).toBe(true)
+    expect(messages.map(m => m.content.type)).toEqual(['system', 'result', 'system', 'status', 'status'])
+    unsubscribe()
+  })
+
+  it.each(['close', 'error', 'unsubscribe', 'stop'])('rejects ready on %s before the acknowledgement', async (event) => {
+    FakeWebSocket.autoHandshake = false
+    const client = makeClient()
+    const { ready, unsubscribe } = client.subscribeToStream('sess-1', () => {})
+    const rejection = expect(ready).rejects.toThrow(/before initialization|connection failed/)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    if (event === 'unsubscribe') unsubscribe()
+    else if (event === 'stop') client.terminateConnections()
+    else sockets[0].emit(event, new Error('connection failed'))
+    await rejection
+    unsubscribe()
+  })
+
+  it('cancels an attachment before port discovery finishes without opening a socket', async () => {
+    const client = makeClient()
+    let resolvePort!: (info: ContainerInfo) => void
+    vi.spyOn(client, 'getInfoFromRuntime').mockImplementationOnce(() =>
+      new Promise(resolve => { resolvePort = resolve }))
+    const { ready, unsubscribe } = client.subscribeToStream('sess-1', () => {})
+    const rejection = expect(ready).rejects.toThrow('unsubscribed before initialization')
+    unsubscribe()
+    resolvePort({ status: 'running', port: 12345 })
+    await rejection
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(sockets).toHaveLength(0)
+  })
+
+  it('rejects a replaced attachment and keeps the new socket when the old caller unsubscribes', async () => {
+    FakeWebSocket.autoHandshake = false
+    const client = makeClient()
+    const first = client.subscribeToStream('sess-1', () => {})
+    const rejection = expect(first.ready).rejects.toThrow('closed before initialization')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    const second = client.subscribeToStream('sess-1', () => {})
+    await rejection
+    sockets[1].receive({ type: 'status', data: { message: 'Connected to session stream' } })
+    await second.ready
+    first.unsubscribe()
+    expect(sockets[1].closed).toBe(false)
+    second.unsubscribe()
   })
 
   it('does not route connection_closed on a deliberate unsubscribe', async () => {
@@ -90,9 +172,9 @@ describe('subscribeToStream unsubscribe', () => {
 
     sockets[0].emit('close')
 
-    expect(messages).toHaveLength(1)
-    expect(messages[0].type).toBe('connection_closed')
-    expect(messages[0].sessionId).toBe('sess-1')
+    expect(messages.filter(m => m.type === 'connection_closed')).toEqual([
+      expect.objectContaining({ type: 'connection_closed', sessionId: 'sess-1' }),
+    ])
   })
 
   it('does not let a stale close delete a newer socket after resubscribe', async () => {

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -4718,6 +4718,106 @@ describe('MessagePersister', () => {
       expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
+    function announceProcess(processInstance = 'process-1') {
+      mockClient._sendMessage({
+        type: 'system', subtype: 'capabilities', session_state_events: true,
+        process_instance: processInstance,
+      })
+    }
+
+    function evictProcess(processInstance = 'process-1') {
+      mockClient._sendMessage({ type: 'system', subtype: 'process_evicted', process_instance: processInstance })
+    }
+
+    it('retains a chat stream on idle, then detaches only its transport on eviction', async () => {
+      await resubscribeWithMetadata({ isChatIntegrationSession: true })
+      announceProcess()
+      settleSession()
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+      const teardown = vi.spyOn(messagePersister, 'unsubscribeFromSession')
+      const recovery = vi.fn()
+      messagePersister.setUnexpectedDeathCallback(recovery)
+      evictProcess()
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(teardown).not.toHaveBeenCalled()
+      expect(recovery).not.toHaveBeenCalled()
+      const subscription = vi.mocked(mockClient.subscribeToStream).mock.results.at(-1)!.value
+      expect(subscription.unsubscribe).toHaveBeenCalledTimes(1)
+      teardown.mockRestore()
+      messagePersister.setUnexpectedDeathCallback(null)
+    })
+
+    it.each([null, { isChatIntegrationSession: true, promotedToInteractive: true }])(
+      'retains interactive or promoted streams on eviction (%j)', async (metadata) => {
+        await resubscribeWithMetadata(metadata)
+        announceProcess()
+        settleSession()
+        evictProcess()
+        expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+      },
+    )
+
+    it('does not detach for an older process or a new turn racing eviction', async () => {
+      await resubscribeWithMetadata({ isChatIntegrationSession: true })
+      announceProcess()
+      settleSession()
+      evictProcess('older-process')
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      evictProcess()
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+    })
+
+    it.each(['isAwaitingInput', 'isRecovering'] as const)('retains a chat transport while %s', async (hold) => {
+      await resubscribeWithMetadata({ isChatIntegrationSession: true })
+      announceProcess()
+      settleSession()
+      const states = (messagePersister as unknown as {
+        streamingStates: Map<string, { isAwaitingInput: boolean; isRecovering: boolean }>
+      }).streamingStates
+      states.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))![hold] = true
+      evictProcess()
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+    })
+
+    it('retains a chat transport with background work even if foreground is idle', async () => {
+      await resubscribeWithMetadata({ isChatIntegrationSession: true })
+      announceProcess()
+      settleSession()
+      mockClient._sendMessage({ type: 'system', subtype: 'background_tasks_changed', tasks: [{ task_id: 'background-task' }] })
+      evictProcess()
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+    })
+
+    it('retains an evicted chat stream after promotion', async () => {
+      await resubscribeWithMetadata({ isChatIntegrationSession: true })
+      announceProcess()
+      settleSession()
+      await messagePersister.promoteAutomatedSession(AGENT_SLUG, SESSION_ID)
+      evictProcess()
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+    })
+
+    it('releases chat transports on repeated eviction and receives output after reconnect', async () => {
+      await resubscribeWithMetadata({ isChatIntegrationSession: true })
+      const events: unknown[] = []
+      const removeListener = messagePersister.addSSEClient(AGENT_SLUG, SESSION_ID, (event) => events.push(event))
+      for (let cycle = 0; cycle < 12; cycle++) {
+        announceProcess(`process-${cycle}`)
+        settleSession()
+        evictProcess(`process-${cycle}`)
+        expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+        await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+        expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+        mockClient._sendMessage({ type: 'system', subtype: 'init', slash_commands: [] })
+        expect(events.at(-1)).toMatchObject({ type: 'stream_start' })
+      }
+      removeListener()
+    })
+
     it('keeps the stream for an interactive session', async () => {
       await resubscribeWithMetadata(null)
 

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import type { ContainerClient, StreamMessage } from './types'
+import type { ContainerClient, ContainerInfo, StreamMessage } from './types'
+import { WebSocketServer } from 'ws'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SchedMockFn = (...args: any[]) => any
@@ -967,6 +968,38 @@ describe('MessagePersister', () => {
       expect(mockAppendInformationalEntry).toHaveBeenCalledTimes(1)
       expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(sseEvents.some((e) => e.type === 'session_idle')).toBe(true)
+    })
+
+    it.each([
+      { isChatIntegrationSession: true },
+      { isScheduledExecution: true },
+      { isWebhookExecution: true },
+      { invokedByAgentSlug: 'caller' },
+    ])('finishes attachment before releasing a missed completed turn (%j)', async (metadata) => {
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      vi.mocked(getSessionMetadata).mockResolvedValue(metadata as never)
+      const subscribe = vi.mocked(mockClient.subscribeToStream).getMockImplementation()!
+      let finishReplay!: () => void
+      vi.mocked(mockClient.subscribeToStream).mockImplementationOnce((...args) => ({
+        ...subscribe(...args),
+        ready: new Promise<void>(resolve => { finishReplay = resolve }),
+      }))
+      const subscription = messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+      try {
+        await new Promise(resolve => setTimeout(resolve, 0))
+        sendCapabilities()
+        mockClient._sendMessage({ type: 'result', subtype: 'success', is_error: false, replayed: true })
+        mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle', replayed: true })
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+        expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+        finishReplay()
+        await subscription
+        expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
+      } finally {
+        finishReplay()
+        await subscription
+        vi.mocked(getSessionMetadata).mockResolvedValue(null)
+      }
     })
 
     it('ignores replayed frames when the live copies were already processed', () => {
@@ -2729,6 +2762,124 @@ describe('MessagePersister', () => {
       } finally {
         vi.mocked(getSessionMetadata).mockResolvedValue(null)
       }
+    })
+
+    it.each([
+      { isChatIntegrationSession: true },
+      { isScheduledExecution: true },
+      { isWebhookExecution: true },
+      { invokedByAgentSlug: 'caller' },
+    ])('keeps the new reply subscribed when terminal replay arrives after WebSocket open (%j)', async (metadata) => {
+      // Exercise the real client's readiness contract: the server opens the
+      // socket and sends capabilities, then delays its replay and acknowledgement.
+      const { BaseContainerClient } = await import('./base-container-client')
+      const server = new WebSocketServer({ host: '127.0.0.1', port: 0 })
+      await new Promise<void>(resolve => server.once('listening', resolve))
+      const address = server.address() as { port: number }
+      class ReplayClient extends BaseContainerClient {
+        protected getRunnerCommand() { return 'docker' }
+        async getInfoFromRuntime(): Promise<ContainerInfo> {
+          return { status: 'running', port: address.port }
+        }
+        getHostAuthHeaders() { return {} }
+      }
+      const client = new ReplayClient({ agentId: AGENT_SLUG })
+      const socketConnected = new Promise<import('ws').WebSocket>(resolve => {
+        server.once('connection', socket => {
+          socket.send(JSON.stringify({ type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'process-1' }))
+          resolve(socket)
+        })
+      })
+      const capabilitiesReceived = new Promise<void>(resolve => client.once('message', () => resolve()))
+      let acceptDelivery!: () => void
+      const deliveryAccepted = new Promise<void>(resolve => { acceptDelivery = resolve })
+      let sendStarted!: () => void
+      const deliveryStarted = new Promise<void>(resolve => { sendStarted = resolve })
+      let pendingSend: Promise<void> | undefined
+      vi.mocked(getSessionMetadata).mockResolvedValue(metadata as never)
+      try {
+        await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+        await send(async () => { emitResult(); emitIdle() })
+        expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
+        const idleEventsBefore = sseEvents.filter(e => e.type === 'session_idle').length
+        pendingSend = messagePersister.withSessionSend(AGENT_SLUG, SESSION_ID, client, async () => {
+          sendStarted()
+          await deliveryAccepted
+        })
+        const socket = await socketConnected
+        await capabilitiesReceived
+        const replayReceived = new Promise<void>(resolve => {
+          const onMessage = (_id: string, message: { type: string }) => {
+            if (message.type === 'status') {
+              client.off('message', onMessage)
+              resolve()
+            }
+          }
+          client.on('message', onMessage)
+        })
+        socket.send(JSON.stringify({ type: 'result', subtype: 'success', is_error: false, replayed: true }))
+        socket.send(JSON.stringify({ type: 'system', subtype: 'session_state_changed', state: 'idle', replayed: true }))
+        socket.send(JSON.stringify({ type: 'status', data: { message: 'Connected to session stream' } }))
+        await replayReceived
+        await deliveryStarted
+        acceptDelivery()
+        await pendingSend
+        expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+        expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(idleEventsBefore)
+
+        const replyReceived = new Promise<void>(resolve => {
+          const onMessage = (_id: string, message: { state?: string }) => {
+            if (message.state === 'idle') {
+              client.off('message', onMessage)
+              resolve()
+            }
+          }
+          client.on('message', onMessage)
+        })
+        socket.send(JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: 'The new reply' } }))
+        socket.send(JSON.stringify({ type: 'result', subtype: 'success', is_error: false }))
+        socket.send(JSON.stringify({ type: 'system', subtype: 'session_state_changed', state: 'idle' }))
+        await replyReceived
+        expect(notificationManager.triggerSessionComplete).toHaveBeenLastCalledWith(SESSION_ID, AGENT_SLUG,
+          expect.objectContaining({ responseText: 'The new reply' }))
+        expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
+      } finally {
+        acceptDelivery()
+        messagePersister.unsubscribeFromSession(AGENT_SLUG, SESSION_ID)
+        await pendingSend?.catch(() => {})
+        for (const socket of server.clients) socket.terminate()
+        await new Promise<void>(resolve => server.close(() => resolve()))
+        vi.mocked(getSessionMetadata).mockResolvedValue(null)
+      }
+    })
+
+    it.each(['explicit', 'automatic'])('waits for an %s attachment already in progress before sending', async (mode) => {
+      const subscribe = vi.mocked(mockClient.subscribeToStream).getMockImplementation()!
+      let finishReplay!: () => void
+      vi.mocked(mockClient.subscribeToStream).mockImplementationOnce((...args) => ({
+        ...subscribe(...args),
+        ready: new Promise<void>(resolve => { finishReplay = resolve }),
+      }))
+      let subscription: Promise<void> | undefined
+      if (mode === 'explicit') {
+        subscription = messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+      } else {
+        vi.mocked(mockClient.getSession).mockResolvedValueOnce({ isRunning: true } as never)
+        mockClient._sendMessage({ type: 'connection_closed' })
+        await new Promise(resolve => setTimeout(resolve, 0))
+      }
+      const delivery = vi.fn(async () => {})
+      const pendingSend = send(delivery)
+      try {
+        await new Promise(resolve => setTimeout(resolve, 0))
+        expect(delivery).not.toHaveBeenCalled()
+      } finally {
+        finishReplay()
+        await Promise.all([subscription, pendingSend])
+      }
+      expect(delivery).toHaveBeenCalledOnce()
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
     it('reconnects before activating a new turn and ignores the previous terminal replay', async () => {

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -2548,6 +2548,215 @@ describe('MessagePersister', () => {
   // markSessionIdle (optimistic-active revert)
   // ============================================================================
 
+  describe('withSessionSend', () => {
+    const emitResult = (subtype = 'success') => mockClient._sendMessage({
+      type: 'result', subtype, is_error: subtype !== 'success', num_turns: 1,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    })
+    const emitIdle = () => mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+    const send = (delivery: () => Promise<void>) =>
+      messagePersister.withSessionSend(AGENT_SLUG, SESSION_ID, mockClient, delivery)
+
+    beforeEach(() => {
+      mockClient._sendMessage({ type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'process-1' })
+    })
+
+    it.each(['before', 'after'] as const)('preserves an active turn when its final idle arrives %s a follow-up fails', async (timing) => {
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'running' })
+      emitResult()
+      await expect(send(async () => {
+        if (timing === 'before') emitIdle()
+        throw new Error('HTTP 429')
+      })).rejects.toThrow('HTTP 429')
+      if (timing === 'after') {
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+        emitIdle()
+      }
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
+      expect(notificationManager.triggerSessionComplete).toHaveBeenCalledOnce()
+    })
+
+    it('preserves a newer terminal result received during a failed follow-up', async () => {
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      emitResult()
+      await expect(send(async () => {
+        emitResult('error_during_execution')
+        emitIdle()
+        throw new Error('send failed')
+      })).rejects.toThrow('send failed')
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(notificationManager.triggerSessionComplete).not.toHaveBeenCalled()
+      expect(sseEvents.filter(e => e.type === 'session_error')).toHaveLength(1)
+    })
+
+    it('restores background waiting and settles when the last background task is stopped', async () => {
+      vi.useFakeTimers()
+      try {
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+        mockClient._sendMessage({ type: 'system', subtype: 'background_tasks_changed', tasks: [{ task_id: 'bg-task' }] })
+        emitResult()
+        emitIdle()
+        await expect(send(async () => { throw new Error('send failed') })).rejects.toThrow('send failed')
+        expect(messagePersister.isSessionWaitingBackground(AGENT_SLUG, SESSION_ID)).toBe(true)
+        mockClient._sendMessage({ type: 'system', subtype: 'task_notification', task_id: 'bg-task', status: 'stopped' })
+        await vi.advanceTimersByTimeAsync(1500)
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('preserves the stopped-task grace when a follow-up fails', async () => {
+      vi.useFakeTimers()
+      try {
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+        mockClient._sendMessage({ type: 'system', subtype: 'background_tasks_changed', tasks: [{ task_id: 'bg-task' }] })
+        emitResult()
+        emitIdle()
+        mockClient._sendMessage({ type: 'system', subtype: 'task_notification', task_id: 'bg-task', status: 'stopped' })
+        await expect(send(async () => { throw new Error('send failed') })).rejects.toThrow('send failed')
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+        await vi.advanceTimersByTimeAsync(1500)
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('cleans up a rejected reconnect without activating or sending', async () => {
+      messagePersister.unsubscribeFromSession(AGENT_SLUG, SESSION_ID)
+      const unsubscribe = vi.fn()
+      vi.mocked(mockClient.subscribeToStream).mockReturnValueOnce({
+        unsubscribe, ready: Promise.reject(new Error('reconnect failed')),
+      })
+      const delivery = vi.fn(async () => {})
+      await expect(send(delivery)).rejects.toThrow('reconnect failed')
+      expect(delivery).not.toHaveBeenCalled()
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(unsubscribe).toHaveBeenCalledOnce()
+    })
+
+    it('rolls back an unaccepted fresh send and its provisional recency', async () => {
+      await expect(send(async () => { throw new Error('send failed') })).rejects.toThrow('send failed')
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(mockRevertSessionActivity).toHaveBeenCalledOnce()
+    })
+
+    it.each(['assistant', 'stream_event'])('does not roll back accepted %s output after a failed HTTP response', async (type) => {
+      await expect(send(async () => {
+        mockClient._sendMessage(type === 'assistant'
+          ? { type, message: { role: 'assistant', content: 'Already running' } }
+          : { type, event: { type: 'message_start', message: { id: 'new-message' } } })
+        throw new Error('response lost')
+      })).rejects.toThrow('response lost')
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+      expect(mockRevertSessionActivity).not.toHaveBeenCalled()
+      emitResult()
+      emitIdle()
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+    })
+
+    it('rolls back overlapping failed deliveries without inheriting provisional activity', async () => {
+      let rejectFirst!: (error: Error) => void
+      const first = send(() => new Promise<void>((_resolve, reject) => { rejectFirst = reject }))
+      const secondDelivery = vi.fn(async () => { throw new Error('second failed') })
+      const second = send(secondDelivery)
+      expect(secondDelivery).not.toHaveBeenCalled()
+      const failures = Promise.all([
+        expect(first).rejects.toThrow('first failed'),
+        expect(second).rejects.toThrow('second failed'),
+      ])
+      rejectFirst(new Error('first failed'))
+      await failures
+      expect(secondDelivery).toHaveBeenCalledOnce()
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(mockRevertSessionActivity).toHaveBeenCalledTimes(2)
+    })
+
+    it('leaves a turn owned by recovery active when delivery fails', async () => {
+      await expect(send(async () => {
+        messagePersister.snapshotMidTurnSessions(AGENT_SLUG)
+        throw new Error('connection lost during recovery')
+      })).rejects.toThrow('connection lost during recovery')
+      expect(messagePersister.isSessionRecovering(AGENT_SLUG, SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+      expect(mockRevertSessionActivity).not.toHaveBeenCalled()
+    })
+
+    it('does not roll back a newer send when an older delivery fails', async () => {
+      await expect(send(async () => {
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+        throw new Error('older send failed')
+      })).rejects.toThrow('older send failed')
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+      expect(mockRevertSessionActivity).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      { isScheduledExecution: true },
+      { isWebhookExecution: true },
+      { isChatIntegrationSession: true },
+      { invokedByAgentSlug: 'caller' },
+    ])('releases an unpromoted automation only after delivery and settlement (%j)', async (metadata) => {
+      vi.mocked(getSessionMetadata).mockResolvedValue(metadata as never)
+      try {
+        await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+        await send(async () => {
+          emitResult()
+          emitIdle()
+          expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+        })
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+        expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
+      } finally {
+        vi.mocked(getSessionMetadata).mockResolvedValue(null)
+      }
+    })
+
+    it('remembers eviction during a failed send and releases its idle transport', async () => {
+      vi.mocked(getSessionMetadata).mockResolvedValue({ isChatIntegrationSession: true } as never)
+      try {
+        await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+        await expect(send(async () => {
+          mockClient._sendMessage({ type: 'system', subtype: 'process_evicted', process_instance: 'process-1' })
+          expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+          throw new Error('send failed')
+        })).rejects.toThrow('send failed')
+        expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
+      } finally {
+        vi.mocked(getSessionMetadata).mockResolvedValue(null)
+      }
+    })
+
+    it('reconnects before activating a new turn and ignores the previous terminal replay', async () => {
+      vi.mocked(getSessionMetadata).mockResolvedValue({ isChatIntegrationSession: true } as never)
+      try {
+        await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+        await send(async () => { emitResult(); emitIdle() })
+        expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
+        const subscribe = vi.mocked(mockClient.subscribeToStream).getMockImplementation()!
+        vi.mocked(mockClient.subscribeToStream).mockImplementationOnce((...args) => {
+          const subscription = subscribe(...args)
+          return { ...subscription, ready: Promise.resolve().then(() => {
+            mockClient._sendMessage({ type: 'result', subtype: 'success', is_error: false, replayed: true })
+            mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle', replayed: true })
+          }) }
+        })
+        const idleEventsBefore = sseEvents.filter(e => e.type === 'session_idle').length
+        await send(async () => {
+          expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+          expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+          expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(idleEventsBefore)
+        })
+      } finally {
+        vi.mocked(getSessionMetadata).mockResolvedValue(null)
+      }
+    })
+  })
+
   describe('markSessionIdle', () => {
     it('flips an active session back to idle and broadcasts session_idle', () => {
       messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
@@ -4729,15 +4938,13 @@ describe('MessagePersister', () => {
       mockClient._sendMessage({ type: 'system', subtype: 'process_evicted', process_instance: processInstance })
     }
 
-    it('retains a chat stream on idle, then detaches only its transport on eviction', async () => {
+    it('releases only a chat transport when its turn settles', async () => {
       await resubscribeWithMetadata({ isChatIntegrationSession: true })
       announceProcess()
-      settleSession()
-      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
       const teardown = vi.spyOn(messagePersister, 'unsubscribeFromSession')
       const recovery = vi.fn()
       messagePersister.setUnexpectedDeathCallback(recovery)
-      evictProcess()
+      settleSession()
       expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(teardown).not.toHaveBeenCalled()
       expect(recovery).not.toHaveBeenCalled()
@@ -4760,7 +4967,6 @@ describe('MessagePersister', () => {
     it('does not detach for an older process or a new turn racing eviction', async () => {
       await resubscribeWithMetadata({ isChatIntegrationSession: true })
       announceProcess()
-      settleSession()
       evictProcess('older-process')
       expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
       messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
@@ -4772,7 +4978,6 @@ describe('MessagePersister', () => {
     it.each(['isAwaitingInput', 'isRecovering'] as const)('retains a chat transport while %s', async (hold) => {
       await resubscribeWithMetadata({ isChatIntegrationSession: true })
       announceProcess()
-      settleSession()
       const states = (messagePersister as unknown as {
         streamingStates: Map<string, { isAwaitingInput: boolean; isRecovering: boolean }>
       }).streamingStates
@@ -4784,7 +4989,6 @@ describe('MessagePersister', () => {
     it('retains a chat transport with background work even if foreground is idle', async () => {
       await resubscribeWithMetadata({ isChatIntegrationSession: true })
       announceProcess()
-      settleSession()
       mockClient._sendMessage({ type: 'system', subtype: 'background_tasks_changed', tasks: [{ task_id: 'background-task' }] })
       evictProcess()
       expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
@@ -4793,13 +4997,12 @@ describe('MessagePersister', () => {
     it('retains an evicted chat stream after promotion', async () => {
       await resubscribeWithMetadata({ isChatIntegrationSession: true })
       announceProcess()
-      settleSession()
       await messagePersister.promoteAutomatedSession(AGENT_SLUG, SESSION_ID)
       evictProcess()
       expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 
-    it('releases chat transports on repeated eviction and receives output after reconnect', async () => {
+    it('releases chat transports on repeated settlement and receives output after reconnect', async () => {
       await resubscribeWithMetadata({ isChatIntegrationSession: true })
       const events: unknown[] = []
       const removeListener = messagePersister.addSSEClient(AGENT_SLUG, SESSION_ID, (event) => events.push(event))
@@ -4880,6 +5083,41 @@ describe('MessagePersister', () => {
       })
 
       expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+    })
+
+    it('releases when automation metadata resolves after the turn already settled', async () => {
+      let resolveMetadata!: (value: never) => void
+      vi.mocked(getSessionMetadata).mockImplementationOnce(() => new Promise(resolve => { resolveMetadata = resolve }))
+      await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+      settleSession()
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+      resolveMetadata({ invokedByAgentSlug: 'caller' } as never)
+      await vi.waitFor(() => expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false))
+    })
+
+    it('does not use an older idle as settlement for a newer error result', async () => {
+      settleSession()
+      let resolveMetadata!: (value: never) => void
+      vi.mocked(getSessionMetadata).mockImplementationOnce(() => new Promise(resolve => { resolveMetadata = resolve }))
+      await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      mockClient._sendMessage({ type: 'result', subtype: 'error_during_execution', is_error: true })
+      resolveMetadata({ isChatIntegrationSession: true } as never)
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+      expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(false)
+    })
+
+    it.each([
+      { isScheduledExecution: true }, { isWebhookExecution: true },
+      { isChatIntegrationSession: true }, { invokedByAgentSlug: 'caller' },
+    ])('retains every promoted automation category (%j)', async (metadata) => {
+      await resubscribeWithMetadata({ ...metadata, promotedToInteractive: true })
+      announceProcess()
+      settleSession()
+      evictProcess()
       expect(messagePersister.isSubscribed(AGENT_SLUG, SESSION_ID)).toBe(true)
     })
 

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -219,13 +219,20 @@ interface StreamingState {
   agentSlug: string // The agent that owns this session; half of its registry key
   sessionId: string // The bare id, for payloads and disk paths
   notAutomationSession?: boolean // Cached "not a cron/webhook session" verdict; skips the automation-status metadata write on later results
-  // Unpromoted cron/webhook session: release its container stream when the
-  // session settles. Resolved from session metadata at subscribe time so the
-  // settle-time teardown in finalizeIdle stays synchronous (race-free).
-  releaseStreamOnSettle?: boolean
-  releaseStreamOnEviction?: boolean
+  // Shared by every unpromoted automation, including chat and x-agent sessions.
+  // Unknown metadata keeps the stream until its policy is resolved.
+  releaseStreamWhenIdle?: boolean
+  retainStateOnStreamRelease?: boolean
+  evictedProcessInstanceId?: string
+  // Send rollback must not overwrite a later host send or runtime result.
+  activityGeneration?: number
+  resultGeneration?: number
+  // Only an idle after this result proves settlement on the current transport.
+  settledResultGeneration?: number
+  // A fresh send that already produced output was accepted despite HTTP failure.
+  outputGeneration?: number
   // Set synchronously on promote so an in-flight subscribe-time metadata read
-  // cannot flip releaseStreamOnSettle back to true.
+  // cannot enable stream release again.
   promotedToInteractive?: boolean
   // True when the most recent result was a clean success (not error-shaped,
   // not an interrupt, not a resume-exit). Consumed by finalizeIdle: a success
@@ -423,6 +430,12 @@ class MessagePersister {
   // subscribeToSession() calls for the same session share the underlying
   // promise so we don't double-install listeners or double-tear-down state.
   private subscribingNow: Map<SessionKey, Promise<void>> = new Map()
+  // A send can outlive the previous turn's idle or the reconnect handshake.
+  // Hold the transport independently of the current turn's activity.
+  private pendingSessionSends: Map<SessionKey, number> = new Map()
+  // Serialize delivery attempts, not runtime turns. A rejected send is fully
+  // rolled back before another caller snapshots the same session's activity.
+  private sendingNow: Map<SessionKey, Promise<void>> = new Map()
 
   constructor() {
     // Unified wire: every registry transition — no matter which of the many
@@ -630,14 +643,21 @@ class MessagePersister {
       processInstanceId: prior?.processInstanceId ?? null,
       pendingDeliverFiles: new Map(),
       stateEventsAuthority: prior?.stateEventsAuthority ?? false,
-      lastResultSubtype: null,
-      lastResultCleanSuccess: false,
-      provisionalActivity: null,
+      lastResultSubtype: prior?.lastResultSubtype ?? null,
+      lastResultCleanSuccess: prior?.lastResultCleanSuccess ?? false,
+      provisionalActivity: prior?.provisionalActivity ?? null,
+      activityGeneration: prior?.activityGeneration,
+      resultGeneration: prior?.resultGeneration,
+      outputGeneration: prior?.outputGeneration,
+      // A requested reattach must stay open until this subscription observes
+      // settlement/eviction; the outgoing transport's proof is already spent.
+      settledResultGeneration: undefined,
+      evictedProcessInstanceId: undefined,
       isRetrying: false,
       // Carried over so a transport reattach mid-run doesn't lose the verdict
       // before the refresh below lands.
-      releaseStreamOnSettle: prior?.releaseStreamOnSettle ?? false,
-      releaseStreamOnEviction: prior?.releaseStreamOnEviction ?? false,
+      releaseStreamWhenIdle: prior?.releaseStreamWhenIdle ?? false,
+      retainStateOnStreamRelease: prior?.retainStateOnStreamRelease ?? false,
       promotedToInteractive: prior?.promotedToInteractive ?? false,
     })
 
@@ -660,8 +680,14 @@ class MessagePersister {
       await this.capture.recordNote(sessionId, 'subscribe', { agentSlug, containerSessionId })
     }
 
-    // Wait for the WebSocket connection to be established
-    await ready
+    // A rejected handshake must not leave isSubscribed pointing at a dead
+    // transport. A replacement subscription, if any, owns its own cleanup.
+    try {
+      await ready
+    } catch (error) {
+      if (this.subscriptions.get(ctx.key) === unsubscribe) this.detachSessionTransport(agentSlug, sessionId)
+      throw error
+    }
   }
 
   // An unresolved metadata read keeps the transport rather than guessing its lifecycle.
@@ -675,11 +701,9 @@ class MessagePersister {
         if (!current || current !== stateRef) return
         // Promote wins: its marker is set synchronously, this read may be stale.
         if (current.promotedToInteractive) return
-        current.releaseStreamOnEviction = Boolean(meta?.isChatIntegrationSession && !meta?.promotedToInteractive)
-        current.releaseStreamOnSettle = Boolean(
-          (meta?.isScheduledExecution || meta?.isWebhookExecution || meta?.invokedByAgentSlug) &&
-            !meta?.promotedToInteractive
-        )
+        current.releaseStreamWhenIdle = isHiddenAutomatedSession(meta)
+        current.retainStateOnStreamRelease = Boolean(meta?.isChatIntegrationSession)
+        this.maybeReleaseSessionTransport(current)
       })
       .catch((error) => {
         console.warn('[MessagePersister] Failed to resolve automation stream policy:', error)
@@ -733,20 +757,160 @@ class MessagePersister {
       agentSlug: state.agentSlug,
       isActive: false,
     })
-    this.maybeReleaseSettledAutomationStream(state)
+    this.maybeReleaseSessionTransport(state)
   }
 
-  // Tear down a settled automation stream. Sync: an async gap races the wake path's isSubscribed check.
-  // Gated on stateEventsAuthority so a legacy idle can't drop a queued turn's stream.
-  private maybeReleaseSettledAutomationStream(state: StreamingState): void {
+  // All automation categories share the same release guard. Chat retains
+  // conversation/request state across reconnect; other automations keep their
+  // existing full cleanup so completed runs don't accumulate in memory.
+  // A result alone cannot prove the queue and background work have drained.
+  private maybeReleaseSessionTransport(state: StreamingState): void {
     const { agentSlug, sessionId } = state
+    const key = sessionKeyOf(agentSlug, sessionId)
+    const settled = state.stateEventsAuthority && state.runtimeState === 'idle' &&
+      state.lastResultSubtype !== null && state.settledResultGeneration === state.resultGeneration
+    const evicted = state.evictedProcessInstanceId !== undefined && state.evictedProcessInstanceId === state.processInstanceId
     if (
-      state.releaseStreamOnSettle &&
-      state.stateEventsAuthority &&
-      this.subscriptions.has(sessionKeyOf(agentSlug, sessionId))
+      state.releaseStreamWhenIdle && !state.promotedToInteractive &&
+      !state.isActive && !state.isAwaitingInput && !state.isRecovering &&
+      this.openBackgroundWorkCount(state) === 0 &&
+      !this.pendingSessionSends.has(key) &&
+      (settled || evicted) && this.subscriptions.has(key)
     ) {
-      console.log(`[MessagePersister] Releasing settled automation stream for session ${sessionId}`)
-      this.unsubscribeFromSession(agentSlug, sessionId)
+      console.log(`[MessagePersister] Releasing idle automation stream for session ${sessionId}`)
+      if (state.retainStateOnStreamRelease) this.detachSessionTransport(agentSlug, sessionId)
+      else this.unsubscribeFromSession(agentSlug, sessionId)
+    }
+  }
+
+  // Shared delivery boundary for chat, scheduled wakes and x-agent follow-ups.
+  // The transport reservation precedes reconnect; activity is marked only
+  // after reconnect, allowing its terminal replay to observe the settled turn.
+  async withSessionSend<T>(
+    agentSlug: string,
+    sessionId: string,
+    client: ContainerClient,
+    send: () => Promise<T>,
+  ): Promise<T> {
+    const key = sessionKeyOf(agentSlug, sessionId)
+    const previousSend = this.sendingNow.get(key)
+    let finishDelivery!: () => void
+    const deliveryDone = new Promise<void>(resolve => { finishDelivery = resolve })
+    this.sendingNow.set(key, deliveryDone)
+    this.pendingSessionSends.set(key, (this.pendingSessionSends.get(key) ?? 0) + 1)
+    try {
+      if (previousSend) await previousSend
+      if (!this.isSubscribed(agentSlug, sessionId)) {
+        await this.subscribeToSession(agentSlug, sessionId, client, sessionId)
+      }
+      const before = { ...this.streamingStates.get(key)! }
+      this.markSessionActive(agentSlug, sessionId)
+      const marked = this.streamingStates.get(key)!
+      const generation = marked.activityGeneration
+      const activity = marked.provisionalActivity
+      try {
+        return await send()
+      } catch (error) {
+        const state = this.streamingStates.get(key)
+        // A later send, interrupt, recovery, or new runtime turn owns its state.
+        if (
+          state && state.activityGeneration === generation &&
+          state.turnGeneration === before.turnGeneration &&
+          state.processInstanceId === before.processInstanceId && !state.isInterrupted && !state.isRecovering
+        ) {
+          const outputArrived = state.outputGeneration !== before.outputGeneration
+          if ((before.isActive || !outputArrived) && state.provisionalActivity === activity && activity) {
+            revertSessionActivity(agentSlug, sessionId, activity)
+            state.provisionalActivity = null
+          }
+          if (before.isActive) {
+            const resultArrived = state.resultGeneration !== before.resultGeneration
+            // Remove only this rejected queued message. If its speculative
+            // boundary was consumed by a result, there is no next answer to reset.
+            if (state.queuedTurnCount > 0) state.queuedTurnCount -= 1
+            else state.resetAssistantBeforeNextTurnOutput = false
+            if (!resultArrived) {
+              state.lastResultSubtype = before.lastResultSubtype
+              state.lastResultCleanSuccess = before.lastResultCleanSuccess
+              state.lastApiErrorCode = before.lastApiErrorCode
+              state.isInterrupted = before.isInterrupted
+            }
+            // The final idle may have arrived while the failed send was in
+            // flight and its result guard was cleared. Apply it now as well.
+            if (
+              !resultArrived && (before.settleAfterStopTimer || before.waitingBackground) &&
+              state.isActive && state.runtimeState === 'idle' && this.openBackgroundWorkCount(state) === 0
+            ) {
+              // Preserve the stopped background task's grace for a possible wake.
+              this.scheduleSettleAfterStop(agentSlug, sessionId, state)
+            } else if (state.runtimeState === 'idle') {
+              this.handleSessionIdle(state)
+            }
+          } else if (!outputArrived) {
+            this.markSessionIdle(agentSlug, sessionId)
+            state.lastResultSubtype = before.lastResultSubtype
+            state.lastResultCleanSuccess = before.lastResultCleanSuccess
+          }
+        }
+        throw error
+      }
+    } finally {
+      finishDelivery()
+      if (this.sendingNow.get(key) === deliveryDone) this.sendingNow.delete(key)
+      const remaining = (this.pendingSessionSends.get(key) ?? 1) - 1
+      if (remaining > 0) this.pendingSessionSends.set(key, remaining)
+      else this.pendingSessionSends.delete(key)
+      const state = this.streamingStates.get(key)
+      if (state) this.maybeReleaseSessionTransport(state)
+    }
+  }
+
+  private handleSessionIdle(state: StreamingState): void {
+    const { agentSlug, sessionId } = state
+    // Only treat idle as authoritative when a result was actually seen
+    // for this turn (lastResultSubtype is cleared on every new send).
+    // A bare idle with no preceding result — a stale idle from a prior
+    // or interrupted run racing a fresh message, or an event before any
+    // turn output — must not finalize, or it fires a spurious
+    // session_idle (and a bogus completion notification).
+    if (state.isActive && state.lastResultSubtype !== null) {
+      const openBackgroundWork = this.openBackgroundWorkCount(state)
+      if (openBackgroundWork > 0) {
+        // Idle here does NOT mean "settled". activeBackgroundTasks holds
+        // backgrounded Bash commands (task_type=local_bash) and dynamic
+        // workflows (local_workflow); for both the SDK fires `idle` at
+        // TURN-END while the work is still running, then re-fires `running`
+        // + task_notification when it actually finishes. Phantom-clearing
+        // + finalizing here would
+        // drop the indicator and un-gate auto-sleep mid-job — the exact
+        // failure run_in_background is meant to prevent. Keep the session
+        // alive and surface it as waiting-on-background; the per-task
+        // terminal signal (task_notification / task_updated) clears each
+        // task, and the subsequent, truly-settled idle finalizes.
+        state.waitingBackground = true
+        this.broadcastToSSE(agentSlug, sessionId, {
+          type: 'session_waiting_background',
+          backgroundTaskCount: openBackgroundWork,
+        })
+      } else {
+        this.finalizeIdle(agentSlug, sessionId, state)
+        // Completion notification at the real end of the work. Skip
+        // resume-exits: the session is pausing for a resume, not done.
+        if (state.lastResultSubtype === 'success' && state.agentSlug) {
+          notificationManager.triggerSessionComplete(sessionId, state.agentSlug, {
+            responseText: state.lastAssistantText,
+            responseTranscriptEndOffset: this.getSessionTranscriptEndOffset(
+              state.agentSlug,
+              sessionId,
+            ),
+          }).catch((err) => {
+            console.error('[MessagePersister] Failed to trigger session complete notification:', err)
+          })
+        }
+      }
+    } else if (!state.isActive && state.lastResultSubtype !== null) {
+      // Error path already cleared isActive, so finalizeIdle never ran.
+      this.maybeReleaseSessionTransport(state)
     }
   }
 
@@ -1518,6 +1682,7 @@ class MessagePersister {
     // session's whole reported status collapses to "Working…" the moment a
     // follow-up is queued (SUP-736).
     const wasActive = state.isActive
+    state.activityGeneration = (state.activityGeneration ?? 0) + 1
     state.isActive = true
     // Message-scoped: true for a queued message just as much as a new turn.
     state.isInterrupted = false // Reset interrupted flag on new message
@@ -1764,8 +1929,7 @@ class MessagePersister {
     const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     if (state) {
       state.promotedToInteractive = true
-      state.releaseStreamOnSettle = false
-      state.releaseStreamOnEviction = false
+      state.releaseStreamWhenIdle = false
     }
 
     console.log(`[MessagePersister] Promoted automated session ${sessionId} to interactive (agent: ${agentSlug})`)
@@ -1935,6 +2099,11 @@ class MessagePersister {
     }
 
     const content = message.content
+    if (!content.replayed && (
+      content.type === 'assistant' || content.type === 'user' || content.type === 'result' || content.type === 'stream_event'
+    )) {
+      state.outputGeneration = (state.outputGeneration ?? 0) + 1
+    }
 
     // Detect background task completion from `task_notification` system messages
     // BEFORE the sidechain filter. This is the idle/wake path: when a backgrounded
@@ -2406,16 +2575,11 @@ class MessagePersister {
             this.broadcastSubagentCompleted(agentSlug, sessionId, state, toolUseId!, summary)
           }
         } else if (content.subtype === 'process_evicted') {
-          if (
-            state.releaseStreamOnEviction &&
-            !state.isActive &&
-            !state.isAwaitingInput &&
-            !state.isRecovering &&
-            this.openBackgroundWorkCount(state) === 0 &&
-            typeof content.process_instance === 'string' &&
-            content.process_instance === state.processInstanceId
-          ) {
-            this.detachSessionTransport(agentSlug, sessionId)
+          if (typeof content.process_instance === 'string' && content.process_instance === state.processInstanceId) {
+            // Remember eviction across an in-flight send or metadata read; a
+            // failed delivery must not lose this one-shot release opportunity.
+            state.evictedProcessInstanceId = content.process_instance
+            this.maybeReleaseSessionTransport(state)
           }
         } else if (content.subtype === 'process_restarted') {
           // Container-synthesized, live: the session's CLI process was replaced
@@ -2457,51 +2621,8 @@ class MessagePersister {
             state.turnGeneration += 1
           }
           if (content.state === 'idle') {
-            // Only treat idle as authoritative when a result was actually seen
-            // for this turn (lastResultSubtype is cleared on every new send).
-            // A bare idle with no preceding result — a stale idle from a prior
-            // or interrupted run racing a fresh message, or an event before any
-            // turn output — must not finalize, or it fires a spurious
-            // session_idle (and a bogus completion notification).
-            if (state.isActive && state.lastResultSubtype !== null) {
-              const openBackgroundWork = this.openBackgroundWorkCount(state)
-              if (openBackgroundWork > 0) {
-                // Idle here does NOT mean "settled". activeBackgroundTasks holds
-                // backgrounded Bash commands (task_type=local_bash) and dynamic
-                // workflows (local_workflow); for both the SDK fires `idle` at
-                // TURN-END while the work is still running, then re-fires `running`
-                // + task_notification when it actually finishes. Phantom-clearing
-                // + finalizing here would
-                // drop the indicator and un-gate auto-sleep mid-job — the exact
-                // failure run_in_background is meant to prevent. Keep the session
-                // alive and surface it as waiting-on-background; the per-task
-                // terminal signal (task_notification / task_updated) clears each
-                // task, and the subsequent, truly-settled idle finalizes.
-                state.waitingBackground = true
-                this.broadcastToSSE(agentSlug, sessionId, {
-                  type: 'session_waiting_background',
-                  backgroundTaskCount: openBackgroundWork,
-                })
-              } else {
-                this.finalizeIdle(agentSlug, sessionId, state)
-                // Completion notification at the real end of the work. Skip
-                // resume-exits: the session is pausing for a resume, not done.
-                if (state.lastResultSubtype === 'success' && state.agentSlug) {
-                  notificationManager.triggerSessionComplete(sessionId, state.agentSlug, {
-                    responseText: state.lastAssistantText,
-                    responseTranscriptEndOffset: this.getSessionTranscriptEndOffset(
-                      state.agentSlug,
-                      sessionId,
-                    ),
-                  }).catch((err) => {
-                    console.error('[MessagePersister] Failed to trigger session complete notification:', err)
-                  })
-                }
-              }
-            } else if (!state.isActive && state.lastResultSubtype !== null) {
-              // Error path already cleared isActive, so finalizeIdle never ran.
-              this.maybeReleaseSettledAutomationStream(state)
-            }
+            state.settledResultGeneration = state.resultGeneration
+            this.handleSessionIdle(state)
           } else if (content.state === 'running') {
             // A turn is running again, so the interrupted turn's stale frames
             // can no longer be in the pipe: let this turn's content through.
@@ -2589,6 +2710,7 @@ class MessagePersister {
       }
 
       case 'result': {
+        state.resultGeneration = (state.resultGeneration ?? 0) + 1
         // Query completed. Classification handles both error shapes — the
         // legacy error subtypes and the modern success-subtype-with-is_error
         // (terminal_reason: api_error etc.) that a subtype check alone misses.

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -550,7 +550,7 @@ class MessagePersister {
   }
 
   // Subscribe to a session's messages for SSE streaming.
-  // Returns a promise that resolves when the WebSocket connection is ready.
+  // Resolves after the guest attaches its listener and finishes terminal replay.
   // Idempotent: concurrent calls for the same sessionId await the same in-flight
   // subscription instead of racing each other (which would re-init state and
   // leak listeners).
@@ -563,10 +563,19 @@ class MessagePersister {
     const ctx = sessionCtx(agentSlug, sessionId)
     const inFlight = this.subscribingNow.get(ctx.key)
     if (inFlight) return inFlight
-    const promise = this.doSubscribeToSession(ctx, client, containerSessionId)
-      .finally(() => {
-        this.subscribingNow.delete(ctx.key)
-      })
+    return this.trackSubscription(ctx, this.doSubscribeToSession(ctx, client, containerSessionId))
+  }
+
+  private trackSubscription(ctx: SessionCtx, ready: Promise<void>): Promise<void> {
+    const promise = ready.finally(() => {
+      if (this.subscribingNow.get(ctx.key) !== promise) return
+      this.subscribingNow.delete(ctx.key)
+      // Replayed terminal frames can settle an automation during attachment.
+      // Defer its release until ready resolves, or closing before the guest's
+      // acknowledgement would abort an otherwise successful subscription.
+      const state = this.streamingStates.get(ctx.key)
+      if (state) this.maybeReleaseSessionTransport(state)
+    })
     this.subscribingNow.set(ctx.key, promise)
     return promise
   }
@@ -774,7 +783,7 @@ class MessagePersister {
       state.releaseStreamWhenIdle && !state.promotedToInteractive &&
       !state.isActive && !state.isAwaitingInput && !state.isRecovering &&
       this.openBackgroundWorkCount(state) === 0 &&
-      !this.pendingSessionSends.has(key) &&
+      !this.pendingSessionSends.has(key) && !this.subscribingNow.has(key) &&
       (settled || evicted) && this.subscriptions.has(key)
     ) {
       console.log(`[MessagePersister] Releasing idle automation stream for session ${sessionId}`)
@@ -800,6 +809,8 @@ class MessagePersister {
     this.pendingSessionSends.set(key, (this.pendingSessionSends.get(key) ?? 0) + 1)
     try {
       if (previousSend) await previousSend
+      const connecting = this.subscribingNow.get(key)
+      if (connecting) await connecting
       if (!this.isSubscribed(agentSlug, sessionId)) {
         await this.subscribeToSession(agentSlug, sessionId, client, sessionId)
       }
@@ -3007,7 +3018,7 @@ class MessagePersister {
           // handler to the `ready` promise. A failed reconnect routes a
           // synthesized connection_closed message through the callback above;
           // this only stops the discarded rejection from becoming unhandled.
-          ready.catch((err) => {
+          this.trackSubscription(sessionCtx(agentSlug, sessionId), ready).catch((err) => {
             console.error(`[MessagePersister] Re-subscribe failed for session ${sessionId}:`, err)
           })
         } else {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -223,6 +223,7 @@ interface StreamingState {
   // session settles. Resolved from session metadata at subscribe time so the
   // settle-time teardown in finalizeIdle stays synchronous (race-free).
   releaseStreamOnSettle?: boolean
+  releaseStreamOnEviction?: boolean
   // Set synchronously on promote so an in-flight subscribe-time metadata read
   // cannot flip releaseStreamOnSettle back to true.
   promotedToInteractive?: boolean
@@ -636,10 +637,11 @@ class MessagePersister {
       // Carried over so a transport reattach mid-run doesn't lose the verdict
       // before the refresh below lands.
       releaseStreamOnSettle: prior?.releaseStreamOnSettle ?? false,
+      releaseStreamOnEviction: prior?.releaseStreamOnEviction ?? false,
       promotedToInteractive: prior?.promotedToInteractive ?? false,
     })
 
-    this.resolveReleaseStreamOnSettle(ctx)
+    this.resolveStreamReleasePolicy(ctx)
 
     // Store container client for reconnection checks
     this.containerClients.set(ctx.key, client)
@@ -662,12 +664,8 @@ class MessagePersister {
     await ready
   }
 
-  // Resolve whether this subscription belongs to an unpromoted cron, webhook,
-  // or x-agent session. Non-blocking: automation runs last long enough that
-  // the verdict lands well before finalizeIdle consumes it, and an unresolved
-  // read just means the stream is kept (the pre-fix behavior). Automation
-  // paths register metadata before subscribing, so the read can't miss them.
-  private resolveReleaseStreamOnSettle(ctx: SessionCtx): void {
+  // An unresolved metadata read keeps the transport rather than guessing its lifecycle.
+  private resolveStreamReleasePolicy(ctx: SessionCtx): void {
     const { agentSlug, sessionId } = ctx
     const stateRef = this.streamingStates.get(ctx.key)
     void getSessionMetadata(agentSlug, sessionId)
@@ -677,6 +675,7 @@ class MessagePersister {
         if (!current || current !== stateRef) return
         // Promote wins: its marker is set synchronously, this read may be stale.
         if (current.promotedToInteractive) return
+        current.releaseStreamOnEviction = Boolean(meta?.isChatIntegrationSession && !meta?.promotedToInteractive)
         current.releaseStreamOnSettle = Boolean(
           (meta?.isScheduledExecution || meta?.isWebhookExecution || meta?.invokedByAgentSlug) &&
             !meta?.promotedToInteractive
@@ -685,7 +684,7 @@ class MessagePersister {
       .catch((error) => {
         console.warn('[MessagePersister] Failed to resolve automation stream policy:', error)
         captureException(error, {
-          tags: { area: 'container', op: 'resolveReleaseStreamOnSettle' },
+          tags: { area: 'container', op: 'resolveStreamReleasePolicy' },
           extra: { sessionId, agentSlug },
         })
       })
@@ -1766,6 +1765,7 @@ class MessagePersister {
     if (state) {
       state.promotedToInteractive = true
       state.releaseStreamOnSettle = false
+      state.releaseStreamOnEviction = false
     }
 
     console.log(`[MessagePersister] Promoted automated session ${sessionId} to interactive (agent: ${agentSlug})`)
@@ -2404,6 +2404,18 @@ class MessagePersister {
           ) {
             const summary = typeof content.summary === 'string' ? content.summary : undefined
             this.broadcastSubagentCompleted(agentSlug, sessionId, state, toolUseId!, summary)
+          }
+        } else if (content.subtype === 'process_evicted') {
+          if (
+            state.releaseStreamOnEviction &&
+            !state.isActive &&
+            !state.isAwaitingInput &&
+            !state.isRecovering &&
+            this.openBackgroundWorkCount(state) === 0 &&
+            typeof content.process_instance === 'string' &&
+            content.process_instance === state.processInstanceId
+          ) {
+            this.detachSessionTransport(agentSlug, sessionId)
           }
         } else if (content.subtype === 'process_restarted') {
           // Container-synthesized, live: the session's CLI process was replaced

--- a/src/shared/lib/container/types.ts
+++ b/src/shared/lib/container/types.ts
@@ -274,7 +274,8 @@ export interface ContainerClient {
   observeUnexpectedDeath(input?: ObserveUnexpectedDeathInput): Promise<UnexpectedDeathPlan>
   getRuntimeGenerationId(): string | null
 
-  // Streaming - returns unsubscribe function and a ready promise
+  // Streaming - ready resolves after listener attachment and terminal replay,
+  // before a new send may safely mark the session active.
   subscribeToStream(
     sessionId: string,
     callback: (message: StreamMessage) => void

--- a/src/shared/lib/scheduler/task-scheduler.session-wake.test.ts
+++ b/src/shared/lib/scheduler/task-scheduler.session-wake.test.ts
@@ -47,6 +47,11 @@ const mockBroadcastSessionUpdate = vi.fn()
 
 vi.mock('@shared/lib/container/message-persister', () => ({
   messagePersister: {
+    withSessionSend: async (agentSlug: string, sessionId: string, _client: unknown, send: () => Promise<unknown>) => {
+      mockMarkSessionActive(agentSlug, sessionId)
+      try { return await send() }
+      catch (error) { mockMarkSessionIdle(agentSlug, sessionId); throw error }
+    },
     subscribeToSession: (...args: unknown[]) => mockSubscribeToSession(...args),
     markSessionActive: (...args: unknown[]) => mockMarkSessionActive(...args),
     markSessionIdle: (...args: unknown[]) => mockMarkSessionIdle(...args),

--- a/src/shared/lib/scheduler/task-scheduler.ts
+++ b/src/shared/lib/scheduler/task-scheduler.ts
@@ -250,9 +250,9 @@ class TaskScheduler {
       automationStatus: 'running',
     })
 
-    // Subscribe to the session for SSE updates
-    await messagePersister.subscribeToSession(task.agentSlug, sessionId, client, sessionId)
+    // createSession already started the turn; replay may finish it during attachment.
     messagePersister.markSessionActive(task.agentSlug, sessionId)
+    await messagePersister.subscribeToSession(task.agentSlug, sessionId, client, sessionId)
 
     console.log(
       `[TaskScheduler] Task ${task.id} started, session: ${sessionId}`

--- a/src/shared/lib/scheduler/trigger-manager.ts
+++ b/src/shared/lib/scheduler/trigger-manager.ts
@@ -371,8 +371,9 @@ class TriggerManager {
       automationStatus: 'running',
     })
 
-    await messagePersister.subscribeToSession(trigger.agentSlug, sessionId, client, sessionId)
+    // createSession already started the turn; replay may finish it during attachment.
     messagePersister.markSessionActive(trigger.agentSlug, sessionId)
+    await messagePersister.subscribeToSession(trigger.agentSlug, sessionId, client, sessionId)
 
     // Update trigger tracking
     await markTriggerFired(trigger.id, sessionId)

--- a/src/shared/lib/scheduler/wake-delivery.test.ts
+++ b/src/shared/lib/scheduler/wake-delivery.test.ts
@@ -28,6 +28,11 @@ const mockBroadcastSessionUpdate = vi.fn()
 
 vi.mock('@shared/lib/container/message-persister', () => ({
   messagePersister: {
+    withSessionSend: async (agentSlug: string, sessionId: string, _client: unknown, send: () => Promise<unknown>) => {
+      mockMarkSessionActive(agentSlug, sessionId)
+      try { return await send() }
+      catch (error) { mockMarkSessionIdle(agentSlug, sessionId); throw error }
+    },
     subscribeToSession: (...args: unknown[]) => mockSubscribeToSession(...args),
     markSessionActive: (...args: unknown[]) => mockMarkSessionActive(...args),
     markSessionIdle: (...args: unknown[]) => mockMarkSessionIdle(...args),

--- a/src/shared/lib/scheduler/wake-delivery.ts
+++ b/src/shared/lib/scheduler/wake-delivery.ts
@@ -108,17 +108,11 @@ export async function deliverSessionWake(
     // starts a fresh turn instead of deadlocking behind the blocked tool.
     await messagePersister.cancelAwaitingInput(task.agentSlug, sessionId)
 
-    messagePersister.markSessionActive(task.agentSlug, sessionId)
-    try {
-      await client.sendMessage(sessionId, buildWakeMessage(task, trigger), randomUUID(), {
+    await messagePersister.withSessionSend(task.agentSlug, sessionId, client, () =>
+      client.sendMessage(sessionId, buildWakeMessage(task, trigger), randomUUID(), {
         shouldQuery: true,
-      })
-    } catch (error) {
-      // The turn never started — clear the optimistic active flag so the UI
-      // doesn't show a phantom "working" session while the wake awaits retry.
-      messagePersister.markSessionIdle(task.agentSlug, sessionId)
-      throw error
-    }
+      }),
+    )
 
     // Side effect landed; record the slot so a crash between here and
     // markTaskExecuted can't double-deliver on the next attempt.


### PR DESCRIPTION
## Problem

Completed chat conversations can retain a host-to-container WebSocket indefinitely. A failed follow-up also has a race: when the previous turn has emitted its result but has not reached final idle, provisional activity can clear that result and leave the session marked active after the send fails. X-agent follow-ups have a related missing rollback. Reconnecting also needs a replay boundary: WebSocket open can precede the previous turn’s replayed result and idle, which must not settle a newly sent turn.

This generalizes connection cleanup across unpromoted chat, scheduled, webhook, and x-agent sessions. Related to [SUP-788](https://linear.app/datawizz/issue/SUP-788/microvm-ingress-throttling-slack-session-failures-and-false-unhealthy); the exact AWS quota behind the reported ingress 429 remains unverified.

## Change

- Use one release policy for unpromoted automated sessions. Release the transport after authoritative settlement of the current result, or a matching process eviction, once active work, pending sends, input waits, background work, and recovery no longer hold it open. Interactive and promoted sessions keep their existing behavior.
- Preserve chat state and request registrations when detaching its transport, so replies reconnect to the same conversation. Other automation types retain their existing full cleanup on release.
- Route chat replies, scheduled wake delivery, and x-agent follow-ups through a shared send helper. Reserve and reconnect the transport before marking the next turn active, serialize delivery attempts, and roll back failed sends without overwriting accepted output or newer runtime state.
- Resolve stream readiness only on the guest’s existing acknowledgement, sent after listener attachment and terminal replay. Sends also wait for an attachment already in progress; cleanup waits until attachment finishes. Closing, cancelling, replacing, or stopping an attachment rejects its pending readiness promise.
- Mark an already-started initial turn active before attachment, and attach chat forwarding before consuming replay, so fast first turns can finish normally.
- Handle final idle arriving during a failed follow-up, delayed session metadata, queued send failures, reconnect failures, and background wake grace.
- Keep the guest process-eviction fallback: emit the process instance only after a successful idle stop, and ignore stale process identities on the host. Existing idle thresholds remain unchanged.

## Expected behavior

A completed unpromoted automation releases its connection when settlement is confirmed. A subsequent chat reply reconnects before sending to the same session. Failed follow-ups preserve the previous turn's result and allow final idle to settle it. Pending work and promotion prevent automatic release.

## Validation

- 746 focused host tests passed across the persister, stream client, request lifecycle, chat integrations, scheduler, triggers, and x-agent routes.
- 133 guest lifecycle tests passed during review; guest code is unchanged by the follow-up fix.
- The original failed-follow-up reproduction passes. A real host WebSocket connected to a local server reproduced delayed-replay detachment for chat, scheduled, webhook, and x-agent sessions before the fix; all four now stay subscribed through the new reply.
- Host TypeScript checking, ESLint on changed TypeScript files, and `git diff --check` passed.
- Coverage includes all automation categories, promotion, delayed metadata, repeated reconnects, overlapping failures, accepted output, recovery, and background work.
- Live Slack/Telegram/iMessage delivery and the production AWS quota were not validated.

## Deployment / scope

Settlement cleanup uses existing authoritative runtime idle events. Replay-aware readiness uses an existing acknowledgement and requires no additional guest protocol change. The process-eviction fallback additionally requires the updated agent-container image. No production deployment, quota adjustment, retry-policy change, health-probe change, or UI change is included.

