### PR TITLE
fix(container): recover from corrupt image content on a failed health check

### DIFF
--- a/src/shared/lib/container/base-container-client.ts
+++ b/src/shared/lib/container/base-container-client.ts
@@ -528,6 +528,25 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
   }
 
   /**
+   * The other face of the same corruption: `run` succeeds, but the agent
+   * server dies at boot reading a file that ships inside the image (a
+   * truncated package.json under /app/node_modules, a module missing from
+   * /app/dist, a JS file cut off mid-way). Seen on Docker Desktop (Windows)
+   * and the bundled Lima VM after a pull unpacked onto a strained disk. The
+   * container can never become healthy; the fix is the same remove-and-
+   * recreate as the snapshot case. Only image-owned paths (/app) count:
+   * /workspace is user data and is not something a re-pull can repair.
+   */
+  protected isCorruptImageContentLog(logs: string): boolean {
+    if (!logs) return false
+    return (
+      /Invalid package config \/app\//.test(logs) ||
+      /Cannot find module '\/app\//.test(logs) ||
+      /\/app\/(?:node_modules|dist)\/[^\n]*:\d+\n[\s\S]{0,500}SyntaxError: Unexpected end of input/.test(logs)
+    )
+  }
+
+  /**
    * Remove the agent image so the next ensureImageExists() recreates it from
    * scratch. Base implementation only removes the tagged image — conservative
    * on user-owned daemons (docker/podman) that may hold unrelated images.
@@ -750,7 +769,9 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
       // Bounded retry loop. Each recovery path makes exactly one attempt of
       // progress so the loop can't spin: dropping a mount shrinks `volumes`,
       // re-picking a port is capped by portRetries, and VM provisioning and
-      // image re-creation each run once. A fresh force-remove precedes every
+      // image re-creation each run once (the latter shared between the two
+      // corruption shapes: a run that fails to mount, and a run that starts
+      // but dies on a corrupt file). A fresh force-remove precedes every
       // attempt so we never double-start, using one runtime process instead
       // of a redundant stop followed by rm.
       const MAX_PORT_RETRIES = 3
@@ -765,7 +786,6 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
           try {
             ({ stdout } = await execWithPath(buildRunCmd(), { timeoutMs: this.getRunExecTimeoutMs() }))
-            break
           } catch (runError: any) {
             // 1. Inaccessible bind mount (e.g. iCloud/File Provider path the VM
             //    can't stat). Drop that one mount and retry without it.
@@ -829,44 +849,73 @@ export abstract class BaseContainerClient extends EventEmitter implements Contai
 
             throw runError
           }
+
+          console.log(`Started container ${stdout.trim()} on port ${port}`)
+
+          // Wait for container to be healthy
+          addErrorBreadcrumb({ category: 'container', message: 'Waiting for container health check', data: { port, containerName } })
+          const healthy = await this.waitForHealthy(60000, port)
+          if (healthy) break
+
+          // Grab logs to help diagnose the failure
+          const logs = await this.getLogs(30)
+
+          // 5. The run succeeded but the server died reading a file baked into
+          //    the image (see isCorruptImageContentLog). Same corruption, same
+          //    remedy, same once-only budget as #3: remove the image, recreate
+          //    it, and go around again. The dead container must go first — a
+          //    stopped container still pins the image, so `rmi` would refuse.
+          if (!imageRecoveryTried && this.isCorruptImageContentLog(logs)) {
+            imageRecoveryTried = true
+            console.warn(`[Container] Corrupt image content detected in container logs, removing ${image} and recreating`)
+            addErrorBreadcrumb({ category: 'container', message: 'Corrupt image content, removing image and recreating', data: { image, agentId: this.config.agentId } })
+            await execWithPathSilent(`${runner} rm -f ${containerName}`)
+            try {
+              await this.removeCorruptImage(image)
+              await this.recreateImage(image)
+              captureMessage('Recovered from corrupt container image content', {
+                level: 'warning',
+                tags: { component: 'container', operation: 'corrupt-image-recovery' },
+                extra: { agentId: this.config.agentId, image, containerLogs: logs.slice(0, 2000) },
+              })
+              continue
+            } catch (repairError) {
+              captureException(repairError, {
+                tags: { component: 'container', operation: 'corrupt-image-recovery' },
+                extra: { agentId: this.config.agentId, image, containerLogs: logs.slice(0, 2000) },
+              })
+              // Fall through — surface the health error below.
+            }
+          }
+
+          const logsSnippet = logs ? `\n\nContainer logs:\n${logs}` : ''
+          const healthError = new Error(`Container failed to become healthy${logsSnippet}`)
+          captureException(healthError, {
+            tags: { component: 'container', operation: 'health-check' },
+            extra: {
+              agentId: this.config.agentId,
+              containerName,
+              port,
+              image,
+              runner: settings.container.containerRunner,
+              cpu,
+              memory,
+              containerLogs: logs,
+            },
+          })
+          // Stop + remove the just-created-but-unhealthy container. Otherwise it
+          // stays process-alive, and the next start() short-circuits on the
+          // running-status early return (getInfoFromRuntime derives 'running'
+          // from inspect's State.Running, not /health), caching a container that
+          // never became healthy. Best-effort/silent so an already-gone container
+          // is harmless and cleanup failure never masks the health error. Logs
+          // were already captured above, before this removes the container.
+          await execWithPathSilent(`${runner} stop ${containerName}`)
+          await execWithPathSilent(`${runner} rm ${containerName}`)
+          throw healthError
         }
       } finally {
         cleanupEnvFile()
-      }
-
-      console.log(`Started container ${stdout.trim()} on port ${port}`)
-
-      // Wait for container to be healthy
-      addErrorBreadcrumb({ category: 'container', message: 'Waiting for container health check', data: { port, containerName } })
-      const healthy = await this.waitForHealthy(60000, port)
-      if (!healthy) {
-        // Grab logs to help diagnose the failure
-        const logs = await this.getLogs(30)
-        const logsSnippet = logs ? `\n\nContainer logs:\n${logs}` : ''
-        const healthError = new Error(`Container failed to become healthy${logsSnippet}`)
-        captureException(healthError, {
-          tags: { component: 'container', operation: 'health-check' },
-          extra: {
-            agentId: this.config.agentId,
-            containerName,
-            port,
-            image,
-            runner: settings.container.containerRunner,
-            cpu,
-            memory,
-            containerLogs: logs,
-          },
-        })
-        // Stop + remove the just-created-but-unhealthy container. Otherwise it
-        // stays process-alive, and the next start() short-circuits on the
-        // running-status early return (getInfoFromRuntime derives 'running'
-        // from inspect's State.Running, not /health), caching a container that
-        // never became healthy. Best-effort/silent so an already-gone container
-        // is harmless and cleanup failure never masks the health error. Logs
-        // were already captured above, before this removes the container.
-        await execWithPathSilent(`${runner} stop ${containerName}`)
-        await execWithPathSilent(`${runner} rm ${containerName}`)
-        throw healthError
       }
 
       console.log(`Container ${containerName} is now running on port ${port}`)

--- a/src/shared/lib/container/corrupt-image-content-recovery.test.ts
+++ b/src/shared/lib/container/corrupt-image-content-recovery.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ============================================================================
+// Corrupt-image-content recovery in start().
+//
+// The snapshot case (corrupt-image-snapshot-recovery.test.ts) is a `run` that
+// fails to mount. This is the other shape of the same corruption: `run`
+// succeeds, the agent server boots, and Node dies reading a file that ships
+// inside the image — a truncated /app/node_modules/<pkg>/package.json
+// ("Invalid package config", ERR_INVALID_PACKAGE_CONFIG), a module missing
+// from /app/dist, a JS file cut off mid-way. The container never becomes
+// healthy and retrying against the same image can never succeed, so start()
+// must remove the image, recreate it, and try once more.
+//
+// These tests record every command handed to child_process.exec and script
+// the health-check outcome and the container logs per attempt.
+// ============================================================================
+
+const execCommands: string[] = []
+
+// Scripted health outcomes for successive run attempts; attempts beyond the
+// script are healthy.
+let healthScript: boolean[] = []
+let healthAttempts = 0
+
+// Container logs returned when a health check fails.
+let containerLogs = ''
+
+// Lifted from a real Sentry event (Docker Desktop on Windows, app 0.5.19):
+// the image's unpacked copy of hono/package.json was garbled on disk.
+const INVALID_PACKAGE_CONFIG_LOGS = `node:internal/modules/package_json_reader:116
+  const parsed = modulesBinding.readPackageJSON(
+                                ^
+
+Error: Invalid package config /app/node_modules/hono/package.json.
+    at Object.read (node:internal/modules/package_json_reader:116:33)
+    at _readPackage (node:internal/modules/cjs/loader:482:55)
+    at Module.require (node:internal/modules/cjs/loader:1527:12) {
+  code: 'ERR_INVALID_PACKAGE_CONFIG'
+}
+
+Node.js v22.23.2`
+
+const MISSING_DIST_MODULE_LOGS = `node:internal/modules/cjs/loader:1228
+  throw err;
+  ^
+
+Error: Cannot find module '/app/dist/session-manager.js'
+Require stack:
+- /app/dist/index.js
+    at Module._resolveFilename (node:internal/modules/cjs/loader:1225:15) {
+  code: 'MODULE_NOT_FOUND'
+}`
+
+const TRUNCATED_JS_LOGS = `/app/node_modules/@hono/node-server/dist/index.js:412
+    for (const [k, v] of Object.entries(headers)) {
+                                                   
+
+SyntaxError: Unexpected end of input
+    at wrapSafe (node:internal/modules/cjs/loader:1378:20)`
+
+// A workspace file the agent itself wrote: user data, not image content.
+const WORKSPACE_PACKAGE_LOGS = `Error: Invalid package config /workspace/project/package.json.
+    at Object.read (node:internal/modules/package_json_reader:116:33) {
+  code: 'ERR_INVALID_PACKAGE_CONFIG'
+}`
+
+vi.mock('child_process', () => {
+  const exec = (
+    command: string,
+    optionsOrCb: unknown,
+    maybeCb?: (err: Error | null, result?: { stdout: string; stderr: string }) => void
+  ) => {
+    const cb = (typeof optionsOrCb === 'function' ? optionsOrCb : maybeCb) as (
+      err: Error | null,
+      result?: { stdout: string; stderr: string }
+    ) => void
+    execCommands.push(command)
+    if (/run\s+-d/.test(command)) {
+      cb(null, { stdout: 'fake-container-id', stderr: '' })
+      return {}
+    }
+    // image inspect → found; ps → no used ports; rmi/stop/rm → succeed silently.
+    cb(null, { stdout: '', stderr: '' })
+    return {}
+  }
+  return { exec, execSync: vi.fn(), spawn: vi.fn() }
+})
+
+vi.mock('net', () => {
+  const createServer = vi.fn(() => {
+    const listeners = new Map<string, () => void>()
+    return {
+      once: vi.fn((event: string, callback: () => void) => {
+        listeners.set(event, callback)
+      }),
+      close: vi.fn(),
+      listen: vi.fn(() => {
+        queueMicrotask(() => listeners.get('listening')?.())
+      }),
+    }
+  })
+  return { default: { createServer }, createServer }
+})
+
+const captureExceptionMock = vi.fn()
+const captureMessageMock = vi.fn()
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+  captureMessage: (...args: unknown[]) => captureMessageMock(...args),
+  addErrorBreadcrumb: vi.fn(),
+}))
+
+const pullImageMock = vi.fn((_runner: string, _image: string) => Promise.resolve())
+const buildImageMock = vi.fn((_runner: string, _image: string) => Promise.resolve())
+let canBuild = false
+vi.mock('./client-factory', () => ({
+  canBuildImage: vi.fn(() => canBuild),
+  pullImage: (runner: string, image: string) => pullImageMock(runner, image),
+  buildImage: (runner: string, image: string) => buildImageMock(runner, image),
+}))
+
+vi.mock('@shared/lib/config/settings', () => ({
+  getSettings: vi.fn(() => ({
+    enableToolSearch: false,
+    container: {
+      agentImage: 'superagent/agent:test',
+      containerRunner: 'docker',
+      resourceLimits: { cpu: 2, memory: '2g' },
+    },
+  })),
+}))
+
+vi.mock('@shared/lib/llm-provider', () => ({
+  getActiveLlmProvider: vi.fn(() => ({
+    getContainerEnvVars: () => ({}),
+  })),
+}))
+
+vi.mock('@shared/lib/config/data-dir', () => ({
+  getAgentWorkspaceDir: vi.fn(() => '/tmp/corrupt-content-workspace'),
+}))
+
+vi.mock('fs', () => {
+  const noop = vi.fn()
+  return {
+    default: { mkdirSync: noop, writeFileSync: noop, unlinkSync: noop },
+    mkdirSync: noop,
+    writeFileSync: noop,
+    unlinkSync: noop,
+  }
+})
+
+import { BaseContainerClient } from './base-container-client'
+import type { ContainerConfig, ContainerInfo } from './types'
+
+/**
+ * Reports the container as stopped so start() runs the full path, and plays
+ * back the scripted health outcomes and logs instead of polling a socket.
+ */
+class TestContainerClient extends BaseContainerClient {
+  protected getRunnerCommand(): string {
+    return 'docker'
+  }
+  async getInfoFromRuntime(): Promise<ContainerInfo> {
+    return { status: 'stopped', port: null }
+  }
+  async waitForHealthy(): Promise<boolean> {
+    const outcome = healthScript[healthAttempts] ?? true
+    healthAttempts++
+    return outcome
+  }
+  async getLogs(): Promise<string> {
+    return containerLogs
+  }
+}
+
+const IMAGE = 'superagent/agent:test'
+const CONTAINER = 'superagent-abc123'
+
+function countRunAttempts(): number {
+  return execCommands.filter((c) => /run\s+-d/.test(c)).length
+}
+
+function rmiCommands(): string[] {
+  return execCommands.filter((c) => c.includes(`rmi -f ${IMAGE}`))
+}
+
+function makeClient(): TestContainerClient {
+  return new TestContainerClient({ agentId: 'abc123' } as ContainerConfig)
+}
+
+describe('start() recovers from corrupt image content', () => {
+  beforeEach(() => {
+    execCommands.length = 0
+    healthScript = []
+    healthAttempts = 0
+    containerLogs = ''
+    canBuild = false
+    pullImageMock.mockClear()
+    pullImageMock.mockResolvedValue(undefined)
+    buildImageMock.mockClear()
+    captureExceptionMock.mockClear()
+    captureMessageMock.mockClear()
+  })
+
+  it('removes the image, re-pulls it, and starts again when the server dies on an invalid package.json', async () => {
+    healthScript = [false, true]
+    containerLogs = INVALID_PACKAGE_CONFIG_LOGS
+
+    const info = await makeClient().start()
+
+    expect(info).toEqual({ status: 'running', port: 4000 })
+    expect(rmiCommands()).toHaveLength(1)
+    expect(pullImageMock).toHaveBeenCalledWith('docker', IMAGE)
+    expect(buildImageMock).not.toHaveBeenCalled()
+    expect(countRunAttempts()).toBe(2)
+    // The recovery is reported as a warning, not as a health-check error.
+    expect(captureMessageMock).toHaveBeenCalledWith(
+      'Recovered from corrupt container image content',
+      expect.objectContaining({ level: 'warning' })
+    )
+    expect(captureExceptionMock).not.toHaveBeenCalled()
+  })
+
+  it('removes the dead container before the image so rmi is not refused', async () => {
+    healthScript = [false, true]
+    containerLogs = INVALID_PACKAGE_CONFIG_LOGS
+
+    await makeClient().start()
+
+    const rmiIndex = execCommands.findIndex((c) => c.includes(`rmi -f ${IMAGE}`))
+    const firstRunIndex = execCommands.findIndex((c) => /run\s+-d/.test(c))
+    const rmBetween = execCommands
+      .slice(firstRunIndex, rmiIndex)
+      .filter((c) => c === `docker rm -f ${CONTAINER}`)
+    expect(rmBetween).toHaveLength(1)
+  })
+
+  it('rebuilds instead of pulling when a local build context exists (dev)', async () => {
+    canBuild = true
+    healthScript = [false, true]
+    containerLogs = INVALID_PACKAGE_CONFIG_LOGS
+
+    await makeClient().start()
+
+    expect(buildImageMock).toHaveBeenCalledWith('docker', IMAGE)
+    expect(pullImageMock).not.toHaveBeenCalled()
+    expect(countRunAttempts()).toBe(2)
+  })
+
+  it.each([
+    ['a module missing from /app/dist', MISSING_DIST_MODULE_LOGS],
+    ['a JS file truncated mid-way', TRUNCATED_JS_LOGS],
+  ])('recognises %s as corrupt image content', async (_label, logs) => {
+    healthScript = [false, true]
+    containerLogs = logs
+
+    await makeClient().start()
+
+    expect(rmiCommands()).toHaveLength(1)
+    expect(countRunAttempts()).toBe(2)
+  })
+
+  it('gives up after one recovery attempt when the corruption persists', async () => {
+    healthScript = [false, false]
+    containerLogs = INVALID_PACKAGE_CONFIG_LOGS
+
+    await expect(makeClient().start()).rejects.toThrow(/Container failed to become healthy/)
+
+    // One recovery, two run attempts total — never loops.
+    expect(rmiCommands()).toHaveLength(1)
+    expect(countRunAttempts()).toBe(2)
+    // The dead container from the second attempt is still cleaned up.
+    expect(execCommands.filter((c) => c === `docker stop ${CONTAINER}`)).toHaveLength(1)
+  })
+
+  it('surfaces the health error (with logs) when the re-pull itself fails', async () => {
+    pullImageMock.mockRejectedValueOnce(new Error('Image pull failed with exit code 1'))
+    healthScript = [false]
+    containerLogs = INVALID_PACKAGE_CONFIG_LOGS
+
+    await expect(makeClient().start()).rejects.toThrow(/Invalid package config \/app\/node_modules\/hono/)
+
+    expect(countRunAttempts()).toBe(1)
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ tags: expect.objectContaining({ operation: 'corrupt-image-recovery' }) })
+    )
+  })
+
+  it('does not remove the image when the health check fails for other reasons', async () => {
+    healthScript = [false]
+    containerLogs = 'Listening on :4000\nWarning: slow disk'
+
+    await expect(makeClient().start()).rejects.toThrow(/Container failed to become healthy/)
+
+    expect(rmiCommands()).toHaveLength(0)
+    expect(pullImageMock).not.toHaveBeenCalled()
+    expect(countRunAttempts()).toBe(1)
+  })
+
+  it('does not remove the image for an invalid package.json under /workspace (user data)', async () => {
+    healthScript = [false]
+    containerLogs = WORKSPACE_PACKAGE_LOGS
+
+    await expect(makeClient().start()).rejects.toThrow(/Container failed to become healthy/)
+
+    expect(rmiCommands()).toHaveLength(0)
+    expect(countRunAttempts()).toBe(1)
+  })
+
+  it('does not remove the image when the health check fails with no logs at all', async () => {
+    healthScript = [false]
+    containerLogs = ''
+
+    await expect(makeClient().start()).rejects.toThrow(/Container failed to become healthy/)
+
+    expect(rmiCommands()).toHaveLength(0)
+    expect(countRunAttempts()).toBe(1)
+  })
+})


