### PR TITLE
fix(session): Stop falls back to a full stop when the only background work is untracked

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -184,6 +184,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
     markSessionInterrupted: vi.fn(),
     getTurnGeneration: vi.fn(() => 0),
     isSessionWaitingBackground: vi.fn(() => false),
+    hasOnlyUntrackedBackgroundWork: vi.fn(() => false),
     cancelAwaitingInput: vi.fn(),
     completeInputRequest: vi.fn(),
     completeCapabilityReview: vi.fn(),
@@ -9292,6 +9293,32 @@ describe('cross-agent session scoping', () => {
       expect(res.status).toBe(200)
       expect(messagePersister.markSessionInterrupted).toHaveBeenCalledWith(ATTACKER, OWN_SESSION, { processKept: false, turnGenerationBefore: 0 })
       await expect(res.json()).resolves.toMatchObject({ processKept: false })
+    })
+
+    it('escalates a turn stop to a full stop when the only open background work is untracked', async () => {
+      // The session is pinned by work the runtime lists but the host never
+      // registered (a task a subagent launched). A turn stop keeps the
+      // process and the task, and there is no row to stop the task from —
+      // so the route stops everything, without offering a choice.
+      vi.mocked(messagePersister.hasOnlyUntrackedBackgroundWork).mockReturnValue(true)
+      mockInterruptSession.mockResolvedValue({ interrupted: true, processKept: false })
+
+      const res = await postJson(app, url(OWN_SESSION, '/interrupt'), { scope: 'turn' })
+
+      expect(res.status).toBe(200)
+      expect(messagePersister.hasOnlyUntrackedBackgroundWork).toHaveBeenCalledWith(ATTACKER, OWN_SESSION)
+      expect(mockInterruptSession).toHaveBeenCalledWith(OWN_SESSION, { scope: 'all' })
+      expect(messagePersister.markSessionInterrupted).toHaveBeenCalledWith(ATTACKER, OWN_SESSION, { processKept: false, turnGenerationBefore: 0 })
+      await expect(res.json()).resolves.toMatchObject({ success: true, processKept: false })
+    })
+
+    it('keeps a turn stop as a turn stop while the open background work is tracked', async () => {
+      vi.mocked(messagePersister.hasOnlyUntrackedBackgroundWork).mockReturnValue(false)
+
+      const res = await postJson(app, url(OWN_SESSION, '/interrupt'), { scope: 'turn' })
+
+      expect(res.status).toBe(200)
+      expect(mockInterruptSession).toHaveBeenCalledWith(OWN_SESSION, { scope: 'turn' })
     })
 
     it('rejects an unknown scope', async () => {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -3317,7 +3317,18 @@ agents.post('/:id/sessions/:sessionId/interrupt', AgentUser(), async (c) => {
   if (!body.success) {
     return c.json({ error: 'Invalid interrupt scope' }, 400)
   }
-  const { scope } = body.data
+  const requestedScope = body.data.scope
+  // A turn stop leaves background tasks running on purpose — but only tasks
+  // the user can see and stop one by one. When the only open work is untracked
+  // (the runtime lists it, the host's task list does not — a task a subagent
+  // launched, for one), a turn stop keeps the session pinned "working" with
+  // nothing to stop it from. Escalate to the full stop instead, without asking:
+  // there is no keep/kill choice to offer when the list is empty.
+  const escalate = requestedScope === 'turn' && messagePersister.hasOnlyUntrackedBackgroundWork(agentSlug, sessionId)
+  const scope = escalate ? 'all' : requestedScope
+  if (escalate) {
+    console.log(`[Agents] Session ${sessionId}: only untracked background work is open — stopping everything instead of the turn`)
+  }
 
   try {
     const client = containerManager.getClient(agentSlug)

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -3920,6 +3920,32 @@ describe('MessagePersister', () => {
         expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
       })
 
+      it('stops everything when the only open background work is untracked', async () => {
+        // Same escalation as the interrupt route: the runtime lists a task the
+        // host never registered (a subagent launched it), so a turn stop would
+        // leave the session pinned. The cancel asks for the full stop.
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+        mockClient._sendMessage({
+          type: 'system',
+          subtype: 'background_tasks_changed',
+          tasks: [{ task_id: 'nested-1', task_type: 'local_bash', description: 'Serve local assets' }],
+        })
+        simulateToolUse('AskUserQuestion', 'q-untracked', {
+          questions: [{ question: 'Pick DB', header: 'DB', options: [], multiSelect: false }],
+        })
+        mockContainerClientFetch.mockClear()
+        answerInterruptWith(false)
+        try {
+          await messagePersister.cancelAwaitingInput(AGENT_SLUG, SESSION_ID)
+        } finally {
+          mockContainerClientFetch.mockImplementation(() => Promise.resolve({ ok: true }))
+        }
+
+        expect(interruptCall()?.[1]).toMatchObject({ method: 'POST', body: JSON.stringify({ scope: 'all' }) })
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+        expect(messagePersister.hasOnlyUntrackedBackgroundWork(AGENT_SLUG, SESSION_ID)).toBe(false)
+      })
+
       it('drops background tasks when the container had to restart the process', async () => {
         messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
         startBackgroundTask('bg-1')
@@ -7687,6 +7713,105 @@ describe('MessagePersister', () => {
       mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
       expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
       expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+    })
+
+    // ------------------------------------------------------------------
+    // Work the host never tracked. A background Bash command a SUBAGENT
+    // launches returns its tool result on the sidechain, which registers
+    // nothing — but the runtime's snapshot lists it, so the union keeps the
+    // session in waiting-background with an empty task list. Seen in prod
+    // (2026-09-09): a subagent started a local asset server that never
+    // exited; Stop sent scope 'turn', the container kept the idle process,
+    // and nothing could retire the task. hasOnlyUntrackedBackgroundWork is
+    // the signal the stop paths escalate on.
+    describe('untracked background work (subagent-launched tasks)', () => {
+      // The runtime's snapshot is the full live set, so a launch alongside
+      // other open work lists every id (the self-heal retires what it omits).
+      function launchFromSubagent(taskId: string, liveTaskIds: string[] = [taskId]) {
+        mockClient._sendMessage({
+          type: 'user',
+          parent_tool_use_id: 'agent-tool-1',
+          tool_use_result: { backgroundTaskId: taskId },
+          message: { content: [{ type: 'tool_result', tool_use_id: `sub-tool-${taskId}`, content: 'Running' }] },
+        })
+        mockClient._sendMessage({
+          type: 'system',
+          subtype: 'background_tasks_changed',
+          tasks: liveTaskIds.map((id) => ({ task_id: id, task_type: 'local_bash', description: 'Serve local assets' })),
+        })
+      }
+
+      it('pins the session in waiting-background with an empty task list', () => {
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+        launchFromSubagent('nested-1')
+        // The subagent finishes; the lead's turn ends; the runtime reports idle.
+        mockClient._sendMessage({ type: 'result', subtype: 'success' })
+        sseEvents.length = 0
+        mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+
+        expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(0)
+        expect(sseEvents.filter(e => e.type === 'session_waiting_background')).toHaveLength(1)
+        expect(messagePersister.isSessionWaitingBackground(AGENT_SLUG, SESSION_ID)).toBe(true)
+        // What the UI (and the connected snapshot) get: nothing to stop.
+        expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID)).toEqual([])
+        expect(messagePersister.hasOnlyUntrackedBackgroundWork(AGENT_SLUG, SESSION_ID)).toBe(true)
+      })
+
+      it('is not reported while a tracked task is open alongside', () => {
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+        mockClient._sendMessage({
+          type: 'user',
+          tool_use_result: { backgroundTaskId: 'bg-main' },
+          message: { content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'Running' }] },
+        })
+        launchFromSubagent('nested-1', ['bg-main', 'nested-1'])
+
+        // A tracked row exists, so the keep/kill dialog can be offered.
+        expect(messagePersister.getActiveBackgroundTasks(AGENT_SLUG, SESSION_ID).map(t => t.taskId)).toEqual(['bg-main'])
+        expect(messagePersister.hasOnlyUntrackedBackgroundWork(AGENT_SLUG, SESSION_ID)).toBe(false)
+      })
+
+      it('is not reported with no background work at all, nor for an unknown session', () => {
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+        expect(messagePersister.hasOnlyUntrackedBackgroundWork(AGENT_SLUG, SESSION_ID)).toBe(false)
+        expect(messagePersister.hasOnlyUntrackedBackgroundWork(AGENT_SLUG, 'nonexistent')).toBe(false)
+      })
+
+      it('clears once the untracked task is stopped', () => {
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+        launchFromSubagent('nested-1')
+        mockClient._sendMessage({ type: 'result', subtype: 'success' })
+        mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+        expect(messagePersister.hasOnlyUntrackedBackgroundWork(AGENT_SLUG, SESSION_ID)).toBe(true)
+
+        // The per-task stop route's answer retires the id from the snapshot too.
+        mockClient._sendMessage({
+          type: 'system', subtype: 'task_notification', task_id: 'nested-1', tool_use_id: 'sub-tool-nested-1', status: 'stopped',
+        })
+        expect(messagePersister.hasOnlyUntrackedBackgroundWork(AGENT_SLUG, SESSION_ID)).toBe(false)
+      })
+
+      it('a full stop settles the session the turn stop could not', async () => {
+        // markSessionInterrupted with processKept false is what a scope 'all'
+        // stop produces: the snapshot is dropped and the session goes idle.
+        messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+        launchFromSubagent('nested-1')
+        mockClient._sendMessage({ type: 'result', subtype: 'success' })
+        mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'idle' })
+
+        // The turn-scoped stop (process kept) leaves it pinned...
+        sseEvents.length = 0
+        await messagePersister.markSessionInterrupted(AGENT_SLUG, SESSION_ID, { processKept: true })
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+        expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(0)
+
+        // ...and the escalated full stop settles it.
+        sseEvents.length = 0
+        await messagePersister.markSessionInterrupted(AGENT_SLUG, SESSION_ID, { processKept: false })
+        expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
+        expect(sseEvents.filter(e => e.type === 'session_idle')).toHaveLength(1)
+        expect(messagePersister.hasOnlyUntrackedBackgroundWork(AGENT_SLUG, SESSION_ID)).toBe(false)
+      })
     })
 
     // ------------------------------------------------------------------

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -1078,6 +1078,24 @@ class MessagePersister {
   }
 
   /**
+   * True when every open background task is one the host never tracked: the
+   * SDK's `background_tasks_changed` snapshot lists work, but the incremental
+   * map — the list clients see and the per-task Stop buttons come from — is
+   * empty. A task a subagent launched lands here: its tool result travels the
+   * sidechain, so nothing registers it, while the runtime's snapshot names it.
+   *
+   * A stop scoped to the turn cannot end such a session: the container keeps
+   * the process (and the task) and the union keeps the session active, with
+   * no row anywhere to stop the task from. Callers escalate to a full stop
+   * instead, which is what Stop always did before tasks were spared.
+   */
+  hasOnlyUntrackedBackgroundWork(agentSlug: string, sessionId: string): boolean {
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
+    if (!state) return false
+    return state.activeBackgroundTasks.size === 0 && this.openBackgroundWorkCount(state) > 0
+  }
+
+  /**
    * The generation of the turn an interrupt sent now would stop. Callers read
    * it before the container call and hand it to markSessionInterrupted, which
    * treats a higher generation afterwards as a turn that started after the
@@ -4512,10 +4530,13 @@ ${continuation}`
   private async interruptContainerSession(agentSlug: string, sessionId: string): Promise<{ processKept: boolean }> {
     const cm = await getContainerManager()
     const client = cm.getClient(agentSlug)
+    // Same escalation as the interrupt route: a turn stop cannot settle a
+    // session whose only background work is untracked, so stop everything.
+    const scope = this.hasOnlyUntrackedBackgroundWork(agentSlug, sessionId) ? 'all' : 'turn'
     const response = await client.fetch(`/sessions/${encodeURIComponent(sessionId)}/interrupt`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ scope: 'turn' }),
+      body: JSON.stringify({ scope }),
     })
     if (!response?.ok) return { processKept: false }
     // A container build that predates the field always restarted the process.


### PR DESCRIPTION
## Problem

After #993 (soft interrupt), a session can get stuck on "Working…" with Stop doing nothing. Seen in prod on 2026-09-09.

- A background Bash task launched **by a subagent** returns its tool result on the sidechain, so the host never adds it to `activeBackgroundTasks`.
- The runtime's `background_tasks_changed` snapshot does list it, and `openBackgroundWorkCount()` is the union of both, so the session stays in waiting-background.
- The task list clients see (`getActiveBackgroundTasks`) is empty, so the composer sends `scope: 'turn'`. The runtime is idle, the container keeps the process (`processKept: true`), and the host keeps `isActive` because the union is still non-empty.
- Before #993 Stop killed the process, which reset the snapshot. Now there is no exit from the UI.

## Fix

`messagePersister.hasOnlyUntrackedBackgroundWork()`: tracked map empty, union non-empty. The interrupt route and `cancelAwaitingInput` escalate a `turn` stop to `all` when it is true. No confirmation is asked: there is no keep/kill choice to offer when the list is empty.

Accepted cost: the snapshot leads the tool result by a frame, so a Stop in that sliver stops everything. That is the pre-#993 behaviour.

## Tests

- Route: `turn` + untracked-only → container receives `all`; `turn` + tracked work → stays `turn`. The first fails on the unfixed route (verified by stashing the route change).
- Persister: replay of the prod sequence (sidechain launch, snapshot, result, idle) → waiting-background with an empty task list and the predicate true; predicate false with a tracked task alongside, with no work, and for an unknown session; clears once the task is stopped; a full stop settles what the turn stop could not; `cancelAwaitingInput` sends `all` in that state.

Follow-ups (separate PRs): register subagent-launched tasks in the tracked list; surface snapshot-only ids as stoppable rows.

No UI change.

https://claude.ai/code/session_01Bx1vYnR8ZSa1QiyJg8iD9u
