### PR TITLE
feat(analytics): track the platform paywall card and voice-mode entry/exit

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -36,6 +36,10 @@ const mockUpdateAgentMutate = vi.fn()
 const mockUpdateAgentMutateAsync = vi.fn()
 const mockDeleteAgentMutate = vi.fn()
 
+vi.mock('@renderer/context/analytics-context', () => ({
+  useAnalyticsTracking: () => ({ track: vi.fn() }),
+}))
+
 vi.mock('@renderer/hooks/use-agents', () => ({
   useAgent: () => ({ data: { ...testAgent, mounts: [] } }),
   useAgents: () => ({ data: [testAgent] }),

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -15,6 +15,7 @@ import { RelatedSessions, type SortOrder } from '@renderer/components/sessions/r
 import { SortPopover } from '@renderer/components/sessions/sort-popover'
 import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
 import { useNavTransient } from '@renderer/context/nav-transient-context'
+import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useFilePreview } from '@renderer/context/file-preview-context'
 import { useNavigate } from '@tanstack/react-router'
 import { useUser } from '@renderer/context/user-context'
@@ -124,6 +125,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   const sessionSearchRef = useRef<HTMLInputElement>(null)
   const composerTextareaRef = useRef<HTMLDivElement>(null)
   const isMobile = useIsMobile()
+  const { track } = useAnalyticsTracking()
   // Tracks an explicit user collapse so the auto-expand effect doesn't fight it.
   // Reset when the message clears (e.g. after submit).
   const userCollapsedRef = useRef(false)
@@ -283,10 +285,12 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
         ...composerOptions.toRuntimeOptions(),
       })
       onSessionCreated(session.id, VOICE_MODE_ENTERED_MESSAGE, session.initialMessageUuid, { voiceMode: true })
+      track('voice_mode_entered', { origin: 'home' })
     } catch (error) {
       console.error('Failed to start a voice session:', error)
+      track('voice_mode_start_failed', { origin: 'home' })
     }
