### PR TITLE
fix(container): verify a pulled image before trusting it

### DIFF
--- a/src/shared/lib/container/client-factory.test.ts
+++ b/src/shared/lib/container/client-factory.test.ts
@@ -108,8 +108,10 @@ vi.mock('os', () => ({
 }))
 
 const mockCaptureException = vi.fn()
+const mockCaptureMessage = vi.fn()
 vi.mock('@shared/lib/error-reporting', () => ({
   captureException: (...args: unknown[]) => mockCaptureException(...args),
+  captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
   addErrorBreadcrumb: vi.fn(),
 }))
 
@@ -119,7 +121,10 @@ vi.mock('@shared/lib/error-reporting', () => ({
 
 import {
   checkAllRunnersAvailability,
+  classifyImageCheckOutput,
   clearRunnerAvailabilityCache,
+  IMAGE_CHECK_MARKER,
+  IMAGE_CHECK_TIMEOUT_MS,
   pullImage,
   PULL_STALL_TIMEOUT_MS,
   KILL_STALLED_PULL_TIMEOUT_MS,
@@ -473,7 +478,17 @@ describe('pullImage stall watchdog', () => {
     vi.clearAllMocks()
     vi.useFakeTimers()
     proc = new FakePullProc()
-    mockSpawnWithPath.mockReturnValue(proc)
+    // A successful pull is followed by the integrity-check container (a
+    // `run`); hand that spawn its own process that passes straight away.
+    mockSpawnWithPath.mockImplementation((_cli: string, args: string[]) => {
+      if (args[0] !== 'run') return proc
+      const check = new FakePullProc()
+      queueMicrotask(() => {
+        check.stdout.emit('data', Buffer.from(`${IMAGE_CHECK_MARKER} 139 package.json files checked, 0 damaged\n`))
+        check.emit('close', 0)
+      })
+      return check
+    })
     mockKillWSL2PullProcesses.mockResolvedValue(undefined)
   })
 
@@ -566,5 +581,197 @@ describe('pullImage stall watchdog', () => {
     await assertion
 
     expect(mockKillWSL2PullProcesses).not.toHaveBeenCalled()
+  })
+})
+
+// ============================================================================
+// pullImage integrity check — a pull verifies layer digests on download but
+// not the unpack; a file that lands truncated on a strained disk makes the
+// image fail every start until it is deleted by hand. Right after the pull a
+// throwaway container parses every package.json under /app/node_modules and
+// loads the boot-time modules; a damaged image is deleted and pulled once
+// more, a second damaged copy fails the pull with the damaged copy removed.
+// ============================================================================
+
+describe('classifyImageCheckOutput', () => {
+  it('reads the summary line', () => {
+    expect(classifyImageCheckOutput(`${IMAGE_CHECK_MARKER} 139 package.json files checked, 0 damaged`)).toBe('ok')
+    expect(classifyImageCheckOutput(`damaged /app/node_modules/hono/package.json\n${IMAGE_CHECK_MARKER} 139 package.json files checked, 1 damaged`)).toBe('damaged')
+  })
+
+  it('recognises the server crash signatures when node died before the summary', () => {
+    expect(classifyImageCheckOutput('Error: Invalid package config /app/node_modules/hono/package.json.\n  code: ERR_INVALID_PACKAGE_CONFIG')).toBe('damaged')
+    expect(classifyImageCheckOutput("Error: Cannot find module '/app/dist/server.js'")).toBe('damaged')
+    expect(classifyImageCheckOutput('/app/node_modules/hono/dist/cjs/index.js:412\n  foo(\n\nSyntaxError: Unexpected end of input')).toBe('damaged')
+  })
+
+  it('is inconclusive when the check could not run', () => {
+    expect(classifyImageCheckOutput('')).toBe('inconclusive')
+    expect(classifyImageCheckOutput('docker: Error response from daemon: dial unix /var/run/docker.sock: connect: no such file')).toBe('inconclusive')
+    expect(classifyImageCheckOutput('Error: unknown flag: --entrypoint')).toBe('inconclusive')
+    // A workspace file is user data, not image content.
+    expect(classifyImageCheckOutput('Error: Invalid package config /workspace/app/package.json.')).toBe('inconclusive')
+  })
+})
+
+describe('pullImage integrity check', () => {
+  class FakeProc extends EventEmitter {
+    stdout = new EventEmitter()
+    stderr = new EventEmitter()
+    kill = vi.fn()
+    constructor(public readonly args: string[]) {
+      super()
+    }
+  }
+
+  const IMAGE = 'ghcr.io/acme/agent:1.0.0'
+  const OK_LINE = `${IMAGE_CHECK_MARKER} 139 package.json files checked, 0 damaged\n`
+  const DAMAGED_LINES = `damaged /app/node_modules/hono/package.json\n${IMAGE_CHECK_MARKER} 139 package.json files checked, 1 damaged\n`
+
+  let spawned: FakeProc[]
+  // Scripted outcomes for successive integrity-check containers.
+  let checkScript: Array<'ok' | 'damaged' | 'silent' | 'hang'>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    spawned = []
+    checkScript = []
+    mockKillWSL2PullProcesses.mockResolvedValue(undefined)
+    mockSpawnWithPath.mockImplementation((_cli: string, args: string[]) => {
+      const proc = new FakeProc(args)
+      spawned.push(proc)
+      queueMicrotask(() => {
+        if (args[0] === 'pull') {
+          proc.emit('close', 0)
+        } else if (args[0] === 'run') {
+          const outcome = checkScript.shift() ?? 'ok'
+          if (outcome === 'ok') {
+            proc.stdout.emit('data', Buffer.from(OK_LINE))
+            proc.emit('close', 0)
+          } else if (outcome === 'damaged') {
+            proc.stdout.emit('data', Buffer.from(DAMAGED_LINES))
+            proc.emit('close', 1)
+          } else if (outcome === 'silent') {
+            proc.stderr.emit('data', Buffer.from('docker: Error response from daemon: something unrelated\n'))
+            proc.emit('close', 125)
+          }
+          // 'hang': never closes — the timeout has to settle it.
+        } else {
+          proc.emit('close', 0)
+        }
+      })
+      return proc
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const argsOf = (procs: FakeProc[]) => procs.map((p) => p.args[0])
+  const checkProcs = () => spawned.filter((p) => p.args[0] === 'run')
+
+  it('runs the check in a throwaway container of the pulled image, without a shell in the way', async () => {
+    await pullImage('docker', IMAGE)
+
+    expect(argsOf(spawned)).toEqual(['pull', 'run'])
+    const [check] = checkProcs()
+    expect(check.args).toEqual([
+      'run', '--rm',
+      '-e', expect.stringMatching(/^IMAGE_CHECK=[A-Za-z0-9+/=]+$/),
+      '--entrypoint', 'node',
+      IMAGE,
+      '-e', "eval(Buffer.from(process.env.IMAGE_CHECK,'base64').toString())",
+    ])
+    // The script itself never touches a shell: it rides base64 in the env var.
+    const encoded = check.args[3].slice('IMAGE_CHECK='.length)
+    const script = Buffer.from(encoded, 'base64').toString('utf8')
+    expect(script).toContain("walk('/app/node_modules')")
+    expect(script).toContain("require('hono')")
+    expect(script).toContain("require.resolve('/app/dist/server.js')")
+    expect(mockCaptureMessage).not.toHaveBeenCalled()
+    expect(mockCaptureException).not.toHaveBeenCalled()
+  })
+
+  it('deletes a damaged image and pulls it again', async () => {
+    checkScript = ['damaged', 'ok']
+
+    await expect(pullImage('docker', IMAGE)).resolves.toBeUndefined()
+
+    expect(argsOf(spawned)).toEqual(['pull', 'run', 'rmi', 'pull', 'run'])
+    expect(spawned[2].args).toEqual(['rmi', '-f', IMAGE])
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      'Freshly pulled image is damaged; removing and pulling again',
+      expect.objectContaining({ level: 'warning' })
+    )
+    expect(mockCaptureException).not.toHaveBeenCalled()
+  })
+
+  it('fails the pull, with the damaged copy removed, when the second download is damaged too', async () => {
+    checkScript = ['damaged', 'damaged']
+
+    const failure = await pullImage('docker', IMAGE).then(
+      () => { throw new Error('expected the pull to fail') },
+      (err: Error) => err
+    )
+    expect(failure.message).toMatch(/downloaded damaged twice/)
+    // Marked so start()'s catch does not report the same failure twice.
+    expect(failure).toMatchObject({ sentryCaptured: true })
+
+    // No third pull, and the damaged copy does not linger to be mistaken for
+    // a working image by the caller's "did it appear concurrently?" re-check.
+    expect(argsOf(spawned)).toEqual(['pull', 'run', 'rmi', 'pull', 'run', 'rmi'])
+    expect(mockCaptureException).toHaveBeenCalledOnce()
+    expect(mockCaptureException.mock.calls[0][1]).toMatchObject({
+      tags: { component: 'container', operation: 'image-integrity' },
+    })
+  })
+
+  it('lets the pull succeed when the check cannot run at all', async () => {
+    checkScript = ['silent']
+
+    await expect(pullImage('docker', IMAGE)).resolves.toBeUndefined()
+
+    expect(argsOf(spawned)).toEqual(['pull', 'run'])
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      'Image integrity check inconclusive after pull',
+      expect.objectContaining({ level: 'info' })
+    )
+  })
+
+  it('kills a hung check after the timeout and treats it as inconclusive', async () => {
+    checkScript = ['hang']
+
+    const promise = pullImage('docker', IMAGE)
+    await vi.advanceTimersByTimeAsync(IMAGE_CHECK_TIMEOUT_MS + 1)
+    await expect(promise).resolves.toBeUndefined()
+
+    expect(checkProcs()[0].kill).toHaveBeenCalledWith('SIGKILL')
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      'Image integrity check inconclusive after pull',
+      expect.objectContaining({ extra: expect.objectContaining({ output: expect.stringContaining('timed out') }) })
+    )
+  })
+
+  it('uses `image delete` for the Apple runner, which has no rmi', async () => {
+    checkScript = ['damaged', 'ok']
+
+    await pullImage('apple-container', IMAGE)
+
+    const removal = spawned.find((p) => p.args[0] === 'image' && p.args[1] === 'delete')
+    expect(removal?.args).toEqual(['image', 'delete', '--force', IMAGE])
+  })
+
+  it('does not run the check when the pull itself failed', async () => {
+    mockSpawnWithPath.mockImplementation((_cli: string, args: string[]) => {
+      const proc = new FakeProc(args)
+      spawned.push(proc)
+      queueMicrotask(() => proc.emit('close', 1))
+      return proc
+    })
+
+    await expect(pullImage('docker', IMAGE)).rejects.toThrow(/Image pull failed/)
+    expect(argsOf(spawned)).toEqual(['pull'])
   })
 })

--- a/src/shared/lib/container/client-factory.ts
+++ b/src/shared/lib/container/client-factory.ts
@@ -1,7 +1,7 @@
 import type { ContainerClient, ContainerConfig, ContainerRunner, ImagePullProgress } from './types'
 export { CONTAINER_RUNNER_IDS } from './types'
 export type { ContainerRunner } from './types'
-import { captureException, addErrorBreadcrumb } from '@shared/lib/error-reporting'
+import { captureException, captureMessage, addErrorBreadcrumb } from '@shared/lib/error-reporting'
 import { DockerContainerClient } from './docker-container-client'
 import { PodmanContainerClient } from './podman-container-client'
 import { AppleContainerClient, ensureAppleContainerReady, stopAppleContainerRuntime } from './apple-container-client'
@@ -473,9 +473,185 @@ export function pullImage(
     addErrorBreadcrumb({ category: 'container', message: 'Awaiting already in-flight pull of the same image', data: { image, runner } })
     return existing
   }
-  const pull = doPullImage(runner, image, onProgress).finally(() => inflightPulls.delete(key))
+  const pull = doPullImage(runner, image, onProgress)
+    .then(() => verifyPulledImage(runner, image, onProgress))
+    .finally(() => inflightPulls.delete(key))
   inflightPulls.set(key, pull)
   return pull
+}
+
+// ---------------------------------------------------------------------------
+// Post-pull integrity check
+//
+// A pull verifies every layer's digest as it downloads, but nothing verifies
+// the unpack. On a strained disk (Docker Desktop on Windows, the bundled Lima
+// VM) a file can land truncated or garbled, and the image then fails every
+// start with "Invalid package config /app/node_modules/<pkg>/package.json"
+// until someone deletes it by hand. Two seconds in a throwaway container
+// right after the pull catches that at the moment it happens, while the
+// remedy (delete, pull again) is still cheap and automatic.
+// ---------------------------------------------------------------------------
+
+/** Summary line the in-container check prints; the host reads it back. */
+export const IMAGE_CHECK_MARKER = 'image-check:'
+
+/** Wall-clock cap for the check container; past it the check is inconclusive. */
+export const IMAGE_CHECK_TIMEOUT_MS = 2 * 60 * 1000
+
+/**
+ * Runs inside the image under `node -e`: parses every package.json under
+ * /app/node_modules and loads the modules the agent server needs at boot —
+ * the same reads that crashed the server in the field. It travels to the
+ * container base64-encoded in an env var so no shell on any platform ever
+ * parses it. Exit code 1 means damage was found.
+ */
+const IMAGE_CHECK_SCRIPT = `
+var fs = require('fs'), path = require('path');
+var checked = 0, bad = 0;
+function walk(dir) {
+  var entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (e) { return; }
+  for (var i = 0; i < entries.length; i++) {
+    var entry = entries[i], full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full);
+    else if (entry.name === 'package.json') {
+      checked++;
+      try { JSON.parse(fs.readFileSync(full, 'utf8')); } catch (e) { bad++; console.log('damaged ' + full); }
+    }
+  }
+}
+walk('/app/node_modules');
+try { require('hono'); require('@hono/node-server'); } catch (e) { bad++; console.log('damaged require: ' + e.message); }
+try { require.resolve('@anthropic-ai/claude-agent-sdk'); require.resolve('/app/dist/server.js'); } catch (e) { bad++; console.log('damaged resolve: ' + e.message); }
+console.log('${IMAGE_CHECK_MARKER} ' + checked + ' package.json files checked, ' + bad + ' damaged');
+process.exit(bad ? 1 : 0);
+`
+
+export type ImageCheckVerdict = 'ok' | 'damaged' | 'inconclusive'
+
+/**
+ * Read the check container's output. The summary line is authoritative; if
+ * Node died before printing it, the same crash signatures the agent server
+ * produces on a damaged image still count. Anything else — the runtime
+ * refusing to run a container, a CLI that lacks --entrypoint, a timeout — is
+ * inconclusive: the check must never block a start it cannot judge.
+ */
+export function classifyImageCheckOutput(output: string): ImageCheckVerdict {
+  const summary = output.match(new RegExp(`${IMAGE_CHECK_MARKER} (\\d+) package\\.json files checked, (\\d+) damaged`))
+  if (summary) return Number(summary[2]) > 0 ? 'damaged' : 'ok'
+  if (
+    /Invalid package config \/app\//.test(output) ||
+    /Cannot find module '\/app\//.test(output) ||
+    /\/app\/(?:node_modules|dist)\/[^\n]*:\d+\n[\s\S]{0,500}SyntaxError: Unexpected end of input/.test(output)
+  ) {
+    return 'damaged'
+  }
+  return 'inconclusive'
+}
+
+/**
+ * Run the integrity check in a throwaway container of `image`. Never throws:
+ * a check that cannot run is reported as inconclusive with whatever output
+ * the CLI produced.
+ */
+export function checkImageIntegrity(runner: ContainerRunner, image: string): Promise<{ verdict: ImageCheckVerdict; output: string }> {
+  return new Promise((resolve) => {
+    const cli = getCliCommand(runner)
+    const encoded = Buffer.from(IMAGE_CHECK_SCRIPT, 'utf8').toString('base64')
+    const decodeAndRun = "eval(Buffer.from(process.env.IMAGE_CHECK,'base64').toString())"
+    // spawnWithPath hands args to a shell only on Windows (to reach .cmd
+    // wrappers); there the code argument needs quotes, elsewhere quotes would
+    // reach node verbatim and break the eval.
+    const codeArg = platform() === 'win32' ? `"${decodeAndRun}"` : decodeAndRun
+    const proc = spawnWithPath(cli, ['run', '--rm', '-e', `IMAGE_CHECK=${encoded}`, '--entrypoint', 'node', image, '-e', codeArg])
+
+    const chunks: string[] = []
+    let settled = false
+    const finish = (suffix = '') => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      const output = (chunks.join('') + suffix).trim()
+      resolve({ verdict: classifyImageCheckOutput(output), output })
+    }
+    const timer = setTimeout(() => {
+      try { proc.kill('SIGKILL') } catch { /* already gone */ }
+      finish(`\n[image check timed out after ${IMAGE_CHECK_TIMEOUT_MS / 1000}s]`)
+    }, IMAGE_CHECK_TIMEOUT_MS)
+
+    proc.stdout?.on('data', (data: Buffer) => chunks.push(data.toString()))
+    proc.stderr?.on('data', (data: Buffer) => chunks.push(data.toString()))
+    proc.on('close', () => finish())
+    proc.on('error', (err) => finish(`\n[image check could not start: ${err.message}]`))
+  })
+}
+
+/** Best-effort image removal; a failure here just leaves the next pull to overwrite. */
+function removeImage(runner: ContainerRunner, image: string): Promise<void> {
+  return new Promise((resolve) => {
+    const cli = getCliCommand(runner)
+    // Apple's CLI has no rmi; see AppleContainerClient.removeCorruptImage.
+    const args = runner === 'apple-container' ? ['image', 'delete', '--force', image] : ['rmi', '-f', image]
+    const proc = spawnWithPath(cli, args)
+    proc.on('close', () => resolve())
+    proc.on('error', () => resolve())
+  })
+}
+
+/**
+ * Check a freshly pulled image and, if it is damaged, delete it and pull once
+ * more. A second damaged copy is a runtime-storage problem no re-pull will
+ * fix: the copy is deleted (so a later "did the image appear?" re-check does
+ * not mistake it for success) and the pull fails with a message that says so.
+ */
+async function verifyPulledImage(
+  runner: ContainerRunner,
+  image: string,
+  onProgress?: (progress: ImagePullProgress) => void
+): Promise<void> {
+  onProgress?.({ status: 'Checking the downloaded image', percent: null, completedLayers: 0, totalLayers: 0 })
+  const first = await checkImageIntegrity(runner, image)
+  if (first.verdict === 'ok') {
+    addErrorBreadcrumb({ category: 'container', message: 'Pulled image passed integrity check', data: { image, runner } })
+    return
+  }
+  if (first.verdict === 'inconclusive') {
+    captureMessage('Image integrity check inconclusive after pull', {
+      level: 'info',
+      tags: { component: 'container', operation: 'image-integrity' },
+      extra: { image, runner, output: first.output.slice(-2000) },
+    })
+    return
+  }
+
+  captureMessage('Freshly pulled image is damaged; removing and pulling again', {
+    level: 'warning',
+    tags: { component: 'container', operation: 'image-integrity' },
+    extra: { image, runner, output: first.output.slice(-2000) },
+  })
+  await removeImage(runner, image)
+  await doPullImage(runner, image, onProgress)
+
+  onProgress?.({ status: 'Checking the downloaded image', percent: null, completedLayers: 0, totalLayers: 0 })
+  const second = await checkImageIntegrity(runner, image)
+  if (second.verdict !== 'damaged') {
+    addErrorBreadcrumb({ category: 'container', message: 'Re-pulled image passed integrity check', data: { image, runner } })
+    return
+  }
+
+  await removeImage(runner, image)
+  // sentryCaptured: canonical event for the failure — see pullImage's exit-code path.
+  const error = Object.assign(
+    new Error(
+      `The agent image downloaded damaged twice (${image}). The container runtime's storage may be corrupt or the disk nearly full — free up space, restart the container runtime, and try again. ${second.output.slice(-300)}`
+    ),
+    { sentryCaptured: true }
+  )
+  captureException(error, {
+    tags: { component: 'container', operation: 'image-integrity' },
+    extra: { image, runner, firstOutput: first.output.slice(-2000), secondOutput: second.output.slice(-2000) },
+  })
+  throw error
 }
 
 function doPullImage(


### PR DESCRIPTION
## Problem

A pull verifies every layer's digest as it downloads, but nothing verifies the unpack. On a strained disk (Docker Desktop on Windows, the bundled Lima VM) a file can land truncated or garbled, and the image then fails every agent start with `Invalid package config /app/node_modules/<pkg>/package.json` until someone deletes it by hand. A customer lost a day to this on 0.5.19; a Lima user hit the same shape in August.

Companion to #1017, which heals the same corruption when it is only discovered at start time. This PR catches it earlier, at the moment the pull finishes, while the remedy is still cheap and invisible to the user.

## Fix

`pullImage()` now follows a successful pull with a throwaway container of the image:

```
<cli> run --rm -e IMAGE_CHECK=<base64> --entrypoint node <image> -e "eval(Buffer.from(process.env.IMAGE_CHECK,'base64').toString())"
```

The script parses every package.json under `/app/node_modules` and loads the boot-time modules (`hono`, `@hono/node-server`, resolves the Agent SDK and `dist/server.js`), the same reads that crashed the server in the field. It rides base64 in an env var so no shell on any platform parses it, and prints one summary line the host reads back.

- **damaged** → delete the image, pull once more, check again.
- **damaged twice** → runtime-storage problem no re-pull fixes: delete the copy (so the caller's "did the image appear concurrently?" re-check does not mistake it for success) and fail the pull with a message that says to free disk space and restart the runtime.
- **inconclusive** (runtime refuses to run a container, CLI without `--entrypoint`, 2-minute timeout) → never blocks the pull; reported at info level so we can see how often it happens per runner.

Cost: about two seconds once per new image version.

## Verification

Live against real Docker with the published `0.5.19` image: 139 package.json files checked, 0 damaged. With `hono/package.json` deliberately truncated inside the container it reports 2 damaged and exits 1; with `dist/server.js` deleted it reports 1 damaged.

Unit tests in `client-factory.test.ts`: the exact spawn args (no shell, base64 script), delete-and-re-pull on damage, fail-with-removal on a second damaged copy, inconclusive on a check that cannot run, timeout kill on a hung check, `image delete` for the Apple runner, and no check after a failed pull. The existing stall-watchdog tests now script the follow-up check container.

No UI change.

https://claude.ai/code/session_012tdUx7Qf9Amru2AdEvy69S
