### PR TITLE
Report dictation failures to Sentry

### DIFF
--- a/src/api/routes/voice.ts
+++ b/src/api/routes/voice.ts
@@ -6,6 +6,7 @@ import { resolveTtsSpeed } from '@shared/lib/voice/tts-preferences'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { getUserSettings } from '@shared/lib/services/user-settings-service'
 import { getVoiceAgentPrompt, type VoiceAgentPromptName } from '@shared/prompts/voice-agent'
+import { captureException } from '@shared/lib/error-reporting'
 
 const voice = new Hono()
 
@@ -33,6 +34,7 @@ voice.get('/configured', (c) => {
 })
 
 voice.get('/token', async (c) => {
+  let provider: VoiceProvider | undefined
   try {
     const providerParam = c.req.query('provider')
     if (providerParam && providerParam !== 'deepgram' && providerParam !== 'openai' && providerParam !== 'platform') {
@@ -40,7 +42,7 @@ voice.get('/token', async (c) => {
     }
 
     const voiceSettings = getVoiceSettings()
-    const provider: VoiceProvider | undefined = (providerParam as VoiceProvider) || voiceSettings.sttProvider
+    provider = (providerParam as VoiceProvider) || voiceSettings.sttProvider
 
     if (!provider) {
       return c.json({ error: 'No voice provider configured. Set one in Settings > Voice.' }, 400)
@@ -51,6 +53,11 @@ voice.get('/token', async (c) => {
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'Failed to get STT credentials'
     console.error('Failed to get STT credentials:', error)
+    // The one server-side step of dictation: a failure here means nobody on
+    // this deployment can dictate, so it belongs in the error tracker.
+    captureException(error, {
+      tags: { component: 'voice', operation: 'stt-token', provider: provider ?? 'none' },
+    })
     return c.json({ error: message }, 500)
   }
 })

--- a/src/renderer/hooks/use-voice-input.test.tsx
+++ b/src/renderer/hooks/use-voice-input.test.tsx
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { SttAdapter, SttSessionStats, TranscriptCallback, ErrorCallback } from '@renderer/lib/stt'
+
+const reporting = vi.hoisted(() => ({
+  captureRendererException: vi.fn(),
+  captureRendererMessage: vi.fn(),
+  addRendererBreadcrumb: vi.fn(),
+}))
+vi.mock('@renderer/lib/error-reporting', () => reporting)
+
+const stt = vi.hoisted(() => ({
+  acquireMicStream: vi.fn(),
+  createSttAdapter: vi.fn(),
+  startAudioCapture: vi.fn(),
+}))
+vi.mock('@renderer/lib/stt', () => stt)
+
+const api = vi.hoisted(() => ({ apiFetch: vi.fn() }))
+vi.mock('@renderer/lib/api', () => api)
+
+vi.mock('@renderer/context/analytics-context', () => ({
+  useAnalyticsTracking: () => ({ track: vi.fn() }),
+}))
+
+import { useVoiceInput } from './use-voice-input'
+
+/** A speech adapter whose socket never opens unless the test says so. */
+class FakeAdapter implements SttAdapter {
+  readonly sampleRate = 24000
+  readonly stats: SttSessionStats = {
+    socketOpened: false,
+    bytesReceived: 0,
+    bytesSent: 0,
+    bytesDropped: 0,
+    peakSample: 0,
+    serverEvents: {},
+    interims: 0,
+    finals: 0,
+    errors: 0,
+  }
+  transcriptCb: TranscriptCallback | null = null
+  errorCb: ErrorCallback | null = null
+  connectResult: Promise<void> = new Promise(() => {})
+  connect = vi.fn(() => this.connectResult)
+  sendAudio = vi.fn()
+  onTranscript(cb: TranscriptCallback) { this.transcriptCb = cb }
+  onError(cb: ErrorCallback) { this.errorCb = cb }
+  finish = vi.fn(async () => {})
+  finalize = vi.fn()
+  close = vi.fn()
+
+  /** As if this many seconds of speech (or silence) had gone through. */
+  heard(seconds: number, peakSample: number) {
+    this.stats.bytesReceived = this.sampleRate * 2 * seconds
+    this.stats.peakSample = peakSample
+  }
+}
+
+const stream = {
+  getAudioTracks: () => [{
+    label: 'Built-in Microphone',
+    enabled: true,
+    muted: false,
+    readyState: 'live',
+    getSettings: () => ({ sampleRate: 48000, channelCount: 1 }),
+  }],
+  getTracks: () => [{ stop: vi.fn() }],
+} as unknown as MediaStream
+
+function arrange(adapter: FakeAdapter) {
+  api.apiFetch.mockResolvedValue({ ok: true, json: async () => ({ provider: 'openai', token: 'ephemeral' }) })
+  stt.acquireMicStream.mockResolvedValue(stream)
+  stt.createSttAdapter.mockReturnValue(adapter)
+  stt.startAudioCapture.mockResolvedValue({
+    stream,
+    audioContext: { sampleRate: 24000 },
+    analyser: {},
+    captureKind: 'worklet',
+    setSink: vi.fn(),
+    cleanup: vi.fn(),
+  })
+  const onTranscriptUpdate = vi.fn()
+  const hook = renderHook(() => useVoiceInput({ onTranscriptUpdate }))
+  return { hook, onTranscriptUpdate }
+}
+
+/**
+ * Kick off in one synchronous act so the 'connecting' render lands before the
+ * credential round-trip resolves (as it does against a real network), then
+ * let the rest of the start-up settle.
+ */
+async function start(hook: ReturnType<typeof arrange>['hook']) {
+  let pending!: Promise<void>
+  act(() => { pending = hook.result.current.startRecording('') })
+  await act(async () => { await pending })
+}
+
+async function startRecording(hook: ReturnType<typeof arrange>['hook']) {
+  await start(hook)
+  expect(hook.result.current.isRecording).toBe(true)
+}
+
+async function stop(hook: ReturnType<typeof arrange>['hook']) {
+  await act(async () => { await hook.result.current.stopRecording() })
+}
+
+describe('useVoiceInput error reports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reports a session that heard speech, never opened its socket, and produced no words', async () => {
+    const adapter = new FakeAdapter()
+    const { hook } = arrange(adapter)
+    await startRecording(hook)
+    adapter.heard(4, 9000)
+    await stop(hook)
+
+    expect(reporting.captureRendererMessage).toHaveBeenCalledTimes(1)
+    const [message, context] = reporting.captureRendererMessage.mock.calls[0]
+    expect(message).toBe('Dictation ended without a transcript (attempt 1)')
+    expect(context.fingerprint).toEqual(['dictation', 'no-transcript'])
+    expect(context.tags).toEqual({
+      feature: 'dictation',
+      stage: 'no_transcript',
+      provider: 'openai',
+      socket: 'never_opened',
+      audio: 'audible',
+      capture: 'worklet',
+    })
+    expect(context.extra).toMatchObject({
+      provider: 'openai',
+      captureKind: 'worklet',
+      contextSampleRate: 24000,
+      bytesReceived: 24000 * 2 * 4,
+      peakSample: 9000,
+      track: { label: 'Built-in Microphone', muted: false },
+    })
+    expect(reporting.captureRendererException).not.toHaveBeenCalled()
+  })
+
+  it('numbers retries so consecutive reports are not collapsed as duplicates, under one fingerprint', async () => {
+    const adapter = new FakeAdapter()
+    const { hook } = arrange(adapter)
+    await startRecording(hook)
+    adapter.heard(4, 9000)
+    await stop(hook)
+    const retry = new FakeAdapter()
+    stt.createSttAdapter.mockReturnValue(retry)
+    await startRecording(hook)
+    retry.heard(4, 9000)
+    await stop(hook)
+
+    const messages = reporting.captureRendererMessage.mock.calls.map(([m]) => m)
+    expect(messages).toEqual([
+      'Dictation ended without a transcript (attempt 1)',
+      'Dictation ended without a transcript (attempt 2)',
+    ])
+    const fingerprints = reporting.captureRendererMessage.mock.calls.map(([, c]) => c.fingerprint)
+    expect(fingerprints[0]).toEqual(fingerprints[1])
+    expect(reporting.captureRendererMessage.mock.calls[1][1].extra).toMatchObject({ attempt: 2 })
+  })
+
+  it('tells silence from the mic apart from speech the server ignored', async () => {
+    const adapter = new FakeAdapter()
+    adapter.stats.socketOpened = true
+    const { hook } = arrange(adapter)
+    await startRecording(hook)
+    adapter.heard(4, 12)
+    await stop(hook)
+
+    expect(reporting.captureRendererMessage.mock.calls[0][1].tags).toMatchObject({ socket: 'opened', audio: 'silent' })
+  })
+
+  it('stays quiet about a tap too short to have been an attempt', async () => {
+    const adapter = new FakeAdapter()
+    const { hook } = arrange(adapter)
+    await startRecording(hook)
+    adapter.heard(0.5, 9000)
+    await stop(hook)
+
+    expect(reporting.captureRendererMessage).not.toHaveBeenCalled()
+  })
+
+  it('stays quiet when words came back', async () => {
+    const adapter = new FakeAdapter()
+    const { hook, onTranscriptUpdate } = arrange(adapter)
+    await startRecording(hook)
+    adapter.heard(4, 9000)
+    act(() => { adapter.transcriptCb?.({ type: 'final', text: 'hello there' }) })
+    await stop(hook)
+
+    expect(onTranscriptUpdate).toHaveBeenLastCalledWith('hello there')
+    expect(reporting.captureRendererMessage).not.toHaveBeenCalled()
+  })
+
+  it('reports a stream error with the session, and not again as a missing transcript', async () => {
+    const adapter = new FakeAdapter()
+    const { hook } = arrange(adapter)
+    await startRecording(hook)
+    adapter.heard(4, 9000)
+    await act(async () => { adapter.errorCb?.(new Error('OpenAI connection closed: 1008 policy violation')) })
+
+    expect(hook.result.current.error).toBe('OpenAI connection closed: 1008 policy violation')
+    expect(reporting.captureRendererException).toHaveBeenCalledTimes(1)
+    const [err, context] = reporting.captureRendererException.mock.calls[0]
+    expect((err as Error).message).toContain('1008')
+    expect(context.tags).toEqual({ feature: 'dictation', stage: 'stream', provider: 'openai' })
+    expect(context.extra).toMatchObject({ bytesReceived: 24000 * 2 * 4, captureKind: 'worklet' })
+    expect(reporting.captureRendererMessage).not.toHaveBeenCalled()
+  })
+
+  it('reports a socket that failed to connect under its own stage', async () => {
+    const adapter = new FakeAdapter()
+    adapter.connectResult = Promise.reject(new Error('OpenAI Realtime WebSocket connection timed out'))
+    adapter.connectResult.catch(() => {})
+    const { hook } = arrange(adapter)
+    await start(hook)
+
+    expect(hook.result.current.error).toContain('timed out')
+    expect(reporting.captureRendererException.mock.calls[0][1].tags).toEqual({ feature: 'dictation', stage: 'connect', provider: 'openai' })
+    expect(reporting.captureRendererMessage).not.toHaveBeenCalled()
+  })
+
+  it('reports a failure to obtain credentials before any session exists', async () => {
+    const adapter = new FakeAdapter()
+    const { hook } = arrange(adapter)
+    api.apiFetch.mockResolvedValue({ ok: false, json: async () => ({ error: 'No API key configured for OpenAI. Add one in Settings > Voice.' }) })
+    await start(hook)
+
+    expect(hook.result.current.error).toContain('No API key configured')
+    expect(reporting.captureRendererException.mock.calls[0][1].tags).toEqual({ feature: 'dictation', stage: 'credentials', provider: 'unknown' })
+  })
+
+  it('treats a refused microphone permission as a breadcrumb, not a defect', async () => {
+    const adapter = new FakeAdapter()
+    const { hook } = arrange(adapter)
+    stt.acquireMicStream.mockRejectedValue(new DOMException('Permission denied', 'NotAllowedError'))
+    await start(hook)
+
+    expect(hook.result.current.error).toBeTruthy()
+    expect(hook.result.current.isRecording).toBe(false)
+    expect(reporting.captureRendererException).not.toHaveBeenCalled()
+    expect(reporting.addRendererBreadcrumb).toHaveBeenCalledWith('dictation', 'microphone permission refused', { stage: 'capture' })
+  })
+})

--- a/src/renderer/hooks/use-voice-input.ts
+++ b/src/renderer/hooks/use-voice-input.ts
@@ -2,12 +2,120 @@ import { useState, useRef, useCallback, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { apiFetch } from '@renderer/lib/api'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
-import { acquireMicStream, createSttAdapter, startAudioCapture, type SttAdapter, type VoiceProvider, type AudioCaptureHandle } from '@renderer/lib/stt'
+import { acquireMicStream, createSttAdapter, startAudioCapture, type SttAdapter, type VoiceProvider, type AudioCaptureHandle, type CaptureKind } from '@renderer/lib/stt'
+import { addRendererBreadcrumb, captureRendererException, captureRendererMessage } from '@renderer/lib/error-reporting'
 import type { TtsVoiceInfo } from '@shared/lib/voice/tts-preferences'
 
 // 'finalizing': mic released, but we're flushing buffered audio and awaiting the
 // server's trailing transcripts before the final text is ready.
 export type VoiceInputState = 'idle' | 'connecting' | 'recording' | 'finalizing'
+
+/**
+ * One dictation attempt, from credentials to final text, as the error reports
+ * describe it. Dictation audio goes from the browser straight to the speech
+ * provider, so nothing server-side sees a session that fails on that leg; the
+ * renderer has to report it.
+ */
+interface DictationSession {
+  provider: VoiceProvider
+  /** Ordinal of this attempt within the page, so retries can be told apart. */
+  attempt: number
+  startedAt: number
+  adapter: SttAdapter
+  captureKind?: CaptureKind
+  contextSampleRate?: number
+  track?: Record<string, unknown>
+  /** An error has already been shown and reported for this session. */
+  failed: boolean
+}
+
+/**
+ * Audio a session must have captured before ending with no words counts as a
+ * failure worth reporting, rather than a mic tap the person changed their mind
+ * about. In seconds of PCM at the adapter's rate.
+ */
+const NO_TRANSCRIPT_REPORT_MIN_SECONDS = 1.5
+
+/**
+ * A peak sample at or below this (about -36 dBFS) means the mic delivered
+ * silence: the person did not speak, or the OS handed us a muted device.
+ */
+const SILENT_PEAK_SAMPLE = 500
+
+/** Denied or missing mic permission is the person's choice, not a defect. */
+function isMicPermissionRefusal(err: unknown): boolean {
+  return err instanceof DOMException && (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError' || err.name === 'SecurityError')
+}
+
+function describeTrack(stream: MediaStream): Record<string, unknown> {
+  const track = stream.getAudioTracks()[0]
+  if (!track) return { present: false }
+  const settings = typeof track.getSettings === 'function' ? track.getSettings() : {}
+  return {
+    present: true,
+    label: track.label,
+    enabled: track.enabled,
+    muted: track.muted,
+    readyState: track.readyState,
+    sampleRate: settings.sampleRate,
+    channelCount: settings.channelCount,
+  }
+}
+
+function describeSession(session: DictationSession): Record<string, unknown> {
+  return {
+    provider: session.provider,
+    attempt: session.attempt,
+    durationMs: Date.now() - session.startedAt,
+    captureKind: session.captureKind,
+    contextSampleRate: session.contextSampleRate,
+    adapterSampleRate: session.adapter.sampleRate ?? 16000,
+    track: session.track,
+    ...session.adapter.stats,
+  }
+}
+
+function reportSessionFailure(session: DictationSession | null, provider: VoiceProvider | undefined, stage: string, err: unknown): void {
+  if (session) session.failed = true
+  if (isMicPermissionRefusal(err)) {
+    addRendererBreadcrumb('dictation', 'microphone permission refused', { stage })
+    return
+  }
+  captureRendererException(err, {
+    tags: { feature: 'dictation', stage, provider: session?.provider ?? provider ?? 'unknown' },
+    extra: session ? describeSession(session) : undefined,
+  })
+}
+
+/**
+ * The session ended with audio captured but no words back, and no error was
+ * shown: the case that otherwise leaves no trace anywhere. Tagged so a socket
+ * that never opened, silence from the mic, and a server that stayed quiet can
+ * each be told apart in the tracker.
+ */
+function reportNoTranscript(session: DictationSession): void {
+  const stats = session.adapter.stats
+  if (!stats) return
+  const minBytes = (session.adapter.sampleRate ?? 16000) * 2 * NO_TRANSCRIPT_REPORT_MIN_SECONDS
+  if (stats.bytesReceived < minBytes) return
+  // The attempt number is in the message on purpose: Sentry drops an event
+  // identical to the previous one, and a person who retries three times in a
+  // row is exactly who we need every attempt from. The fingerprint keeps them
+  // in one issue.
+  captureRendererMessage(`Dictation ended without a transcript (attempt ${session.attempt})`, {
+    fingerprint: ['dictation', 'no-transcript'],
+    level: 'warning',
+    tags: {
+      feature: 'dictation',
+      stage: 'no_transcript',
+      provider: session.provider,
+      socket: stats.socketOpened ? 'opened' : 'never_opened',
+      audio: stats.peakSample > SILENT_PEAK_SAMPLE ? 'audible' : 'silent',
+      capture: session.captureKind ?? 'unknown',
+    },
+    extra: describeSession(session),
+  })
+}
 
 interface UseVoiceInputOptions {
   onTranscriptUpdate: (text: string) => void
@@ -102,6 +210,10 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
   // the component unmounts can detect it's stale and release what it acquired
   // instead of resurrecting a session nobody owns.
   const generationRef = useRef(0)
+  // The attempt in progress, as the error reports describe it.
+  const sessionRef = useRef<DictationSession | null>(null)
+  // Attempts started on this page, numbering each report.
+  const attemptsRef = useRef(0)
 
   // Keep stateRef in sync so callbacks always see the latest value
   stateRef.current = state
@@ -123,6 +235,7 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
 
     adapterRef.current?.close()
     adapterRef.current = null
+    sessionRef.current = null
   }, [])
 
   /**
@@ -146,6 +259,8 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
     // guard on adapter identity) treat this session as already gone.
     const adapter = adapterRef.current
     adapterRef.current = null
+    const session = sessionRef.current
+    sessionRef.current = null
     await adapter?.finish().catch(() => {}) // finish() never rejects; guard anyway
 
     // Include both finalized and any pending interim text
@@ -156,6 +271,10 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
     finalizedRef.current = ''
     interimRef.current = ''
     const transcribed = (finalized + (interim ? (finalized ? ' ' : '') + interim : '')).trimEnd()
+    if (session) {
+      addRendererBreadcrumb('dictation', 'stopped', { transcribedChars: transcribed.length, ...describeSession(session) })
+      if (!transcribed && !session.failed) reportNoTranscript(session)
+    }
     // If nothing was transcribed, restore original text (prefix without trailing space)
     const finalText = transcribed
       ? prefix + transcribed
@@ -199,6 +318,7 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
       }).catch(() => {})
     }
 
+    let provider: VoiceProvider | undefined
     try {
       // 1. Get API key from backend
       const credRes = await apiFetch('/api/voice/token')
@@ -206,7 +326,10 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
       if (!credRes.ok) {
         throw new Error(('error' in credData ? credData.error : null) || 'Failed to get STT credentials')
       }
-      const { provider, token } = credData as SttCredentials
+      const credentials = credData as SttCredentials
+      provider = credentials.provider
+      const token = credentials.token
+      addRendererBreadcrumb('dictation', 'credentials received', { provider })
 
       // Bail if a stop/restart or unmount happened while fetching the token.
       // Cast needed because TS narrows the ref, but callbacks can mutate it during awaits.
@@ -218,6 +341,8 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
       // 2. Create adapter and wire transcript events
       const adapter = createSttAdapter(provider)
       adapterRef.current = adapter
+      const session: DictationSession = { provider, attempt: ++attemptsRef.current, startedAt: Date.now(), adapter, failed: false }
+      sessionRef.current = session
 
       adapter.onTranscript((event) => {
         switch (event.type) {
@@ -238,6 +363,7 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
       adapter.onError((err) => {
         if (adapterRef.current !== adapter) return // stale/orphaned adapter — don't touch the live session
         console.error('STT adapter error:', err)
+        reportSessionFailure(session, provider, 'stream', err)
         setError(err.message)
         stopRecording()
       })
@@ -248,6 +374,7 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
         if (adapterRef.current !== adapter) return // recording already stopped
         const message = err instanceof Error ? err.message : 'Failed to connect'
         console.error('STT connect error:', err)
+        reportSessionFailure(session, provider, 'connect', err)
         setError(message)
         stopRecording()
       })
@@ -260,16 +387,27 @@ export function useVoiceInput({ onTranscriptUpdate }: UseVoiceInputOptions) {
         capture.cleanup()
         adapter.close()
         if (adapterRef.current === adapter) adapterRef.current = null
+        if (sessionRef.current === session) sessionRef.current = null
         releaseStream()
         return
       }
       captureRef.current = capture
       analyserRef.current = capture.analyser
+      session.captureKind = capture.captureKind
+      session.contextSampleRate = capture.audioContext.sampleRate
+      session.track = describeTrack(capture.stream)
+      addRendererBreadcrumb('dictation', 'capture started', {
+        provider,
+        captureKind: session.captureKind,
+        contextSampleRate: session.contextSampleRate,
+        track: session.track,
+      })
 
       setState('recording')
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to start recording'
       console.error('Voice input error:', err)
+      reportSessionFailure(sessionRef.current, provider, sessionRef.current ? 'capture' : 'credentials', err)
       setError(message)
       releaseStream()
       cleanup()

--- a/src/renderer/lib/error-reporting.ts
+++ b/src/renderer/lib/error-reporting.ts
@@ -90,3 +90,50 @@ export function captureRendererException(
     // against a future implementation changing that contract.
   })
 }
+
+/**
+ * Report a condition that is not an exception but still needs a record — a
+ * session that ended without producing what it should have. Same safety
+ * contract as captureRendererException: never throws, no-op in dev.
+ */
+export function captureRendererMessage(
+  message: string,
+  context?: {
+    level?: 'info' | 'warning' | 'error'
+    tags?: Record<string, string>
+    extra?: Record<string, unknown>
+    /**
+     * Groups every report under one issue regardless of message text. Sentry
+     * drops an event identical to the one before it (same message, fingerprint,
+     * and stack), so a caller that expects repeats varies the message and pins
+     * the fingerprint to keep each repeat and still get one issue.
+     */
+    fingerprint?: string[]
+  }
+): void {
+  void loadSentry().then((provider) => {
+    if (!provider) return
+    try {
+      provider.captureMessage(message, {
+        level: context?.level ?? 'warning',
+        tags: context?.tags,
+        extra: context?.extra,
+        fingerprint: context?.fingerprint,
+      })
+    } catch { /* never crash */ }
+  }).catch(() => {})
+}
+
+/**
+ * Leave a breadcrumb on the trail that travels with the next captured event,
+ * so a lifecycle step (a socket opened, a capture started) explains an error
+ * reported seconds later. Never throws, no-op in dev.
+ */
+export function addRendererBreadcrumb(category: string, message: string, data?: Record<string, unknown>): void {
+  void loadSentry().then((provider) => {
+    if (!provider) return
+    try {
+      provider.addBreadcrumb({ category, message, data, level: 'info' })
+    } catch { /* never crash */ }
+  }).catch(() => {})
+}

--- a/src/renderer/lib/sentry-browser-provider.ts
+++ b/src/renderer/lib/sentry-browser-provider.ts
@@ -1,4 +1,4 @@
 // Keep the dynamic boundary tree-shakeable. Importing the package namespace
 // through import('@sentry/browser') makes Rollup retain every public export;
-// this wrapper exposes only the three primitives the renderer facade uses.
-export { captureException, init, setUser } from '@sentry/browser'
+// this wrapper exposes only the few primitives the renderer facade uses.
+export { addBreadcrumb, captureException, captureMessage, init, setUser } from '@sentry/browser'

--- a/src/renderer/lib/stt.test.ts
+++ b/src/renderer/lib/stt.test.ts
@@ -226,6 +226,7 @@ describe('startAudioCapture', () => {
     vi.stubGlobal('AudioContext', function FakeAudioContext() { return ctx } as unknown as typeof AudioContext)
     const a = sink()
     const handle = await startAudioCapture(a, stream)
+    expect(handle.captureKind).toBe('worklet')
     expect(processors).toHaveLength(0)
     const node = FakeWorkletNode.instances[0]
     expect(node.name).toBe('pcm-capture')
@@ -255,7 +256,8 @@ describe('startAudioCapture', () => {
     const { ctx, processors } = fakeContext({ worklet: 'fails' })
     vi.stubGlobal('AudioContext', function FakeAudioContext() { return ctx } as unknown as typeof AudioContext)
     const a = sink()
-    await startAudioCapture(a, stream)
+    const handle = await startAudioCapture(a, stream)
+    expect(handle.captureKind).toBe('script-processor')
     expect(FakeWorkletNode.instances).toHaveLength(0)
     expect(processors).toHaveLength(1)
     processors[0].onaudioprocess?.({ inputBuffer: { getChannelData: () => Float32Array.from([1]) } })
@@ -716,5 +718,97 @@ describe('finalize', () => {
     adapter.finalize()
     expect(ws.sent).toHaveLength(before)
     expect(events).toEqual([{ type: 'finalized', text: '' }])
+  })
+})
+
+// ============================================================================
+// Session stats (what an error report can say about a session after the fact)
+// ============================================================================
+
+describe('session stats', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = []
+    FakeWebSocket.autoOpen = false
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  function pcm(...samples: number[]): ArrayBuffer {
+    return Int16Array.from(samples).buffer as ArrayBuffer
+  }
+
+  it('deepgram: records the socket opening, the audio that flowed and its peak, the words, and how it closed', async () => {
+    const adapter = createSttAdapter('deepgram')
+    const errors: Error[] = []
+    adapter.onError((err) => errors.push(err))
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+
+    adapter.sendAudio(pcm(0, 1200, -3000))
+    expect(adapter.stats).toMatchObject({ socketOpened: false, bytesReceived: 6, bytesSent: 0, peakSample: 3000 })
+
+    ws.simulateOpen()
+    await connectPromise
+    expect(adapter.stats).toMatchObject({ socketOpened: true, bytesSent: 6 })
+    expect(typeof adapter.stats!.connectMs).toBe('number')
+
+    ws.simulateMessage({ type: 'Results', is_final: true, channel: { alternatives: [{ transcript: 'hi' }] } })
+    ws.simulateMessage({ type: 'Results', is_final: false, channel: { alternatives: [{ transcript: 'hi there' }] } })
+    expect(adapter.stats).toMatchObject({ finals: 1, interims: 1, serverEvents: { Results: 2 } })
+
+    ws.simulateClose(1011, 'server went away')
+    expect(errors).toHaveLength(1)
+    expect(adapter.stats).toMatchObject({ closeCode: 1011, closeReason: 'server went away', errors: 1 })
+    expect(adapter.stats!.lastError).toContain('1011')
+  })
+
+  it('counts audio discarded from an overflowing pre-open buffer', () => {
+    const adapter = createSttAdapter('deepgram')
+    void adapter.connect('token').catch(() => {})
+    adapter.sendAudio(chunkOf(600_000, 1))
+    adapter.sendAudio(chunkOf(600_000, 2))
+    expect(adapter.stats).toMatchObject({ bytesReceived: 1_200_000, bytesDropped: 600_000, bytesSent: 0 })
+  })
+
+  it('openai: a failed transcription surfaces as an error instead of vanishing', async () => {
+    const adapter = createSttAdapter('openai')
+    const errors: Error[] = []
+    adapter.onError((err) => errors.push(err))
+    const connectPromise = adapter.connect('token')
+    FakeWebSocket.instances[0].simulateOpen()
+    await connectPromise
+
+    FakeWebSocket.instances[0].simulateMessage({
+      type: 'conversation.item.input_audio_transcription.failed',
+      error: { message: 'The model `gpt-4o-mini-transcribe` is not available for this project' },
+    })
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain('not available for this project')
+    expect(adapter.stats).toMatchObject({
+      errors: 1,
+      serverEvents: { 'conversation.item.input_audio_transcription.failed': 1 },
+    })
+  })
+
+  it('openai: an error swallowed while finishing still goes on the record', async () => {
+    const adapter = createSttAdapter('openai')
+    const errors: Error[] = []
+    adapter.onError((err) => errors.push(err))
+    const connectPromise = adapter.connect('token')
+    const ws = FakeWebSocket.instances[0]
+    ws.simulateOpen()
+    await connectPromise
+    adapter.sendAudio(pcm(1, 2, 3))
+
+    const finishPromise = adapter.finish()
+    ws.simulateMessage({ type: 'error', error: { message: 'insufficient_quota' } })
+    await finishPromise
+    expect(errors).toHaveLength(0)
+    expect(adapter.stats!.lastError).toContain('quota')
   })
 })

--- a/src/renderer/lib/stt.ts
+++ b/src/renderer/lib/stt.ts
@@ -1,6 +1,7 @@
 // --- Types ---
 
 import type { VoiceProvider } from '@shared/lib/config/settings'
+import { addRendererBreadcrumb } from './error-reporting'
 export type { VoiceProvider }
 
 const CONNECT_TIMEOUT_MS = 10_000
@@ -11,6 +12,9 @@ const CONNECT_TIMEOUT_MS = 10_000
  * On overflow the oldest chunks are dropped.
  */
 const MAX_BUFFERED_AUDIO_BYTES = 1_000_000
+
+/** Distinct server event types a session's stats will keep count of. */
+const MAX_TRACKED_EVENT_TYPES = 32
 
 /**
  * Upper bound on how long finish() waits for the server's trailing transcripts
@@ -32,9 +36,42 @@ export interface TranscriptEvent {
 export type TranscriptCallback = (event: TranscriptEvent) => void
 export type ErrorCallback = (error: Error) => void
 
+/**
+ * What happened on one adapter session, for diagnosing "I spoke and nothing
+ * came back" after the fact: whether the socket ever opened, how much audio
+ * went out and how loud it was, what the server sent, and how it ended.
+ */
+export interface SttSessionStats {
+  /** The socket reached OPEN; audio can only flow after this. */
+  socketOpened: boolean
+  /** connect() to open, in ms. Absent when the socket never opened. */
+  connectMs?: number
+  /** Audio handed to the adapter, written or still buffered. */
+  bytesReceived: number
+  /** Audio written to the socket. */
+  bytesSent: number
+  /** Audio discarded because the pre-open buffer overflowed. */
+  bytesDropped: number
+  /** Loudest 16-bit sample seen (0..32767). 0 means the mic delivered silence. */
+  peakSample: number
+  /** Server events by type, so a missing or unexpected one stands out. */
+  serverEvents: Record<string, number>
+  /** Transcript events delivered to the caller. */
+  interims: number
+  finals: number
+  /** Errors surfaced to the caller. */
+  errors: number
+  /** The last error message, surfaced or not (a late one during finish is swallowed). */
+  lastError?: string
+  closeCode?: number
+  closeReason?: string
+}
+
 export interface SttAdapter {
   /** Required audio sample rate in Hz. Defaults to 16000 if not set. */
   readonly sampleRate?: number
+  /** Running account of this session, for error reports. */
+  readonly stats?: SttSessionStats
   connect(token: string): Promise<void>
   sendAudio(chunk: ArrayBuffer): void
   onTranscript(cb: TranscriptCallback): void
@@ -66,6 +103,17 @@ export interface SttAdapter {
  * a chunk, finalize, and parse incoming messages.
  */
 abstract class WebSocketSttAdapter implements SttAdapter {
+  readonly stats: SttSessionStats = {
+    socketOpened: false,
+    bytesReceived: 0,
+    bytesSent: 0,
+    bytesDropped: 0,
+    peakSample: 0,
+    serverEvents: {},
+    interims: 0,
+    finals: 0,
+    errors: 0,
+  }
   protected ws: WebSocket | null = null
   private transcriptCb: TranscriptCallback | null = null
   private errorCb: ErrorCallback | null = null
@@ -76,6 +124,7 @@ abstract class WebSocketSttAdapter implements SttAdapter {
   private finishTimer: ReturnType<typeof setTimeout> | null = null
   private pendingAudio: ArrayBuffer[] = []
   private pendingBytes = 0
+  private connectStartedAt = 0
 
   /** Open the provider's WebSocket, authenticated with `token`. */
   protected abstract createSocket(token: string): WebSocket
@@ -109,18 +158,21 @@ abstract class WebSocketSttAdapter implements SttAdapter {
 
   async connect(token: string): Promise<void> {
     return new Promise((resolve, reject) => {
+      this.connectStartedAt = Date.now()
       this.ws = this.createSocket(token)
 
       const timeout = setTimeout(() => {
         this.ws?.close()
-        reject(new Error(`${this.connectErrorLabel} WebSocket connection timed out`))
+        reject(this.noteError(new Error(`${this.connectErrorLabel} WebSocket connection timed out`)))
       }, CONNECT_TIMEOUT_MS)
 
       this.ws.onopen = () => {
         clearTimeout(timeout)
         this.connected = true
+        this.stats.socketOpened = true
+        this.stats.connectMs = Date.now() - this.connectStartedAt
         this.onConnected()
-        for (const chunk of this.pendingAudio) this.writeAudio(chunk)
+        for (const chunk of this.pendingAudio) this.write(chunk)
         this.pendingAudio = []
         this.pendingBytes = 0
         // If finish() was requested during the handshake, finalize now that the
@@ -131,45 +183,84 @@ abstract class WebSocketSttAdapter implements SttAdapter {
 
       this.ws.onerror = () => {
         clearTimeout(timeout)
-        const err = new Error(`${this.connectErrorLabel} WebSocket connection failed`)
+        const err = this.noteError(new Error(`${this.connectErrorLabel} WebSocket connection failed`))
         if (!this.connected) {
           reject(err)
         } else if (!this.closed && !this.finishing) {
-          this.errorCb?.(err)
+          this.emitError(err)
         }
       }
 
       this.ws.onmessage = (event) => {
+        let data: any
         try {
-          this.handleMessage(JSON.parse(event.data as string))
+          data = JSON.parse(event.data as string)
         } catch {
           // Ignore non-JSON messages
+          return
         }
+        this.noteServerEvent(data)
+        this.handleMessage(data)
       }
 
       this.ws.onclose = (event) => {
+        this.stats.closeCode = event.code
+        this.stats.closeReason = event.reason
         // A close during finish() (server flushed finals / closed after commit)
         // is finish()'s completion signal.
         if (this.finishResolve) { this.completeFinish(); return }
         if (this.closed) return
         if (event.code !== 1000 && event.code !== 1005) {
-          this.errorCb?.(new Error(`${this.closeErrorLabel} connection closed: ${event.code} ${event.reason}`))
+          this.emitError(new Error(`${this.closeErrorLabel} connection closed: ${event.code} ${event.reason}`))
         }
       }
     })
   }
 
   sendAudio(chunk: ArrayBuffer): void {
+    this.stats.bytesReceived += chunk.byteLength
+    this.notePeak(chunk)
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.writeAudio(chunk)
+      this.write(chunk)
     } else if (!this.connected && !this.closed) {
       // Capture can start before the socket opens — buffer and flush on open
       this.pendingAudio.push(chunk)
       this.pendingBytes += chunk.byteLength
       while (this.pendingBytes > MAX_BUFFERED_AUDIO_BYTES && this.pendingAudio.length > 0) {
-        this.pendingBytes -= this.pendingAudio.shift()!.byteLength
+        const dropped = this.pendingAudio.shift()!.byteLength
+        this.pendingBytes -= dropped
+        this.stats.bytesDropped += dropped
       }
     }
+  }
+
+  private write(chunk: ArrayBuffer): void {
+    this.writeAudio(chunk)
+    this.stats.bytesSent += chunk.byteLength
+  }
+
+  private notePeak(chunk: ArrayBuffer): void {
+    const samples = new Int16Array(chunk, 0, chunk.byteLength >> 1)
+    let peak = this.stats.peakSample
+    for (let i = 0; i < samples.length; i++) {
+      const magnitude = samples[i] < 0 ? -samples[i] : samples[i]
+      if (magnitude > peak) peak = magnitude
+    }
+    this.stats.peakSample = peak
+  }
+
+  private noteServerEvent(data: any): void {
+    const type = typeof data?.type === 'string' ? data.type : 'unknown'
+    const events = this.stats.serverEvents
+    // Bounded: a misbehaving server cannot grow the record without limit.
+    const key = type in events || Object.keys(events).length < MAX_TRACKED_EVENT_TYPES ? type : 'other'
+    events[key] = (events[key] ?? 0) + 1
+  }
+
+  /** Record an error on the session, whether or not it reaches the caller. */
+  protected noteError(error: Error): Error {
+    this.stats.lastError = error.message
+    return error
   }
 
   onTranscript(cb: TranscriptCallback): void {
@@ -239,10 +330,14 @@ abstract class WebSocketSttAdapter implements SttAdapter {
   }
 
   protected emitTranscript(event: TranscriptEvent): void {
+    if (event.type === 'interim') this.stats.interims++
+    else if (event.type === 'final') this.stats.finals++
     this.transcriptCb?.(event)
   }
 
   protected emitError(error: Error): void {
+    this.noteError(error)
+    this.stats.errors++
     this.errorCb?.(error)
   }
 }
@@ -425,12 +520,22 @@ class OpenaiAdapter extends WebSocketSttAdapter {
       case 'input_audio_buffer.speech_stopped':
         this.emitTranscript({ type: 'speech_ended', text: '' })
         break
+      case 'conversation.item.input_audio_transcription.failed':
+        // The server heard the utterance but could not transcribe it (a model
+        // the project may not use, a quota). Without this the words just vanish.
+        this.emitError(friendlyRealtimeError(data.error))
+        if (this.isFinishing) this.completeFinish()
+        break
       case 'error':
         // A late error while wrapping up (e.g. an empty-buffer commit that raced
         // the server's auto-commit) is benign — finish quietly instead of alarming
         // the user, who already has their transcript.
-        if (this.isFinishing) this.completeFinish()
-        else this.emitError(friendlyRealtimeError(data.error))
+        if (this.isFinishing) {
+          this.noteError(friendlyRealtimeError(data.error))
+          this.completeFinish()
+        } else {
+          this.emitError(friendlyRealtimeError(data.error))
+        }
         break
       case 'response.done':
         if (data.response?.status === 'failed') {
@@ -482,10 +587,14 @@ export interface AudioSink {
   sendAudio(chunk: ArrayBuffer): void
 }
 
+export type CaptureKind = 'worklet' | 'script-processor'
+
 export interface AudioCaptureHandle {
   stream: MediaStream
   audioContext: AudioContext
   analyser: AnalyserNode
+  /** Which node is delivering the samples (the worklet, or its fallback). */
+  captureKind: CaptureKind
   /** Redirect the captured audio (a reconnected adapter), or drop it (null). */
   setSink: (sink: AudioSink | null) => void
   cleanup: () => void
@@ -529,6 +638,7 @@ let captureWorkletUrl: string | null = null
 
 interface CaptureNode {
   node: AudioNode
+  kind: CaptureKind
   disconnect: () => void
 }
 
@@ -545,6 +655,7 @@ async function createCaptureNode(audioContext: AudioContext, onChunk: (samples: 
       node.port.onmessage = (event: MessageEvent<Float32Array>) => onChunk(event.data)
       return {
         node,
+        kind: 'worklet',
         disconnect: () => {
           node.port.onmessage = null
           node.disconnect()
@@ -552,12 +663,16 @@ async function createCaptureNode(audioContext: AudioContext, onChunk: (samples: 
       }
     } catch (err) {
       console.warn('Audio capture worklet unavailable, falling back to ScriptProcessor:', err)
+      addRendererBreadcrumb('dictation', 'capture worklet unavailable, using ScriptProcessor', {
+        reason: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+      })
     }
   }
   const processor = audioContext.createScriptProcessor(CAPTURE_CHUNK_SAMPLES, 1, 1)
   processor.onaudioprocess = (e) => onChunk(e.inputBuffer.getChannelData(0))
   return {
     node: processor,
+    kind: 'script-processor',
     disconnect: () => {
       processor.onaudioprocess = null
       processor.disconnect()
@@ -631,6 +746,7 @@ export async function startAudioCapture(
     stream,
     audioContext,
     analyser,
+    captureKind: capture.kind,
     setSink: (next) => {
       currentSink = next
     },


### PR DESCRIPTION
## Why

A customer reported dictation on the web app showing a moving waveform and never producing text. Sentry had nothing: dictation audio goes from the browser straight to the speech provider over a WebSocket, the waveform is driven by a separate analyser on the mic, and nothing on the voice path reported anywhere. The same failure reproduced on Chrome and with the platform provider, so we need the browser to tell us what happened.

## What

- **Session stats on the STT adapter** (`stats`): socket opened, connect time, bytes received / sent / dropped, peak PCM sample, a count of every server event type, transcript counts, last error, close code and reason.
- **`captureKind` on the capture handle**: whether the AudioWorklet or the ScriptProcessor fallback delivered the samples, plus a breadcrumb when the worklet fails to load.
- **Errors reported by stage** from `useVoiceInput`: `credentials`, `connect`, `stream`, `capture`. Mic permission refusals are breadcrumbs only.
- **A warning when a session ends without a transcript**: at least 1.5 s of audio captured, no words back, no error shown. Tagged `socket` (opened / never_opened), `audio` (audible / silent from the peak sample), `capture` (worklet / script-processor), `provider`. The attempt number is in the message so Sentry's dedupe keeps each retry; a fixed fingerprint keeps them in one issue.
- **Breadcrumbs** for credentials received, capture started (mic track label, muted state, sample rates) and stopped.
- **Server-side capture** on `GET /api/voice/token`, the one server step of dictation.
- **Behaviour fix**: OpenAI's `conversation.item.input_audio_transcription.failed` was unhandled, so a transcription the server refused (model not allowed for the project, quota) made the words silently vanish. It now surfaces as an error.

## Not covered

Voice mode and the voice agent share the adapter stats but do not report on their own yet. Navigating away mid-dictation is torn down without a report.

## Tests

- `stt.test.ts`: stats through open / audio / transcripts / abnormal close, dropped pre-open audio, transcription-failed surfaces, a swallowed late error is still on the record, `captureKind` for both nodes.
- `use-voice-input.test.tsx` (new): each report path, silence vs audible tagging, short taps stay quiet, words back stay quiet, a stream error is not double-reported, retries are numbered under one fingerprint, permission refusal is a breadcrumb.

Typecheck, lint and the full unit suite pass.

No UI change.

https://claude.ai/code/session_01R5oB9meXiTQ2C9RKresB1q