-  }, [createSession, agent.slug, composerOptions, onSessionCreated])
+  }, [createSession, agent.slug, composerOptions, onSessionCreated, track])
 
   const isFreshUntitled = agent.name === UNTITLED_AGENT_NAME && sessions.length === 0
   const typewriterPlaceholder = useTypewriterPlaceholder(

--- a/src/renderer/components/messages/message-input.tsx
+++ b/src/renderer/components/messages/message-input.tsx
@@ -324,16 +324,21 @@ export function MessageInput({ sessionId, agentSlug, onMessageSent, onMessageUui
   }, [track])
   const exitVoiceMode = useCallback(() => setVoiceModeOn(false), [])
   const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const trackRef = useRef(track)
+  trackRef.current = track
   // Leaving voice mode — by the exit button or by navigating away from the
   // session — tells the agent. Deferred a tick so a development-mode
   // remount does not send it for a mode that is still on.
   useEffect(() => {
     if (!voiceModeOn) return
     return () => {
-      const timer = setTimeout(() => sendNoticeRef.current(VOICE_MODE_EXITED_MESSAGE), 0)
+      const timer = setTimeout(() => {
+        sendNoticeRef.current(VOICE_MODE_EXITED_MESSAGE)
+        trackRef.current('voice_mode_exited', { origin: openedByVoice ? 'home' : 'session' })
+      }, 0)
       exitTimerRef.current = timer
     }
-  }, [voiceModeOn])
+  }, [voiceModeOn, openedByVoice])
   useEffect(() => {
     if (!voiceModeOn || exitTimerRef.current === null) return
     clearTimeout(exitTimerRef.current)

--- a/src/renderer/components/provider-error/platform-paywall-card.test.tsx
+++ b/src/renderer/components/provider-error/platform-paywall-card.test.tsx
@@ -11,6 +11,11 @@ import type { BillingInfoResponse } from '@renderer/hooks/use-billing-info'
 import { PlatformPaywallCard } from './platform-paywall-card'
 import { PAYWALL_RECHECK_INTERVAL_MS } from './use-platform-paywall-billing'
 
+const mocks = vi.hoisted(() => ({ track: vi.fn() }))
+vi.mock('@renderer/context/analytics-context', () => ({
+  useAnalyticsTracking: () => ({ track: mocks.track }),
+}))
+
 const platformAuth = {
   connected: true,
   role: 'member' as string | null,
@@ -102,6 +107,18 @@ describe('PlatformPaywallCard', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+  })
+
+  it('tracks the paywall being shown, its CTA click and its dismissal', async () => {
+    renderCard()
+    await waitFor(() => expect(screen.getByText('Workspace billing needs attention')).toBeInTheDocument())
+    expect(mocks.track).toHaveBeenCalledWith('paywall_shown', { ctaKind: 'ask_admin', blocked: true, placement: 'composer' })
+    expect(mocks.track).toHaveBeenCalledTimes(1)
+    act(() => { screen.getByRole('button', { name: 'Go to billing' }).click() })
+    expect(mocks.track).toHaveBeenCalledWith('paywall_cta_clicked', { ctaKind: 'ask_admin' })
+    act(() => { screen.getByRole('button', { name: 'Dismiss' }).click() })
+    expect(mocks.track).toHaveBeenCalledWith('paywall_dismissed', { ctaKind: 'ask_admin', handedOff: true })
+    expect(screen.queryByTestId('paywall-card')).not.toBeInTheDocument()
   })
 
   it('shows a checking state, then routes members to ask an admin', async () => {

--- a/src/renderer/components/provider-error/platform-paywall-card.tsx
+++ b/src/renderer/components/provider-error/platform-paywall-card.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 
 import { extractSubscriptionRequired } from '@shared/lib/llm-provider/platform-error-presentation'
 import { cn } from '@shared/lib/utils/cn'
+import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { HomeEmptyClouds } from '@renderer/components/home/home-empty-clouds'
 import { Button } from '@renderer/components/ui/button'
 import { openExternalUrl } from '@renderer/lib/open-external'
@@ -60,9 +61,9 @@ function PaywallActions({
   cta: PaywallCta | null
   loading: boolean
   handedOff: boolean
-  onDismiss: () => void
-  onHandOff: () => void
-  onRecheck: () => void
+  onDismiss: (ctaKind: string) => void
+  onHandOff: (ctaKind: string) => void
+  onRecheck: (ctaKind: string) => void
 }) {
   if (loading) {
     return (
@@ -73,9 +74,10 @@ function PaywallActions({
     )
   }
   const href = cta ? ctaHref(cta) : null
+  const ctaKind = cta?.kind ?? 'none'
   return (
     <div className="flex items-center gap-2" data-testid="paywall-actions">
-      <Button size="sm" variant="ghost" onClick={onDismiss}>
+      <Button size="sm" variant="ghost" onClick={() => onDismiss(ctaKind)}>
         Dismiss
       </Button>
       {handedOff ? (
@@ -83,7 +85,7 @@ function PaywallActions({
           size="sm"
           onClick={(event) => {
             event.stopPropagation()
-            onRecheck()
+            onRecheck(ctaKind)
           }}
         >
           Recheck
@@ -96,7 +98,7 @@ function PaywallActions({
             event.stopPropagation()
             if (!href) return
             void openExternalUrl(href)
-            onHandOff()
+            onHandOff(ctaKind)
           }}
         >
           {CTA_LABELS[cta.kind]}
@@ -112,12 +114,26 @@ function PaywallActions({
 export function PlatformPaywallCard({ message, presentation, children, live = true }: ProviderErrorComponentProps) {
   const [dismissed, setDismissed] = useState(false)
   const [handedOff, setHandedOff] = useState(false)
+  const { track } = useAnalyticsTracking()
   const billing = usePlatformPaywallBilling(
     extractSubscriptionRequired(message),
     presentation?.href ?? null,
     live,
     !dismissed,
   )
+
+  const ctaKind = billing.cta?.kind ?? 'none'
+  const shownRef = useRef(false)
+  useEffect(() => {
+    if (shownRef.current || billing.loading || billing.cleared || dismissed) return
+    shownRef.current = true
+    track('paywall_shown', { ctaKind, blocked: billing.blocked, placement: presentation?.placement ?? 'unknown' })
+  }, [billing.loading, billing.cleared, billing.blocked, dismissed, ctaKind, presentation?.placement, track])
+  useEffect(() => {
+    if (!shownRef.current || !billing.cleared) return
+    track('paywall_cleared', { ctaKind, handedOff })
+  }, [billing.cleared, ctaKind, handedOff, track])
+
   if (billing.cleared || dismissed) return <>{children}</>
 
   const fallback = splitMessage(presentation?.message ?? message)
@@ -141,9 +157,18 @@ export function PlatformPaywallCard({ message, presentation, children, live = tr
             cta={billing.cta}
             loading={billing.loading}
             handedOff={handedOff}
-            onDismiss={() => setDismissed(true)}
-            onHandOff={() => setHandedOff(true)}
-            onRecheck={billing.recheck}
+            onDismiss={(kind) => {
+              track('paywall_dismissed', { ctaKind: kind, handedOff })
+              setDismissed(true)
+            }}
+            onHandOff={(kind) => {
+              track('paywall_cta_clicked', { ctaKind: kind })
+              setHandedOff(true)
+            }}
+            onRecheck={(kind) => {
+              track('paywall_recheck_clicked', { ctaKind: kind })
+              billing.recheck()
+            }}
           />
         </div>
       </div>


### PR DESCRIPTION
## Why

The 2026-09-09 weekly analytics audit found two revenue/adoption surfaces that shipped in 0.5.17–0.5.19 with no tracking:

- **Platform 402 paywall card** (#961/#962/#994, SUP-725) — the moment a user is told to subscribe / add a card / top up, and what they do next, is invisible in Amplitude.
- **Voice-to-voice mode** (#991) — `voice_mode_entered` only fires from the in-session composer button. The agent-home voice button creates the session with the voice notice as its first message and never calls `enterVoiceMode`, so that entry point emits nothing, and there is no exit or failure event.

## What

`platform-paywall-card.tsx`
- `paywall_shown {ctaKind, blocked, placement}` — once per card, when the billing snapshot has resolved (not while "Checking billing").
- `paywall_cta_clicked {ctaKind}` — the CTA hand-off (external URL, so no flush concern).
- `paywall_dismissed {ctaKind, handedOff}`, `paywall_recheck_clicked {ctaKind}`.
- `paywall_cleared {ctaKind, handedOff}` — a fresh snapshot allows access again after the card was shown (the conversion).

`ctaKind` ∈ `subscribe | add_card | topup | manage_payment | go_to_billing | ask_admin | none`.

`agent-home.tsx` — `voice_mode_entered {origin: "home"}` after the voice session is created; failure twin `voice_mode_start_failed {origin: "home"}` in the catch.

`message-input.tsx` — `voice_mode_exited {origin: "home" | "session"}` in the existing deferred exit cleanup (same timer as the exit notice, so a dev-mode remount does not fire it).

Tests: analytics-context mock added to `platform-paywall-card.test.tsx` (+1 test covering shown → CTA → dismiss) and `agent-home.test.tsx`.

## Notes

- Property names follow the hard rules: no `source`/`platform`/`versionId`/`os`/`browser`/`tenantId`; literal event names only.
- Catalog CSV rows added for all seven names (analytics-docs, synced to the sheet).
- Authored from the API (no local toolchain): `pnpm vitest run src/renderer/components/provider-error src/renderer/components/agents/agent-home src/renderer/components/messages` and typecheck should be run in CI before merge.
