### PR TITLE
docs: stop identifying Gamut as Claude in the product FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,4 +288,4 @@ Each agent runs in its own Docker/Podman container with Claude Code in headless 
 - Containers communicate via HTTP/WebSocket APIs
 - SSE streaming for real-time message updates
 - File-based persistence for agents, sessions, and messages
-- SQLite database for OAuth connected accounts
+- SQLite database for OAuth connected accounts 

--- a/agent-container/docs/faqs/what-is-gamut-and-how-does-it-work.md
+++ b/agent-container/docs/faqs/what-is-gamut-and-how-does-it-work.md
@@ -12,7 +12,7 @@ Gamut is a platform for building and running personal AI agents. You create agen
 
 ### How it works
 
-Each agent you create in Gamut runs inside its own isolated container (Docker, Podman, or other supported runtimes). Inside that container, the agent is powered by Claude, Anthropic's large language model. The agent has access to a set of tools -- a shell, file system, web browser, and any external services you connect -- and uses them to carry out the tasks you describe in natural language.
+Each agent you create in Gamut runs inside its own isolated container (Docker, Podman, or other supported runtimes). Inside that container, the agent is powered by the best models from the leading AI labs. The agent has access to a set of tools -- a shell, file system, web browser, and any external services you connect -- and uses them to carry out the tasks you describe in natural language.
 
 You interact with agents through a chat interface. You can send messages, ask questions, assign tasks, and watch the agent work in real time. Agents remember context across sessions, learn your preferences over time, and can be scheduled to run tasks on their own.
 


### PR DESCRIPTION
## Summary
- The baked-in product FAQ (`what-is-gamut-and-how-does-it-work.md`) told agents they are powered by Claude / Anthropic.
- That one sentence now says they are powered by the best models from the leading AI labs.
- No other Claude Code harness references were changed.

## Test plan
- [x] Read the FAQ sentence under "How it works" and confirm Claude / Anthropic are gone there.
- [x] Confirm `CLAUDE.md`, Claude Agent SDK, and the Anthropic API key prerequisite are unchanged.
- [x] After image rebuild, ask an agent "what is Gamut?" and confirm it does not introduce itself as Claude.


Made with [Cursor](https://cursor.com)