### PR TITLE
fix(browserbase): recover blocked Google passkey challenges

### DIFF
--- a/src/main/host-browser/browserbase-provider.ts
+++ b/src/main/host-browser/browserbase-provider.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { getSettings, getEffectiveBrowserbaseApiKey, getEffectiveBrowserbaseProjectId } from '@shared/lib/config/settings'
 import { getDataDir } from '@shared/lib/config/data-dir'
 import { getOrCreateMapping } from './context-map-store'
+import { GooglePasskeyRecovery } from './google-passkey-recovery'
 import type { HostBrowserProvider, HostBrowserProviderStatus, BrowserConnectionInfo, BrowserDebugInfo } from './types'
 
 const BROWSERBASE_API_BASE = 'https://api.browserbase.com/v1'
@@ -30,6 +31,7 @@ export class BrowserbaseProvider implements HostBrowserProvider {
 
   /** Maps instanceId → Browserbase session ID */
   private sessions: Map<string, string> = new Map()
+  private passkeyRecovery = new GooglePasskeyRecovery()
 
   onExternalClose: ((instanceId: string) => void) | null = null
 
@@ -67,12 +69,14 @@ export class BrowserbaseProvider implements HostBrowserProvider {
           const debugUrl = await this.getDebugBrowserUrl(existingSessionId, apiKey)
           if (debugUrl) {
             console.log(`[BrowserbaseProvider] Reusing session ${existingSessionId} for instance ${instanceId}`)
+            this.passkeyRecovery.watch(instanceId, debugUrl)
             return { cdpUrl: debugUrl }
           }
         }
       } catch {
         // Session no longer valid
       }
+      this.passkeyRecovery.stop(instanceId)
       this.sessions.delete(instanceId)
     }
 
@@ -135,6 +139,7 @@ export class BrowserbaseProvider implements HostBrowserProvider {
     // unlike the connectUrl which is single-use)
     const debugUrl = await this.getDebugBrowserUrl(session.id, apiKey)
     if (debugUrl) {
+      this.passkeyRecovery.watch(instanceId, debugUrl)
       return { cdpUrl: debugUrl }
     }
 
@@ -172,6 +177,7 @@ export class BrowserbaseProvider implements HostBrowserProvider {
   }
 
   async stop(instanceId: string): Promise<void> {
+    this.passkeyRecovery.stop(instanceId)
     const sessionId = this.sessions.get(instanceId)
     if (!sessionId) return
 

--- a/src/main/host-browser/cloud-passkey-recovery.test.ts
+++ b/src/main/host-browser/cloud-passkey-recovery.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({ watch: vi.fn(), stop: vi.fn() }))
+vi.mock('./google-passkey-recovery', () => ({
+  GooglePasskeyRecovery: class { watch = h.watch; stop = h.stop },
+}))
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: () => ({ app: {} }),
+  getEffectiveBrowserbaseApiKey: () => 'test-key',
+  getEffectiveBrowserbaseProjectId: () => 'test-project',
+}))
+vi.mock('@shared/lib/config/data-dir', () => ({ getDataDir: () => '/test-data' }))
+vi.mock('@shared/lib/services/platform-auth-service', () => ({ getPlatformAccessToken: () => 'test-token' }))
+vi.mock('@shared/lib/platform-auth/config', () => ({ getPlatformProxyBaseUrl: () => 'https://platform.test' }))
+vi.mock('./context-map-store', () => ({ getOrCreateMapping: async () => 'test-context' }))
+
+import { BrowserbaseProvider } from './browserbase-provider'
+import { PlatformBrowserProvider } from './platform-provider'
+
+let available = true
+let sessionStatus = 'RUNNING'
+let created = 0
+beforeEach(() => {
+  vi.clearAllMocks()
+  available = true
+  sessionStatus = 'RUNNING'
+  created = 0
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.stubGlobal('fetch', vi.fn(async (input: string, options?: RequestInit) => {
+    if (input.endsWith('/debug')) return Response.json({ wsUrl: available ? `wss://test/debug/${created}` : undefined })
+    if (input.endsWith('/sessions') && options?.method === 'POST') {
+      created++
+      return Response.json({ id: `session-${created}`, connectUrl: `wss://test/single-use/${created}`, status: 'RUNNING', keepAlive: true })
+    }
+    return Response.json({ status: sessionStatus })
+  }))
+})
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks() })
+
+for (const Provider of [BrowserbaseProvider, PlatformBrowserProvider]) {
+  describe(`${Provider.name} passkey recovery lifecycle`, () => {
+    it('watches the reusable debug connection on launch and reuse, and stops before release', async () => {
+      const provider = new Provider()
+      expect(await provider.launch('instance')).toEqual({ cdpUrl: 'wss://test/debug/1' })
+      expect(h.watch).toHaveBeenLastCalledWith('instance', 'wss://test/debug/1')
+      await provider.launch('instance')
+      expect(created).toBe(1)
+      expect(h.watch).toHaveBeenCalledTimes(2)
+      await provider.stop('instance')
+      expect(h.stop).toHaveBeenCalledWith('instance')
+      expect(h.stop.mock.invocationCallOrder[0]).toBeLessThan(vi.mocked(fetch).mock.invocationCallOrder.at(-1)!)
+    })
+
+    it('preserves the single-use fallback URL for the agent', async () => {
+      available = false
+      const provider = new Provider()
+      expect(await provider.launch('instance')).toEqual({ cdpUrl: 'wss://test/single-use/1' })
+      expect(h.watch).not.toHaveBeenCalled()
+      await provider.stop('instance')
+    })
+
+    it('disposes observers for expired sessions before starting their replacement', async () => {
+      const provider = new Provider()
+      await provider.launch('instance')
+      sessionStatus = 'COMPLETED'
+      await provider.launch('instance')
+      expect(h.stop).toHaveBeenCalledWith('instance')
+      expect(h.watch).toHaveBeenLastCalledWith('instance', 'wss://test/debug/2')
+      expect(h.stop.mock.invocationCallOrder[0]).toBeLessThan(h.watch.mock.invocationCallOrder[1])
+      await provider.stopAll()
+    })
+  })
+}

