### PR TITLE
fix(browser): recover localized Google security-key challenges

### DIFF
--- a/src/main/host-browser/google-passkey-recovery.dom.test.ts
+++ b/src/main/host-browser/google-passkey-recovery.dom.test.ts
@@ -1,25 +1,36 @@
 // @vitest-environment jsdom
 // @vitest-environment-options {"url":"https://accounts.google.com/v3/signin/challenge/pk"}
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { GOOGLE_PASSKEY_RECOVERY_EXPRESSION, isGooglePasskeyChallenge } from './google-passkey-recovery'
+import { GOOGLE_PASSKEY_INSPECTION_EXPRESSION, GOOGLE_PASSKEY_RECOVERY_EXPRESSION, isGooglePasskeyChallenge } from './google-passkey-recovery'
 
-const challengePath = '/v3/signin/challenge/pk'
-let clicked = vi.fn<() => void>()
-const evaluate = () => window.eval(GOOGLE_PASSKEY_RECOVERY_EXPRESSION)
+const challenges = [
+  { challengePath: '/v3/signin/challenge/pk', credential: 'passkey' },
+  { challengePath: '/v3/signin/challenge/sk/webauthn', credential: 'security key' },
+]
 
-beforeEach(() => {
-  history.replaceState({}, '', challengePath)
-  document.body.innerHTML = '<h1>Verifying it’s you...</h1><p>Complete sign-in using your passkey</p><button>Try another way</button>'
-  // jsdom has no layout/innerText. Real rendering is covered by the browser probe.
-  Object.defineProperty(HTMLElement.prototype, 'innerText', { configurable: true, get() { return this.textContent || '' } })
-  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({ width: 120, height: 40 } as DOMRect)
-  clicked = vi.fn(() => { history.replaceState({}, '', '/v3/signin/challenge/selection') })
-  document.querySelector('button')!.addEventListener('click', clicked)
-})
+describe.each(challenges)('scoped Google $credential fallback expression', ({ challengePath, credential }) => {
+  let clicked = vi.fn<() => void>()
+  const evaluate = () => window.eval(GOOGLE_PASSKEY_RECOVERY_EXPRESSION)
 
-afterEach(() => { vi.restoreAllMocks() })
+  beforeEach(() => {
+    history.replaceState({}, '', challengePath)
+    document.body.innerHTML = `<h1>Verifying it’s you...</h1><p>Complete sign-in using your ${credential}</p><button>Try another way</button>`
+    // jsdom has no layout/innerText. Real rendering is covered by the browser probe.
+    Object.defineProperty(HTMLElement.prototype, 'innerText', { configurable: true, get() { return this.textContent || '' } })
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({ width: 120, height: 40 } as DOMRect)
+    clicked = vi.fn(() => { history.replaceState({}, '', '/v3/signin/challenge/selection') })
+    document.querySelector('button')!.addEventListener('click', clicked)
+  })
 
-describe('scoped Google fallback expression', () => {
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it.each(['', '/', '?flow=test'])('recognizes the challenge URL with suffix "%s"', suffix => {
+    expect(isGooglePasskeyChallenge(`https://accounts.google.com${challengePath}${suffix}`)).toBe(true)
+    history.replaceState({}, '', `${challengePath}${suffix}`)
+    expect(evaluate()).toBe('clicked')
+    expect(clicked).toHaveBeenCalledTimes(1)
+  })
+
   it('invokes the actual fallback handler and then stops matching the selection page', () => {
     expect(evaluate()).toBe('clicked')
     expect(clicked).toHaveBeenCalledTimes(1)
@@ -28,16 +39,35 @@ describe('scoped Google fallback expression', () => {
     expect(clicked).toHaveBeenCalledTimes(1)
   })
 
-  it.each(['/v3/signin/challenge/pwd', '/v3/signin/challenge/pk/presend', '/v3/signin/challenge/selection'])('ignores unrelated challenge %s', path => {
+  it('inspects the prompt without invoking the fallback handler', () => {
+    expect(window.eval(GOOGLE_PASSKEY_INSPECTION_EXPRESSION)).toBe('ready')
+    expect(clicked).not.toHaveBeenCalled()
+    document.querySelector('button')!.disabled = true
+    expect(window.eval(GOOGLE_PASSKEY_INSPECTION_EXPRESSION)).toBe('waiting')
+    document.querySelector('h1')!.remove()
+    expect(window.eval(GOOGLE_PASSKEY_INSPECTION_EXPRESSION)).toBe('cleared')
+    expect(clicked).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    '/v3/signin/challenge/pwd',
+    '/v3/signin/challenge/pk/presend',
+    '/v3/signin/challenge/sk',
+    '/v3/signin/challenge/sk/presend',
+    '/v3/signin/challenge/sk/webauthn/presend',
+    '/v3/signin/challenge/sk/webauthn-other',
+    '/v3/signin/challenge/selection',
+  ])('ignores unrelated challenge %s', path => {
     history.replaceState({}, '', path)
+    expect(isGooglePasskeyChallenge(location.href)).toBe(false)
     expect(evaluate()).toBe('not-applicable')
     expect(clicked).not.toHaveBeenCalled()
   })
 
-  it.each(['missing progress', 'missing passkey copy', 'localized', 'multiple buttons', 'disabled', 'disabled fieldset', 'aria-disabled', 'inert', 'hidden', 'zero-size'])('fails closed when UI is uncertain: %s', variant => {
+  it.each(['missing progress', 'missing credential copy', 'localized', 'multiple buttons', 'disabled', 'disabled fieldset', 'aria-disabled', 'inert', 'hidden', 'zero-size'])('fails closed when UI is uncertain: %s', variant => {
     const button = document.querySelector('button')!
     if (variant === 'missing progress') document.querySelector('h1')!.remove()
-    if (variant === 'missing passkey copy') document.querySelector('p')!.remove()
+    if (variant === 'missing credential copy') document.querySelector('p')!.remove()
     if (variant === 'localized') button.textContent = 'Andere Option wählen'
     if (variant === 'multiple buttons') document.body.append(button.cloneNode(true))
     if (variant === 'disabled') button.disabled = true
@@ -51,15 +81,15 @@ describe('scoped Google fallback expression', () => {
     if (variant === 'inert') button.setAttribute('inert', '')
     if (variant === 'hidden') button.style.visibility = 'hidden'
     if (variant === 'zero-size') vi.mocked(button.getBoundingClientRect).mockReturnValue({ width: 0, height: 0 } as DOMRect)
-    expect(evaluate()).toBe('waiting')
+    expect(evaluate()).toBe(variant === 'missing progress' || variant === 'missing credential copy' ? 'cleared' : 'waiting')
     expect(clicked).not.toHaveBeenCalled()
   })
 
   it.each([
-    'https://accounts.google.com.evil.test/v3/signin/challenge/pk',
-    'http://accounts.google.com/v3/signin/challenge/pk',
-    'https://accounts.google.com:444/v3/signin/challenge/pk',
-    'https://example.com/v3/signin/challenge/pk',
+    `https://accounts.google.com.evil.test${challengePath}`,
+    `http://accounts.google.com${challengePath}`,
+    `https://accounts.google.com:444${challengePath}`,
+    `https://example.com${challengePath}`,
     'not a url',
   ])('rejects an unrelated origin: %s', url => {
     expect(isGooglePasskeyChallenge(url)).toBe(false)
@@ -68,6 +98,99 @@ describe('scoped Google fallback expression', () => {
   it('checks the origin inside the browser expression too', () => {
     const run = new Function('location', 'document', `return ${GOOGLE_PASSKEY_RECOVERY_EXPRESSION}`)
     expect(run({ origin: 'https://example.com', pathname: challengePath }, document)).toBe('not-applicable')
+    expect(clicked).not.toHaveBeenCalled()
+  })
+})
+
+// Sanitized structure observed on Google's live security-key challenge in
+// en-US, de, and iw (RTL), 2026-09-09. No account data or hidden inputs retained.
+describe('Google security-key structural recognition', () => {
+  let clicked = vi.fn<() => void>()
+  const evaluate = () => window.eval(GOOGLE_PASSKEY_RECOVERY_EXPRESSION)
+  const render = (heading = 'מתבצע אימות של הזהות שלך...', label = 'אני רוצה לנסות דרך אחרת') => {
+    document.body.innerHTML = `
+      <c-wiz jscontroller="OzD1R" data-view-id="gm7v4">
+        <main>
+          <div jsname="rEuO1b" jscontroller="qPYxq"><span>
+            <section jscontroller="Tbb4sb"><h2>${heading}</h2><div jsname="MZArnb">Localized instructions</div></section>
+            <section jscontroller="Tbb4sb" jsname="INM6z" aria-hidden="true" style="display:none">Localized error</section>
+            <section jscontroller="Tbb4sb" jsname="dZbRZb" style="display:none"></section>
+          </span></div>
+          <div jsname="DH6Rkf" jscontroller="z0u0L"><div jsname="eBSUOb" jscontroller="f8Gu1e">
+            <button jsname="LgbsSe" type="button">${label}</button>
+          </div></div>
+          <button jsname="NakZHc" type="button">Account options</button>
+        </main>
+      </c-wiz>`
+    document.querySelector('button')!.addEventListener('click', clicked)
+  }
+
+  beforeEach(() => {
+    history.replaceState({}, '', '/v3/signin/challenge/sk/webauthn?hl=iw')
+    Object.defineProperty(HTMLElement.prototype, 'innerText', { configurable: true, get() { return this.textContent || '' } })
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({ width: 120, height: 40 } as DOMRect)
+    clicked = vi.fn()
+    render()
+  })
+  afterEach(() => { vi.restoreAllMocks(); document.documentElement.removeAttribute('dir') })
+
+  it.each([
+    ['en-US', 'ltr', 'Verifying it’s you...', 'Try another way'],
+    ['de', 'ltr', 'Identität wird bestätigt…', 'Andere Option wählen'],
+    ['iw', 'rtl', 'מתבצע אימות של הזהות שלך...', 'אני רוצה לנסות דרך אחרת'],
+  ])('recognizes the verified structure in %s without relying on wording or direction', (locale, direction, heading, label) => {
+    history.replaceState({}, '', `/v3/signin/challenge/sk/webauthn?hl=${locale}`)
+    document.documentElement.dir = direction
+    render(heading, label)
+    expect(window.eval(GOOGLE_PASSKEY_INSPECTION_EXPRESSION)).toBe('ready')
+    expect(clicked).not.toHaveBeenCalled()
+    expect(evaluate()).toBe('clicked')
+    expect(clicked).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['missing state', 'duplicate state', 'ambiguous views', 'ambiguous buttons', 'disabled', 'hidden parent', 'wrong footer', 'generic button only'])('does not act on uncertain structural UI: %s', variant => {
+    const button = document.querySelector('button')!
+    if (variant === 'missing state') document.querySelector('[jsname="dZbRZb"]')!.remove()
+    if (variant === 'duplicate state') document.querySelector('[jsname="dZbRZb"]')!.setAttribute('jsname', 'INM6z')
+    if (variant === 'ambiguous views') document.body.append(document.querySelector('c-wiz')!.cloneNode(true))
+    if (variant === 'ambiguous buttons') button.parentElement!.append(button.cloneNode(true))
+    if (variant === 'disabled') button.disabled = true
+    if (variant === 'hidden parent') button.parentElement!.setAttribute('aria-hidden', 'true')
+    if (variant === 'wrong footer') button.parentElement!.removeAttribute('jscontroller')
+    if (variant === 'generic button only') document.querySelector('[jsname="eBSUOb"]')!.remove()
+    expect(evaluate()).toBe('waiting')
+    expect(clicked).not.toHaveBeenCalled()
+  })
+
+  it('recognizes the visible error state as cleared even while hidden verification copy remains', () => {
+    const progress = document.querySelector('section:not([jsname])') as HTMLElement
+    progress.style.display = 'none'
+    const error = document.querySelector('[jsname="INM6z"]') as HTMLElement
+    error.style.display = ''
+    error.removeAttribute('aria-hidden')
+    expect(window.eval(GOOGLE_PASSKEY_INSPECTION_EXPRESSION)).toBe('cleared')
+    expect(evaluate()).toBe('cleared')
+    expect(clicked).not.toHaveBeenCalled()
+  })
+
+  it('waits during an ambiguous transition with both verification and error visible', () => {
+    const error = document.querySelector('[jsname="INM6z"]') as HTMLElement
+    error.style.display = ''
+    error.removeAttribute('aria-hidden')
+    expect(evaluate()).toBe('waiting')
+    expect(clicked).not.toHaveBeenCalled()
+  })
+
+  it('retains English fallback when Google changes an internal marker', () => {
+    render('Verifying it’s you... Complete sign-in using your security key', 'Try another way')
+    document.querySelector('[jsname="eBSUOb"]')!.removeAttribute('jsname')
+    expect(evaluate()).toBe('clicked')
+    expect(clicked).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not infer a localized passkey layout from the security-key controller', () => {
+    history.replaceState({}, '', '/v3/signin/challenge/pk?hl=iw')
+    expect(evaluate()).toBe('cleared')
     expect(clicked).not.toHaveBeenCalled()
   })
 })

--- a/src/main/host-browser/google-passkey-recovery.test.ts
+++ b/src/main/host-browser/google-passkey-recovery.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { GooglePasskeyRecovery } from './google-passkey-recovery'
+import { GooglePasskeyRecovery, GOOGLE_PASSKEY_INSPECTION_EXPRESSION, GOOGLE_PASSKEY_RECOVERY_EXPRESSION } from './google-passkey-recovery'
 
 type Command = { id: number; method: string; params: Record<string, unknown>; sessionId?: string }
 type TestSocket = {
@@ -47,7 +47,11 @@ vi.mock('ws', async () => {
 
 const challenge = 'https://accounts.google.com/v3/signin/challenge/pk?flow=test'
 const info = (targetId = 'tab', url = challenge, type = 'page') => ({ targetId, url, type })
-const evaluations = (socket = h.sockets[0]) => socket.commands.filter(c => c.method === 'Runtime.evaluate')
+const evaluations = (socket = h.sockets[0]) => socket.commands.filter(c =>
+  c.method === 'Runtime.evaluate' && String(c.params.expression).includes(GOOGLE_PASSKEY_RECOVERY_EXPRESSION))
+const inspections = (socket = h.sockets[0]) => socket.commands.filter(c =>
+  c.method === 'Runtime.evaluate' && String(c.params.expression).includes(GOOGLE_PASSKEY_INSPECTION_EXPRESSION))
+const isInspection = (command: Command) => String(command.params.expression).includes(GOOGLE_PASSKEY_INSPECTION_EXPRESSION)
 let recovery: GooglePasskeyRecovery
 
 beforeEach(() => {
@@ -56,10 +60,11 @@ beforeEach(() => {
   h.respond.mockReset().mockImplementation(command => {
     if (command.method === 'Target.getTargets') return { targetInfos: [info()] }
     if (command.method === 'Target.attachToTarget') return { sessionId: `attached-${command.params.targetId}` }
-    if (command.method === 'Runtime.evaluate') return { result: { value: 'clicked' } }
+    if (command.method === 'Runtime.evaluate') return { result: { value: isInspection(command) ? 'ready' : 'clicked' } }
     return {}
   })
   vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
   recovery = new GooglePasskeyRecovery()
 })
 
@@ -109,6 +114,31 @@ describe('Google passkey observer', () => {
     await vi.advanceTimersByTimeAsync(2_000)
     expect(evaluations()).toHaveLength(1)
     expect(evaluations()[0].sessionId).toBe('popup-session')
+  })
+
+  it.each(['already open', 'after password'])('recovers a security-key challenge %s once after the grace period', async entry => {
+    const securityKeyChallenge = 'https://accounts.google.com/v3/signin/challenge/sk/webauthn?flow=test'
+    const initialUrl = entry === 'already open'
+      ? securityKeyChallenge : 'https://accounts.google.com/v3/signin/challenge/pwd'
+    const original = h.respond.getMockImplementation()!
+    h.respond.mockImplementation(command => command.method === 'Target.getTargets'
+      ? { targetInfos: [info('tab', initialUrl)] } : original(command))
+    const socket = await start()
+
+    if (entry === 'after password') {
+      await vi.advanceTimersByTimeAsync(5_000)
+      expect(evaluations()).toHaveLength(0)
+      socket.event('Target.targetInfoChanged', { targetInfo: info('tab', securityKeyChallenge) })
+    }
+
+    await vi.advanceTimersByTimeAsync(1_999)
+    expect(evaluations()).toHaveLength(0)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(evaluations()).toHaveLength(1)
+    expect(evaluations()[0].sessionId).toBe('attached-tab')
+    expect(evaluations()[0].params.expression).toContain(JSON.stringify(securityKeyChallenge))
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(evaluations()).toHaveLength(1)
   })
 
   it('waits for recognizable DOM and rearms only on a new challenge visit', async () => {
@@ -182,12 +212,88 @@ describe('Google passkey observer', () => {
     expect(vi.getTimerCount()).toBe(0)
   })
 
-  it('bounds DOM polling when the page never matches', async () => {
+  it('backs off DOM polling without abandoning a late-rendering prompt', async () => {
     const original = h.respond.getMockImplementation()!
-    h.respond.mockImplementation(c => c.method === 'Runtime.evaluate' ? { result: { value: 'waiting' } } : original(c))
+    let ready = false
+    h.respond.mockImplementation(c => c.method === 'Runtime.evaluate'
+      ? { result: { value: ready ? (isInspection(c) ? 'ready' : 'clicked') : 'waiting' } } : original(c))
     await start()
     await vi.advanceTimersByTimeAsync(120_000)
-    expect(evaluations()).toHaveLength(60)
+    const checksBeforeReady = evaluations().length
+    expect(checksBeforeReady).toBeGreaterThan(60)
+    expect(checksBeforeReady).toBeLessThan(70)
+    ready = true
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(evaluations()).toHaveLength(checksBeforeReady + 1)
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(evaluations()).toHaveLength(checksBeforeReady + 1)
+  })
+
+  it('confirms navigation away from the challenge, rather than claiming success from a click', async () => {
+    const socket = await start()
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(console.log).not.toHaveBeenCalled()
+    socket.event('Target.targetInfoChanged', { targetInfo: info('tab', 'https://accounts.google.com/v3/signin/challenge/selection') })
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('prompt cleared'))
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(console.log).toHaveBeenCalledTimes(1)
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('confirms a stable disappearance and recovers a fresh prompt in the same document', async () => {
+    const original = h.respond.getMockImplementation()!
+    let visible = true
+    h.respond.mockImplementation(c => c.method === 'Runtime.evaluate'
+      ? { result: { value: visible ? (isInspection(c) ? 'ready' : 'clicked') : 'cleared' } } : original(c))
+    await start()
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(evaluations()).toHaveLength(1)
+    visible = false
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('prompt cleared'))
+    visible = true
+    await vi.advanceTimersByTimeAsync(1_999)
+    expect(evaluations()).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(evaluations()).toHaveLength(2)
+    expect(inspections().length).toBeGreaterThan(0)
+  })
+
+  it('does not rearm on a transient disappearance, disabled control, or unchanged prompt', async () => {
+    const original = h.respond.getMockImplementation()!
+    let status = 'ready'
+    h.respond.mockImplementation(c => c.method === 'Runtime.evaluate' && isInspection(c)
+      ? { result: { value: status } } : original(c))
+    await start()
+    await vi.advanceTimersByTimeAsync(2_000)
+    status = 'cleared'
+    await vi.advanceTimersByTimeAsync(1_000)
+    status = 'waiting'
+    await vi.advanceTimersByTimeAsync(3_000)
+    status = 'ready'
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(evaluations()).toHaveLength(1)
+    expect(console.log).not.toHaveBeenCalled()
+    expect(console.warn).toHaveBeenCalledTimes(1)
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Could not confirm'))
+    const reads = inspections().length
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(inspections().length - reads).toBeLessThanOrEqual(4)
+  })
+
+  it('pauses repeated recovery loops across reloads and does not resume just because time elapsed', async () => {
+    const socket = await start()
+    for (let visit = 0; visit < 4; visit++) {
+      if (visit > 0) socket.event('Page.frameNavigated', { frame: { url: challenge } }, 'attached-tab')
+      await vi.advanceTimersByTimeAsync(2_000)
+    }
+    expect(evaluations()).toHaveLength(3)
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('repeated challenges'))
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(evaluations()).toHaveLength(3)
+    socket.event('Page.frameNavigated', { frame: { url: challenge } }, 'attached-tab')
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(evaluations()).toHaveLength(4)
   })
 
 

--- a/src/main/host-browser/google-passkey-recovery.ts
+++ b/src/main/host-browser/google-passkey-recovery.ts
@@ -5,8 +5,15 @@ const CHECK_INTERVAL_MS = 1_000
 const COMMAND_TIMEOUT_MS = 5_000
 const RECONNECT_MS = 5_000
 const MAX_RECONNECTS = 5
-const MAX_CHECKS = 60
-const PASSKEY_PATH = '^/v3/signin/challenge/pk/?$'
+const FAST_CHECKS = 60
+const SLOW_CHECK_INTERVAL_MS = 15_000
+const VERIFY_TIMEOUT_MS = 10_000
+const CLEAR_GRACE_MS = 2_000
+const ATTEMPT_WINDOW_MS = 60_000
+const MAX_ATTEMPTS_PER_WINDOW = 3
+// Google uses pk for passkey sign-in and sk/webauthn for a security key
+// requested as the second factor after a password. Both open native WebAuthn.
+const PASSKEY_PATH = '^/v3/signin/challenge/(?:pk|sk/webauthn)/?$'
 
 export function isGooglePasskeyChallenge(url: string): boolean {
   try {
@@ -20,30 +27,68 @@ export function isGooglePasskeyChallenge(url: string): boolean {
 /**
  * A native WebAuthn dialog blocks CDP input, but Runtime.evaluate still works.
  * Invoke Google's own fallback handler so Google aborts its pending request.
+ * Recognize passkey sign-in and post-password security-key verification.
  * Do not act on conditional WebAuthn, pre-prompt screens, or other challenges.
- * English copy is intentional: unfamiliar/localized UI fails closed.
+ * The security-key structure was verified in English, German, and Hebrew.
+ * Unknown structures retain the narrowly scoped English fallback.
  */
-export const GOOGLE_PASSKEY_RECOVERY_EXPRESSION = String.raw`(() => {
+function googlePasskeyExpression(recover: boolean): string {
+  return String.raw`(() => {
   if (location.origin !== 'https://accounts.google.com' ||
       !new RegExp(${JSON.stringify(PASSKEY_PATH)}).test(location.pathname)) return 'not-applicable';
 
-  const text = (document.body?.innerText || '').replace(/\s+/g, ' ').replace(/\u2019/g, "'");
-  if (!text.includes("Verifying it's you") ||
-      !text.includes('Complete sign-in using your passkey')) return 'waiting';
-
-  const buttons = [...document.querySelectorAll('button')].filter(button => {
-    const rect = button.getBoundingClientRect();
-    const style = getComputedStyle(button);
-    return button.innerText.trim() === 'Try another way' &&
+  const visible = element => {
+    const rect = element.getBoundingClientRect();
+    const style = getComputedStyle(element);
+    return !element.closest('[hidden], [aria-hidden="true"], [inert]') &&
       rect.width > 0 && rect.height > 0 &&
-      style.visibility === 'visible' && style.display !== 'none' &&
+      style.visibility === 'visible' && style.display !== 'none';
+  };
+  const enabled = button => visible(button) &&
       !button.matches(':disabled') && button.getAttribute('aria-disabled') !== 'true' &&
       !button.closest('[inert]');
-  });
+
+  const text = (document.body?.innerText || '').replace(/\s+/g, ' ').replace(/\u2019/g, "'");
+  const englishProgress = text.includes("Verifying it's you") &&
+    (text.includes('Complete sign-in using your passkey') ||
+     text.includes('Complete sign-in using your security key'));
+  let structuralProgress = false;
+  let structuralButtons = [];
+  const views = location.pathname.replace(/\/$/, '') === '/v3/signin/challenge/sk/webauthn'
+    ? [...document.querySelectorAll('c-wiz[jscontroller="OzD1R"][data-view-id="gm7v4"]')].filter(visible) : [];
+  if (views.length > 1) return 'waiting';
+  if (views.length === 1) {
+    const view = views[0];
+    const sections = [...view.querySelectorAll('[jsname="rEuO1b"][jscontroller="qPYxq"] section[jscontroller="Tbb4sb"]')];
+    const progress = sections.filter(section => !section.hasAttribute('jsname'));
+    const errors = sections.filter(section => ['INM6z', 'dZbRZb'].includes(section.getAttribute('jsname')));
+    // These are Google's verification/error states, not translated headings.
+    // Require the complete known shape so a changed view fails closed.
+    const knownShape = sections.length === 3 && progress.length === 1 && errors.length === 2 &&
+      new Set(errors.map(section => section.getAttribute('jsname'))).size === 2;
+    if (knownShape) {
+      const progressVisible = visible(progress[0]);
+      const errorVisible = errors.some(visible);
+      if (!progressVisible && errorVisible) return 'cleared';
+      if (progressVisible && errorVisible) return 'waiting';
+      structuralProgress = progressVisible;
+      structuralButtons = [...view.querySelectorAll('[jsname="DH6Rkf"][jscontroller="z0u0L"] [jsname="eBSUOb"][jscontroller="f8Gu1e"] button[jsname="LgbsSe"][type="button"]')];
+    }
+    if (!structuralProgress && !englishProgress) return 'waiting';
+  }
+  if (!structuralProgress && !englishProgress) return 'cleared';
+  const buttons = [...document.querySelectorAll('button')].filter(button => enabled(button) &&
+    ((structuralProgress && structuralButtons.includes(button)) ||
+     (englishProgress && button.innerText.trim() === 'Try another way')));
   if (buttons.length !== 1) return 'waiting';
+  if (!${recover}) return 'ready';
   buttons[0].click();
   return 'clicked';
 })()`
+}
+
+export const GOOGLE_PASSKEY_RECOVERY_EXPRESSION = googlePasskeyExpression(true)
+export const GOOGLE_PASSKEY_INSPECTION_EXPRESSION = googlePasskeyExpression(false)
 
 interface TargetInfo {
   targetId: string
@@ -58,6 +103,11 @@ interface TargetState {
   generation: number
   checks: number
   attempted: boolean
+  attemptedAt?: number
+  clearSince?: number
+  verificationReported: boolean
+  nextCheckAt: number
+  attemptTimes: number[]
   busy: boolean
 }
 
@@ -164,8 +214,8 @@ class RecoveryConnection {
       this.retries = 0
       this.interval = setInterval(() => {
         for (const [id, target] of this.targets) {
-          if (isGooglePasskeyChallenge(target.url) && !target.busy && !target.attempted &&
-              target.checks < MAX_CHECKS && Date.now() - target.since >= GRACE_MS) {
+          if (isGooglePasskeyChallenge(target.url) && !target.busy &&
+              Date.now() >= target.nextCheckAt && Date.now() - target.since >= GRACE_MS) {
             void this.check(id, target, socket)
           }
         }
@@ -181,15 +231,24 @@ class RecoveryConnection {
     const target = this.targets.get(info.targetId)
     if (target) {
       if (target.url !== info.url || newDocument) {
+        if (target.attemptedAt !== undefined &&
+            !isGooglePasskeyChallenge(info.url)) {
+          console.log('[GooglePasskeyRecovery] Google verification prompt cleared after fallback')
+        }
         target.url = info.url
         target.since = Date.now()
         target.generation++
         target.checks = 0
         target.attempted = false
+        target.attemptedAt = undefined
+        target.clearSince = undefined
+        target.verificationReported = false
+        target.nextCheckAt = 0
       }
     } else if (isGooglePasskeyChallenge(info.url)) {
       this.targets.set(info.targetId, {
         url: info.url, since: Date.now(), generation: 0, checks: 0, attempted: false, busy: false,
+        verificationReported: false, nextCheckAt: 0, attemptTimes: [],
       })
     }
   }
@@ -197,6 +256,8 @@ class RecoveryConnection {
   private async check(id: string, target: TargetState, socket: WebSocket): Promise<void> {
     target.busy = true
     target.checks++
+    target.nextCheckAt = Date.now() + (target.verificationReported || target.checks >= FAST_CHECKS
+      ? SLOW_CHECK_INTERVAL_MS : CHECK_INTERVAL_MS)
     const generation = target.generation
     const current = () => !this.stopped && this.socket === socket &&
       this.targets.get(id) === target && target.generation === generation
@@ -211,20 +272,67 @@ class RecoveryConnection {
         }
       }
       if (!current() || !target.sessionId) return
-      // A timeout may mean the click ran but its response was lost. Never retry
-      // an ambiguous evaluation during this challenge, even after reconnecting.
+      target.attemptTimes = target.attemptTimes.filter(time => Date.now() - time < ATTEMPT_WINDOW_MS)
+      if (!target.attempted && target.attemptTimes.length >= MAX_ATTEMPTS_PER_WINDOW) {
+        // Stay in read-only mode until the prompt clears or a new visit starts.
+        // Waiting out the window must not itself trigger another click.
+        target.attempted = true
+        console.warn('[GooglePasskeyRecovery] Paused automatic fallback after repeated challenges')
+      }
+      const inspection = target.attempted
+      // A timeout may mean the click ran but its response was lost. Only read
+      // afterward, even across reconnects, until the old prompt visibly clears.
       target.attempted = true
+      if (!inspection) {
+        target.attemptedAt = Date.now()
+        // Reserve before dispatch: navigation, exceptions, and timeouts can
+        // prevent a response even though Google's click handler already ran.
+        target.attemptTimes.push(target.attemptedAt)
+      }
+      const expression = inspection ? GOOGLE_PASSKEY_INSPECTION_EXPRESSION : GOOGLE_PASSKEY_RECOVERY_EXPRESSION
       const result = await this.send('Runtime.evaluate', {
-        expression: `location.href === ${JSON.stringify(target.url)} ? ${GOOGLE_PASSKEY_RECOVERY_EXPRESSION} : 'not-applicable'`,
+        expression: `location.href === ${JSON.stringify(target.url)} ? ${expression} : 'not-applicable'`,
         returnByValue: true,
       }, target.sessionId)
       if (!current()) return
       const value = (result.result as { value?: string } | undefined)?.value
-      if (value === 'waiting') target.attempted = false
-      if (value === 'clicked') console.log('[GooglePasskeyRecovery] Invoked Google passkey fallback')
+      if (!inspection) {
+        if (value === 'waiting' || value === 'cleared') {
+          target.attempted = false
+          target.attemptedAt = undefined
+          target.attemptTimes.pop()
+        } else {
+          target.nextCheckAt = Date.now() + CHECK_INTERVAL_MS
+        }
+      } else if (value === 'cleared') {
+        target.clearSince ??= Date.now()
+        target.nextCheckAt = Date.now() + CHECK_INTERVAL_MS
+        if (Date.now() - target.clearSince >= CLEAR_GRACE_MS) {
+          if (target.attemptedAt !== undefined) {
+            console.log('[GooglePasskeyRecovery] Google verification prompt cleared after fallback')
+          }
+          target.attempted = false
+          target.attemptedAt = undefined
+          target.clearSince = undefined
+          target.verificationReported = false
+          target.since = Date.now()
+          target.checks = 0
+        }
+      } else {
+        target.clearSince = undefined
+      }
+      if (inspection && target.attemptedAt !== undefined && !target.verificationReported) {
+        target.nextCheckAt = Date.now() + CHECK_INTERVAL_MS
+      }
     } catch {
       // Recovery is best effort and must never break browser launch or input.
     } finally {
+      if (current() && target.attemptedAt !== undefined && !target.verificationReported &&
+          Date.now() - target.attemptedAt >= VERIFY_TIMEOUT_MS) {
+        target.verificationReported = true
+        target.nextCheckAt = Date.now() + SLOW_CHECK_INTERVAL_MS
+        console.warn('[GooglePasskeyRecovery] Could not confirm fallback cleared the verification prompt; observing without another click')
+      }
       target.busy = false
     }
   }


### PR DESCRIPTION
Google can request a security key after password entry at `/v3/signin/challenge/sk/webauthn`. The recovery in 0.5.20-rc.2 only recognized `/pk` and English passkey copy, leaving the native WebAuthn prompt blocking Browserbase input. This change recognizes the post-password challenge and invokes Google’s own “Try another way” handler to open alternative verification methods.

### Changes

- Recognize the security-key screen and fallback button by their verified DOM structure, independent of translated text. Retain the narrow English fallback for unknown structures and the separate passkey route.
- Continue checking delayed prompts at a reduced frequency after the first minute.
- Observe the result after a fallback attempt, confirm navigation or stable prompt disappearance, and allow recovery of a fresh prompt in the same document.
- Avoid duplicate clicks after ambiguous responses, timeouts, or reconnects; cap repeated fallback attempts at three per minute per tab.
- Keep origin, route, visibility, enabled-state, and ambiguity checks; ignore preliminary screens and unrelated challenges.

### Validation

- `npm run test:run -- src/main/host-browser` — 145 tests passed.
- `npm run typecheck` and ESLint on the three changed files passed.
- Chromium/CDP integration probe passed for a localized delayed prompt, same-document retry, and an unchanged prompt without repeated clicks.
- Inspected the live Browserbase security-key structure in English, German, and Hebrew; the new selector successfully opened alternative verification methods from the Hebrew prompt.
- Rebuilt and launched the dev Electron app with automatic recovery enabled; API health verified.

Language-independent recognition is scoped to the verified security-key layout. Localized active `/pk` prompts remain unverified and retain the existing English fallback. Google’s internal DOM markers may change, so unfamiliar or ambiguous localized layouts are left untouched.