### PR DESCRIPTION
## Problem

A customer on Docker Desktop (Windows, app 0.5.19) could not start any agent for a day. Every start failed with:

```
Container failed to become healthy
Container logs:
Error: Invalid package config /app/node_modules/hono/package.json.
  code: 'ERR_INVALID_PACKAGE_CONFIG'
```

The published image is intact (verified by pulling the amd64 `0.5.19` tag and parsing the file). The copy unpacked into their Docker image store was garbled. The same shape hit a Lima user in August with `uuid/package.json`.

`start()` already knows how to recover from a corrupt image, but only when `run` itself fails to mount it (`mount callback failed`, `failed to stat parent`). When `run` succeeds and the server dies at boot on a damaged file, the failure lands in the health-check branch, which only captures and throws. The user retries forever against the same image; the only fix was deleting it by hand.

## Fix

The health check now lives inside the bounded run loop. When it fails and the container logs carry an image-content signature (`Invalid package config /app/…`, `Cannot find module '/app/…`, a `SyntaxError: Unexpected end of input` under `/app/node_modules` or `/app/dist`), start():

1. removes the dead container (a stopped container still pins the image, so `rmi` would refuse),
2. removes and recreates the image through the existing `removeCorruptImage` / `recreateImage` pair (pull in packaged apps, build in dev),
3. runs once more.

The once-only budget is shared with the mount-failure path, so a corruption that reproduces still terminates with the original health error. Only `/app` paths count: `/workspace` is user data and a re-pull cannot repair it. Recovery is reported to Sentry as a warning so we can see how often it fires.

## Tests

`corrupt-image-content-recovery.test.ts`, modelled on the existing snapshot-recovery test, with the real log text from the Sentry event: recovers on invalid package.json / missing dist module / truncated JS, removes the container before the image, rebuilds in dev, gives up after one attempt, surfaces the health error when the re-pull fails, and leaves the image alone for unrelated failures, empty logs, and a bad package.json under `/workspace`.

No UI change.

https://claude.ai/code/session_012tdUx7Qf9Amru2AdEvy69S