--- a/src/main/host-browser/google-passkey-recovery.dom.test.ts
+++ b/src/main/host-browser/google-passkey-recovery.dom.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+// @vitest-environment-options {"url":"https://accounts.google.com/v3/signin/challenge/pk"}
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { GOOGLE_PASSKEY_RECOVERY_EXPRESSION, isGooglePasskeyChallenge } from './google-passkey-recovery'
+
+const challengePath = '/v3/signin/challenge/pk'
+let clicked = vi.fn<() => void>()
+const evaluate = () => window.eval(GOOGLE_PASSKEY_RECOVERY_EXPRESSION)
+
+beforeEach(() => {
+  history.replaceState({}, '', challengePath)
+  document.body.innerHTML = '<h1>Verifying it’s you...</h1><p>Complete sign-in using your passkey</p><button>Try another way</button>'
+  // jsdom has no layout/innerText. Real rendering is covered by the browser probe.
+  Object.defineProperty(HTMLElement.prototype, 'innerText', { configurable: true, get() { return this.textContent || '' } })
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({ width: 120, height: 40 } as DOMRect)
+  clicked = vi.fn(() => { history.replaceState({}, '', '/v3/signin/challenge/selection') })
+  document.querySelector('button')!.addEventListener('click', clicked)
+})
+
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('scoped Google fallback expression', () => {
+  it('invokes the actual fallback handler and then stops matching the selection page', () => {
+    expect(evaluate()).toBe('clicked')
+    expect(clicked).toHaveBeenCalledTimes(1)
+    expect(location.pathname).toBe('/v3/signin/challenge/selection')
+    expect(evaluate()).toBe('not-applicable')
+    expect(clicked).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['/v3/signin/challenge/pwd', '/v3/signin/challenge/pk/presend', '/v3/signin/challenge/selection'])('ignores unrelated challenge %s', path => {
+    history.replaceState({}, '', path)
+    expect(evaluate()).toBe('not-applicable')
+    expect(clicked).not.toHaveBeenCalled()
+  })
+
+  it.each(['missing progress', 'missing passkey copy', 'localized', 'multiple buttons', 'disabled', 'disabled fieldset', 'aria-disabled', 'inert', 'hidden', 'zero-size'])('fails closed when UI is uncertain: %s', variant => {
+    const button = document.querySelector('button')!
+    if (variant === 'missing progress') document.querySelector('h1')!.remove()
+    if (variant === 'missing passkey copy') document.querySelector('p')!.remove()
+    if (variant === 'localized') button.textContent = 'Andere Option wählen'
+    if (variant === 'multiple buttons') document.body.append(button.cloneNode(true))
+    if (variant === 'disabled') button.disabled = true
+    if (variant === 'disabled fieldset') {
+      const fieldset = document.createElement('fieldset')
+      fieldset.disabled = true
+      document.body.append(fieldset)
+      fieldset.append(button)
+    }
+    if (variant === 'aria-disabled') button.setAttribute('aria-disabled', 'true')
+    if (variant === 'inert') button.setAttribute('inert', '')
+    if (variant === 'hidden') button.style.visibility = 'hidden'
+    if (variant === 'zero-size') vi.mocked(button.getBoundingClientRect).mockReturnValue({ width: 0, height: 0 } as DOMRect)
+    expect(evaluate()).toBe('waiting')
+    expect(clicked).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    'https://accounts.google.com.evil.test/v3/signin/challenge/pk',
+    'http://accounts.google.com/v3/signin/challenge/pk',
+    'https://accounts.google.com:444/v3/signin/challenge/pk',
+    'https://example.com/v3/signin/challenge/pk',
+    'not a url',
+  ])('rejects an unrelated origin: %s', url => {
+    expect(isGooglePasskeyChallenge(url)).toBe(false)
+  })
+
+  it('checks the origin inside the browser expression too', () => {
+    const run = new Function('location', 'document', `return ${GOOGLE_PASSKEY_RECOVERY_EXPRESSION}`)
+    expect(run({ origin: 'https://example.com', pathname: challengePath }, document)).toBe('not-applicable')
+    expect(clicked).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/host-browser/google-passkey-recovery.test.ts
+++ b/src/main/host-browser/google-passkey-recovery.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { GooglePasskeyRecovery } from './google-passkey-recovery'
+
+type Command = { id: number; method: string; params: Record<string, unknown>; sessionId?: string }
+type TestSocket = {
+  commands: Command[]
+  readyState: number
+  event: (method: string, params: Record<string, unknown>, sessionId?: string) => void
+  reply: (command: Command, result: Record<string, unknown>) => void
+  terminate: () => void
+}
+const h = vi.hoisted(() => ({
+  sockets: [] as TestSocket[],
+  respond: vi.fn<(command: Command) => Record<string, unknown> | undefined>(),
+}))
+
+vi.mock('ws', async () => {
+  const { EventEmitter } = await import('node:events')
+  return { default: class extends EventEmitter {
+    static OPEN = 1
+    readyState = 0
+    commands: Command[] = []
+    constructor() {
+      super()
+      h.sockets.push(this)
+      queueMicrotask(() => { this.readyState = 1; this.emit('open') })
+    }
+    send(data: string, callback: (error?: Error) => void) {
+      const command = JSON.parse(data) as Command
+      this.commands.push(command)
+      const result = h.respond(command)
+      if (result !== undefined) queueMicrotask(() => this.reply(command, result))
+      callback()
+    }
+    reply(command: Command, result: Record<string, unknown>) {
+      this.emit('message', Buffer.from(JSON.stringify({ id: command.id, result })))
+    }
+    event(method: string, params: Record<string, unknown>, sessionId?: string) {
+      this.emit('message', Buffer.from(JSON.stringify({ method, params, sessionId })))
+    }
+    terminate() {
+      this.readyState = 3
+      this.emit('close')
+    }
+  } }
+})
+
+const challenge = 'https://accounts.google.com/v3/signin/challenge/pk?flow=test'
+const info = (targetId = 'tab', url = challenge, type = 'page') => ({ targetId, url, type })
+const evaluations = (socket = h.sockets[0]) => socket.commands.filter(c => c.method === 'Runtime.evaluate')
+let recovery: GooglePasskeyRecovery
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  h.sockets.length = 0
+  h.respond.mockReset().mockImplementation(command => {
+    if (command.method === 'Target.getTargets') return { targetInfos: [info()] }
+    if (command.method === 'Target.attachToTarget') return { sessionId: `attached-${command.params.targetId}` }
+    if (command.method === 'Runtime.evaluate') return { result: { value: 'clicked' } }
+    return {}
+  })
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  recovery = new GooglePasskeyRecovery()
+})
+
+afterEach(() => {
+  recovery.stop('instance')
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+async function start() {
+  recovery.watch('instance', 'wss://example.test/reusable-debug')
+  await vi.advanceTimersByTimeAsync(0)
+  return h.sockets[0]
+}
+
+describe('Google passkey observer', () => {
+  it('recovers an already-open challenge once after a grace period, without emulating WebAuthn', async () => {
+    const socket = await start()
+    await vi.advanceTimersByTimeAsync(1_999)
+    expect(evaluations()).toHaveLength(0)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(evaluations()).toHaveLength(1)
+    expect(evaluations()[0].sessionId).toBe('attached-tab')
+    expect(evaluations()[0].params.expression).toContain(JSON.stringify(challenge))
+    socket.event('Target.targetInfoChanged', { targetInfo: { ...info(), title: 'Changed title' } })
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(evaluations()).toHaveLength(1)
+    expect(socket.commands.some(c => c.method.startsWith('WebAuthn.'))).toBe(false)
+  })
+
+  it('discovers new popup tabs, but ignores passwords, pre-prompts, other origins and frames', async () => {
+    h.respond.mockImplementation(command => {
+      if (command.method === 'Target.getTargets') return { targetInfos: [] }
+      if (command.method === 'Target.attachToTarget') return { sessionId: 'popup-session' }
+      return { result: { value: 'clicked' } }
+    })
+    const socket = await start()
+    for (const targetInfo of [
+      info('password', 'https://accounts.google.com/v3/signin/challenge/pwd'),
+      info('pre-prompt', 'https://accounts.google.com/v3/signin/challenge/pk/presend'),
+      info('other-origin', 'https://example.com/v3/signin/challenge/pk'),
+      info('frame', challenge, 'iframe'),
+    ]) socket.event('Target.targetCreated', { targetInfo })
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(evaluations()).toHaveLength(0)
+    socket.event('Target.targetCreated', { targetInfo: info('popup') })
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(evaluations()).toHaveLength(1)
+    expect(evaluations()[0].sessionId).toBe('popup-session')
+  })
+
+  it('waits for recognizable DOM and rearms only on a new challenge visit', async () => {
+    const original = h.respond.getMockImplementation()!
+    let ready = false
+    h.respond.mockImplementation(command => command.method === 'Runtime.evaluate'
+      ? { result: { value: ready ? 'clicked' : 'waiting' } } : original(command))
+    const socket = await start()
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(evaluations()).toHaveLength(2)
+    ready = true
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(evaluations()).toHaveLength(3)
+    socket.event('Target.targetInfoChanged', { targetInfo: info('tab', 'https://accounts.google.com/v3/signin/challenge/selection') })
+    socket.event('Target.targetInfoChanged', { targetInfo: info() })
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(evaluations()).toHaveLength(4)
+    expect(socket.commands.filter(c => c.method === 'Target.attachToTarget')).toHaveLength(1)
+  })
+
+
+  it('rearms on a new document at the same URL but not on subframe navigation', async () => {
+    const socket = await start()
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(evaluations()).toHaveLength(1)
+    socket.event('Page.frameNavigated', { frame: { url: challenge, parentId: 'main-frame' } }, 'attached-tab')
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(evaluations()).toHaveLength(1)
+    socket.event('Page.frameNavigated', { frame: { url: challenge } }, 'attached-tab')
+    await vi.advanceTimersByTimeAsync(1_999)
+    expect(evaluations()).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(evaluations()).toHaveLength(2)
+  })
+
+  it.each(['navigate', 'destroy', 'stop'])('does not click if the target changes during attachment: %s', async action => {
+    const original = h.respond.getMockImplementation()!
+    h.respond.mockImplementation(c => c.method === 'Target.attachToTarget' ? undefined : original(c))
+    const socket = await start()
+    await vi.advanceTimersByTimeAsync(2_000)
+    const attach = socket.commands.find(c => c.method === 'Target.attachToTarget')!
+    if (action === 'navigate') socket.event('Target.targetInfoChanged', { targetInfo: info('tab', 'https://example.com') })
+    if (action === 'destroy') socket.event('Target.targetDestroyed', { targetId: 'tab' })
+    if (action === 'stop') recovery.stop('instance')
+    socket.reply(attach, { sessionId: 'late-attachment' })
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(evaluations()).toHaveLength(0)
+  })
+
+  it('does not repeat a potentially delivered click after a timeout or connection loss', async () => {
+    const original = h.respond.getMockImplementation()!
+    h.respond.mockImplementation(c => c.method === 'Runtime.evaluate' ? undefined : original(c))
+    const socket = await start()
+    await vi.advanceTimersByTimeAsync(8_000)
+    expect(evaluations()).toHaveLength(1)
+    socket.terminate()
+    await vi.advanceTimersByTimeAsync(12_000)
+    expect(h.sockets).toHaveLength(2)
+    expect(evaluations(h.sockets[1])).toHaveLength(0)
+  })
+
+  it('reconnects and resumes detection when disconnected before an action', async () => {
+    const socket = await start()
+    socket.terminate()
+    await vi.advanceTimersByTimeAsync(8_000)
+    expect(h.sockets).toHaveLength(2)
+    expect(evaluations(h.sockets[1])).toHaveLength(1)
+    recovery.stop('instance')
+    await vi.advanceTimersByTimeAsync(20_000)
+    expect(h.sockets).toHaveLength(2)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('bounds DOM polling when the page never matches', async () => {
+    const original = h.respond.getMockImplementation()!
+    h.respond.mockImplementation(c => c.method === 'Runtime.evaluate' ? { result: { value: 'waiting' } } : original(c))
+    await start()
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(evaluations()).toHaveLength(60)
+  })
+
+
+  it('bounds retries for an expired endpoint and can restart on the next provider launch', async () => {
+    h.respond.mockReturnValue(undefined)
+    await start()
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(h.sockets).toHaveLength(6)
+    expect(vi.getTimerCount()).toBe(0)
+    recovery.watch('instance', 'wss://example.test/reusable-debug')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(h.sockets).toHaveLength(7)
+  })
+
+  it('keeps one observer for reuse and disposes the old connection when the browser changes', async () => {
+    const old = await start()
+    recovery.watch('instance', 'wss://example.test/reusable-debug')
+    expect(h.sockets).toHaveLength(1)
+    recovery.watch('instance', 'wss://example.test/another-debug')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(h.sockets).toHaveLength(2)
+    expect(old.readyState).toBe(3)
+    recovery.stop('instance')
+    await vi.advanceTimersByTimeAsync(20_000)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/main/host-browser/google-passkey-recovery.ts
+++ b/src/main/host-browser/google-passkey-recovery.ts
@@ -1,0 +1,291 @@
+import WebSocket from 'ws'
+
+const GRACE_MS = 2_000
+const CHECK_INTERVAL_MS = 1_000
+const COMMAND_TIMEOUT_MS = 5_000
+const RECONNECT_MS = 5_000
+const MAX_RECONNECTS = 5
+const MAX_CHECKS = 60
+const PASSKEY_PATH = '^/v3/signin/challenge/pk/?$'
+
+export function isGooglePasskeyChallenge(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.origin === 'https://accounts.google.com' && new RegExp(PASSKEY_PATH).test(parsed.pathname)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * A native WebAuthn dialog blocks CDP input, but Runtime.evaluate still works.
+ * Invoke Google's own fallback handler so Google aborts its pending request.
+ * Do not act on conditional WebAuthn, pre-prompt screens, or other challenges.
+ * English copy is intentional: unfamiliar/localized UI fails closed.
+ */
+export const GOOGLE_PASSKEY_RECOVERY_EXPRESSION = String.raw`(() => {
+  if (location.origin !== 'https://accounts.google.com' ||
+      !new RegExp(${JSON.stringify(PASSKEY_PATH)}).test(location.pathname)) return 'not-applicable';
+
+  const text = (document.body?.innerText || '').replace(/\s+/g, ' ').replace(/\u2019/g, "'");
+  if (!text.includes("Verifying it's you") ||
+      !text.includes('Complete sign-in using your passkey')) return 'waiting';
+
+  const buttons = [...document.querySelectorAll('button')].filter(button => {
+    const rect = button.getBoundingClientRect();
+    const style = getComputedStyle(button);
+    return button.innerText.trim() === 'Try another way' &&
+      rect.width > 0 && rect.height > 0 &&
+      style.visibility === 'visible' && style.display !== 'none' &&
+      !button.matches(':disabled') && button.getAttribute('aria-disabled') !== 'true' &&
+      !button.closest('[inert]');
+  });
+  if (buttons.length !== 1) return 'waiting';
+  buttons[0].click();
+  return 'clicked';
+})()`
+
+interface TargetInfo {
+  targetId: string
+  type: string
+  url: string
+}
+
+interface TargetState {
+  url: string
+  sessionId?: string
+  since: number
+  generation: number
+  checks: number
+  attempted: boolean
+  busy: boolean
+}
+
+interface PendingCommand {
+  resolve: (result: Record<string, unknown>) => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+/** One observer per cloud browser; independent of the agent and the live viewer. */
+class RecoveryConnection {
+  private socket?: WebSocket
+  private stopped = false
+  private sequence = 0
+  private pending = new Map<number, PendingCommand>()
+  private targets = new Map<string, TargetState>()
+  private interval?: ReturnType<typeof setInterval>
+  private reconnect?: ReturnType<typeof setTimeout>
+  private retries = 0
+
+  constructor(readonly url: string) {
+    this.connect()
+  }
+
+  get active(): boolean {
+    return !this.stopped && !!(this.socket || this.reconnect)
+  }
+
+  stop(): void {
+    this.stopped = true
+    clearTimeout(this.reconnect)
+    clearInterval(this.interval)
+    this.socket?.terminate()
+    this.resetConnection()
+    this.targets.clear()
+  }
+
+  private connect(): void {
+    if (this.stopped) return
+    let socket: WebSocket
+    try {
+      socket = new WebSocket(this.url, { handshakeTimeout: COMMAND_TIMEOUT_MS })
+    } catch {
+      this.scheduleReconnect()
+      return
+    }
+    this.socket = socket
+    socket.on('error', () => {
+      // Never log the socket URL or remote errors: they can contain credentials.
+      socket.terminate()
+    })
+    socket.on('close', () => {
+      if (this.socket !== socket) return
+      this.resetConnection()
+      this.scheduleReconnect()
+    })
+    socket.on('message', data => {
+      if (this.socket !== socket) return
+      try {
+        const message = JSON.parse(data.toString())
+        if (typeof message.id === 'number') {
+          const pending = this.pending.get(message.id)
+          if (!pending) return
+          this.pending.delete(message.id)
+          clearTimeout(pending.timer)
+          if (message.error) pending.reject(new Error('Passkey recovery CDP command failed'))
+          else pending.resolve(message.result ?? {})
+        } else if (message.method === 'Target.targetCreated' || message.method === 'Target.targetInfoChanged') {
+          this.updateTarget(message.params.targetInfo)
+        } else if (message.method === 'Page.frameNavigated' && !message.params.frame.parentId) {
+          // A reload can create a new challenge without changing the URL.
+          for (const [targetId, target] of this.targets) {
+            if (target.sessionId === message.sessionId) {
+              this.updateTarget({ targetId, type: 'page', url: message.params.frame.url }, true)
+            }
+          }
+        } else if (message.method === 'Target.targetDestroyed') {
+          this.targets.delete(message.params.targetId)
+        } else if (message.method === 'Target.detachedFromTarget') {
+          for (const target of this.targets.values()) {
+            if (target.sessionId === message.params.sessionId) target.sessionId = undefined
+          }
+        }
+      } catch {
+        // Malformed/irrelevant CDP messages must not affect normal browsing.
+      }
+    })
+    socket.on('open', () => {
+      void this.discover(socket)
+    })
+  }
+
+  private async discover(socket: WebSocket): Promise<void> {
+    try {
+      await this.send('Target.setDiscoverTargets', { discover: true })
+      const result = await this.send('Target.getTargets')
+      if (this.socket !== socket || this.stopped) return
+      const infos = result.targetInfos as TargetInfo[]
+      const liveIds = new Set(infos.map(info => info.targetId))
+      for (const id of this.targets.keys()) {
+        if (!liveIds.has(id)) this.targets.delete(id)
+      }
+      for (const info of infos) this.updateTarget(info)
+      this.retries = 0
+      this.interval = setInterval(() => {
+        for (const [id, target] of this.targets) {
+          if (isGooglePasskeyChallenge(target.url) && !target.busy && !target.attempted &&
+              target.checks < MAX_CHECKS && Date.now() - target.since >= GRACE_MS) {
+            void this.check(id, target, socket)
+          }
+        }
+      }, CHECK_INTERVAL_MS)
+      this.interval.unref()
+    } catch {
+      socket.terminate()
+    }
+  }
+
+  private updateTarget(info: TargetInfo, newDocument = false): void {
+    if (info.type !== 'page') return
+    const target = this.targets.get(info.targetId)
+    if (target) {
+      if (target.url !== info.url || newDocument) {
+        target.url = info.url
+        target.since = Date.now()
+        target.generation++
+        target.checks = 0
+        target.attempted = false
+      }
+    } else if (isGooglePasskeyChallenge(info.url)) {
+      this.targets.set(info.targetId, {
+        url: info.url, since: Date.now(), generation: 0, checks: 0, attempted: false, busy: false,
+      })
+    }
+  }
+
+  private async check(id: string, target: TargetState, socket: WebSocket): Promise<void> {
+    target.busy = true
+    target.checks++
+    const generation = target.generation
+    const current = () => !this.stopped && this.socket === socket &&
+      this.targets.get(id) === target && target.generation === generation
+    try {
+      if (!target.sessionId) {
+        const attached = await this.send('Target.attachToTarget', { targetId: id, flatten: true })
+        // Keep attachments until browser cleanup. Repeated detach can disrupt
+        // WebAuthn environments belonging to other CDP clients on the same tab.
+        if (this.socket === socket) {
+          target.sessionId = attached.sessionId as string
+          await this.send('Page.enable', {}, target.sessionId)
+        }
+      }
+      if (!current() || !target.sessionId) return
+      // A timeout may mean the click ran but its response was lost. Never retry
+      // an ambiguous evaluation during this challenge, even after reconnecting.
+      target.attempted = true
+      const result = await this.send('Runtime.evaluate', {
+        expression: `location.href === ${JSON.stringify(target.url)} ? ${GOOGLE_PASSKEY_RECOVERY_EXPRESSION} : 'not-applicable'`,
+        returnByValue: true,
+      }, target.sessionId)
+      if (!current()) return
+      const value = (result.result as { value?: string } | undefined)?.value
+      if (value === 'waiting') target.attempted = false
+      if (value === 'clicked') console.log('[GooglePasskeyRecovery] Invoked Google passkey fallback')
+    } catch {
+      // Recovery is best effort and must never break browser launch or input.
+    } finally {
+      target.busy = false
+    }
+  }
+
+  private send(method: string, params: Record<string, unknown> = {}, sessionId?: string): Promise<Record<string, unknown>> {
+    const socket = this.socket
+    if (!socket || socket.readyState !== WebSocket.OPEN) return Promise.reject(new Error('Recovery disconnected'))
+    const id = ++this.sequence
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error('Recovery command timed out'))
+      }, COMMAND_TIMEOUT_MS)
+      timer.unref()
+      this.pending.set(id, { resolve, reject, timer })
+      socket.send(JSON.stringify({ id, method, params, ...(sessionId ? { sessionId } : {}) }), error => {
+        if (!error) return
+        const pending = this.pending.get(id)
+        if (!pending) return
+        this.pending.delete(id)
+        clearTimeout(timer)
+        reject(new Error('Recovery command failed'))
+      })
+    })
+  }
+
+  private resetConnection(): void {
+    this.socket = undefined
+    clearInterval(this.interval)
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer)
+      pending.reject(new Error('Recovery disconnected'))
+    }
+    this.pending.clear()
+    for (const target of this.targets.values()) target.sessionId = undefined
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped || this.retries >= MAX_RECONNECTS) return
+    this.retries++
+    this.reconnect = setTimeout(() => {
+      this.reconnect = undefined
+      this.connect()
+    }, RECONNECT_MS)
+    this.reconnect.unref()
+  }
+}
+
+export class GooglePasskeyRecovery {
+  private connections = new Map<string, RecoveryConnection>()
+
+  /** Only pass the reusable Browserbase debug URL, never its single-use connectUrl. */
+  watch(instanceId: string, debugUrl: string): void {
+    const existing = this.connections.get(instanceId)
+    if (existing?.url === debugUrl && existing.active) return
+    this.stop(instanceId)
+    this.connections.set(instanceId, new RecoveryConnection(debugUrl))
+  }
+
+  stop(instanceId: string): void {
+    this.connections.get(instanceId)?.stop()
+    this.connections.delete(instanceId)
+  }
+}

--- a/src/main/host-browser/platform-provider.ts
+++ b/src/main/host-browser/platform-provider.ts
@@ -4,6 +4,7 @@ import { getDataDir } from '@shared/lib/config/data-dir'
 import { getPlatformAccessToken } from '@shared/lib/services/platform-auth-service'
 import { getPlatformProxyBaseUrl } from '@shared/lib/platform-auth/config'
 import { getOrCreateMapping } from './context-map-store'
+import { GooglePasskeyRecovery } from './google-passkey-recovery'
 import type { HostBrowserProvider, HostBrowserProviderStatus, BrowserConnectionInfo, BrowserDebugInfo } from './types'
 
 const CONTEXTS_FILE = 'platform-browserbase-contexts.json'
@@ -31,6 +32,7 @@ export class PlatformBrowserProvider implements HostBrowserProvider {
 
   /** Maps instanceId → Browserbase session ID (proxied through platform) */
   private sessions: Map<string, string> = new Map()
+  private passkeyRecovery = new GooglePasskeyRecovery()
 
   onExternalClose: ((instanceId: string) => void) | null = null
 
@@ -69,12 +71,14 @@ export class PlatformBrowserProvider implements HostBrowserProvider {
           const debugUrl = await this.getDebugBrowserUrl(existingSessionId, token)
           if (debugUrl) {
             console.log(`[PlatformBrowserProvider] Reusing session ${existingSessionId} for instance ${instanceId}`)
+            this.passkeyRecovery.watch(instanceId, debugUrl)
             return { cdpUrl: debugUrl }
           }
         }
       } catch {
         // Session no longer valid
       }
+      this.passkeyRecovery.stop(instanceId)
       this.sessions.delete(instanceId)
     }
 
@@ -125,6 +129,7 @@ export class PlatformBrowserProvider implements HostBrowserProvider {
 
     const debugUrl = await this.getDebugBrowserUrl(session.id, token)
     if (debugUrl) {
+      this.passkeyRecovery.watch(instanceId, debugUrl)
       return { cdpUrl: debugUrl }
     }
 
@@ -160,6 +165,7 @@ export class PlatformBrowserProvider implements HostBrowserProvider {
   }
 
   async stop(instanceId: string): Promise<void> {
+    this.passkeyRecovery.stop(instanceId)
     const sessionId = this.sessions.get(instanceId)
     if (!sessionId) return
 


### PR DESCRIPTION
Google’s native passkey prompt can leave “Try another way” visible while discarding both agent and viewer input. Add an automatic observer that recognizes the current English Google passkey-in-progress page and invokes Google’s existing fallback handler once after a short delay, allowing Google to cancel the credential request and restore its sign-in choices.

Both direct and platform-managed Browserbase providers own the observer across session launch, reuse, replacement, and release. It uses the reusable debug CDP connection and handles existing tabs, new tabs, navigation, and reloads. URL and DOM checks limit the action to the recognized passkey screen; ambiguous evaluation failures are not retried. Authentication-method selection remains with the user or agent.

Validation on the branch rebased onto current main:

- All 88 host-browser tests pass with the repository’s locked dependencies.
- Full project TypeScript check passes.
- Repository lint passes with zero errors and 43 existing warnings.
- A live Browserbase synthetic probe reproduced native input blocking and verified automatic fallback, request cancellation, and restored trusted input. A second new-tab request also recovered.
- The original investigation independently verified Google’s actual fallback handler twice. Follow-up tests submitted no additional account identifiers, passwords, or SMS requests. Same-URL reload handling was subsequently covered by unit tests.

Compatibility is intentionally limited to the observed English Google UI and current challenge route. Local Chrome and Browserbase’s single-use connection fallback receive no observer.
