### PR TITLE
fix(attribution): resolve an acting member at container cold start

### DIFF
--- a/src/shared/lib/llm-provider/platform-provider.test.ts
+++ b/src/shared/lib/llm-provider/platform-provider.test.ts
@@ -3,9 +3,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // Stub everything with side effects: attribution pulls in the DB, auth-service
 // reads settings storage, config resolves the proxy URL from the environment.
 const currentAttribution = vi.fn()
+const forAgentAttribution = vi.fn()
+const requiresActingMember = vi.fn(() => false)
+const captureMessage = vi.fn()
 const platformAuthStatus = vi.fn()
 vi.mock('@shared/lib/platform-attribution', () => ({
-  attribution: { current: () => currentAttribution() },
+  attribution: {
+    current: () => currentAttribution(),
+    forAgent: (slug: string) => forAgentAttribution(slug),
+    requiresActingMember: () => requiresActingMember(),
+  },
+}))
+vi.mock('@shared/lib/error-reporting', () => ({
+  captureMessage: (...args: unknown[]) => captureMessage(...args),
 }))
 vi.mock('@shared/lib/services/platform-auth-service', () => ({
   getPlatformAccessToken: () => 'platform-token',
@@ -25,8 +35,42 @@ import { PlatformLlmProvider, sanitizeAgentName } from './platform-provider'
 const provider = new PlatformLlmProvider()
 
 beforeEach(() => {
-  currentAttribution.mockReturnValue(null)
+  currentAttribution.mockReset().mockReturnValue(null)
+  forAgentAttribution.mockReset().mockReturnValue(null)
+  requiresActingMember.mockReset().mockReturnValue(false)
+  captureMessage.mockReset()
   platformAuthStatus.mockReturnValue({ connected: true, orgId: 'org_123' })
+})
+
+describe('getContainerEnvVars auth token (cold start)', () => {
+  it('bakes the agent-resolved attribution token when an identity is provided', () => {
+    forAgentAttribution.mockReturnValue({ bearerToken: () => 'org-jwt::sub_owner' })
+    const env = provider.getContainerEnvVars({ id: 'abc123', name: 'My Agent' })
+    expect(forAgentAttribution).toHaveBeenCalledWith('abc123')
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('org-jwt::sub_owner')
+  })
+
+  it('uses the ambient attribution when no identity is provided', () => {
+    currentAttribution.mockReturnValue({ bearerToken: () => 'org-jwt::sub_ambient' })
+    expect(provider.getContainerEnvVars().ANTHROPIC_AUTH_TOKEN).toBe('org-jwt::sub_ambient')
+    expect(forAgentAttribution).not.toHaveBeenCalled()
+  })
+
+  it('reports and falls back to the bare token when an org JWT resolves no member', () => {
+    requiresActingMember.mockReturnValue(true)
+    const env = provider.getContainerEnvVars({ id: 'abc123' })
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('platform-token')
+    expect(captureMessage).toHaveBeenCalledWith(
+      'platform container env built without acting member',
+      expect.objectContaining({ tags: { area: 'platform-attribution', op: 'container.env.no_member' } }),
+    )
+  })
+
+  it('does not report the fallback for an opaque access key', () => {
+    requiresActingMember.mockReturnValue(false)
+    expect(provider.getContainerEnvVars({ id: 'abc123' }).ANTHROPIC_AUTH_TOKEN).toBe('platform-token')
+    expect(captureMessage).not.toHaveBeenCalled()
+  })
 })
 
 describe('PlatformLlmProvider — tool search', () => {

--- a/src/shared/lib/llm-provider/platform-provider.ts
+++ b/src/shared/lib/llm-provider/platform-provider.ts
@@ -7,6 +7,7 @@ import type { ModelDefinition } from './model-catalog-schema'
 import { PLATFORM_CATALOG, PLATFORM_DEFAULT_MODEL_OPTIONS } from './builtin-catalogs'
 import { PLATFORM_CATALOG_DEFAULT_MODELS } from './model-catalog-defaults'
 import { attribution } from '@shared/lib/platform-attribution'
+import { captureMessage } from '@shared/lib/error-reporting'
 import { getPlatformAccessToken, getPlatformAuthStatus } from '@shared/lib/services/platform-auth-service'
 import { getPlatformBaseUrl, getPlatformProxyBaseUrl } from '@shared/lib/platform-auth/config'
 import type { ApiKeyStatus } from '../config/settings'
@@ -69,7 +70,19 @@ export class PlatformLlmProvider extends BaseLlmProvider {
     const proxyUrl = getPlatformProxyBaseUrl()
     const containerUrl = rewriteLoopbackForContainer(proxyUrl)
 
-    const auth = attribution.current()
+    // The token is baked once per container start and shared by every session
+    // in it, so an empty ambient scope here (scheduler / trigger / recovery
+    // start) must still resolve a member — a bare org JWT is admitted by the
+    // proxy as org_runtime and bills to the org pool instead of a seat (SUP-805).
+    const auth = agent ? attribution.forAgent(agent.id) : attribution.current()
+    if (!auth && attribution.requiresActingMember()) {
+      console.warn(`[PlatformLlmProvider] No acting member resolved for agent ${agent?.id ?? '(none)'}; baking bare org token`)
+      captureMessage('platform container env built without acting member', {
+        level: 'warning',
+        tags: { area: 'platform-attribution', op: 'container.env.no_member' },
+        extra: { agentId: agent?.id ?? null },
+      })
+    }
     const authToken = auth?.bearerToken() ?? this.getEffectiveApiKey()
 
     // Agent identity rides into the container as plain env vars; the container

--- a/src/shared/lib/platform-attribution/index.test.ts
+++ b/src/shared/lib/platform-attribution/index.test.ts
@@ -10,6 +10,11 @@ vi.mock('@shared/lib/services/platform-auth-service', () => ({
   getStoredPlatformMemberId: () => mockGetStoredPlatformMemberId(),
 }))
 
+const mockGetAgentOwnerUserId = vi.fn((_slug: string): string | null => null)
+vi.mock('@shared/lib/services/agent-owner', () => ({
+  getAgentOwnerUserId: (slug: string) => mockGetAgentOwnerUserId(slug),
+}))
+
 vi.mock('@shared/lib/db', () => {
   const chainable = {
     select: () => chainable,
@@ -150,6 +155,57 @@ describe('attribution.current', () => {
 
   it('returns null when neither scope is active', () => {
     expect(attribution.current()).toBeNull()
+  })
+})
+
+describe('attribution.forAgent (container cold start)', () => {
+  beforeEach(() => {
+    mockGetAgentOwnerUserId.mockReturnValue(null)
+    mockGetStoredPlatformMemberId.mockReturnValue(null)
+  })
+
+  it('prefers the ambient request user over the agent owner', async () => {
+    mockGetAgentOwnerUserId.mockReturnValue('user_owner')
+    await runWithRequestUser('user_request', () => {
+      attribution.forAgent('agent_a')
+      expect(mockGetAgentOwnerUserId).not.toHaveBeenCalled()
+    })
+  })
+
+  it('prefers an explicit runWithAttribution scope', async () => {
+    const scoped = attribution.fromUserId('user_scoped')!
+    await runWithAttribution(scoped, () => {
+      expect(attribution.forAgent('agent_a')).toBe(scoped)
+    })
+  })
+
+  it('falls back to the agent owner when no scope is active', () => {
+    mockGetAgentOwnerUserId.mockReturnValue('user_owner')
+    const auth = attribution.forAgent('agent_a')
+    expect(mockGetAgentOwnerUserId).toHaveBeenCalledWith('agent_a')
+    expect(auth?.bearerToken()).toBe(`${ORG_TOKEN}::sub_user_123`)
+  })
+
+  it('falls back to the stored member when the agent has no owner', () => {
+    mockGetStoredPlatformMemberId.mockReturnValue('sub_settings_789')
+    expect(attribution.forAgent('agent_a')?.bearerToken()).toBe(`${ORG_TOKEN}::sub_settings_789`)
+  })
+
+  it('falls back to the stored member when the owner has no platform account', () => {
+    mockGetAgentOwnerUserId.mockReturnValue('user_orphan')
+    mockDbAll.mockReturnValue([])
+    mockGetStoredPlatformMemberId.mockReturnValue('sub_settings_789')
+    expect(attribution.forAgent('agent_a')?.bearerToken()).toBe(`${ORG_TOKEN}::sub_settings_789`)
+  })
+
+  it('returns null for an org token when nothing in the chain resolves a member', () => {
+    mockDbAll.mockReturnValue([])
+    expect(attribution.forAgent('agent_a')).toBeNull()
+  })
+
+  it('returns a member-less attribution for an opaque access key', () => {
+    mockGetPlatformAccessToken.mockReturnValue(ACCESS_KEY)
+    expect(attribution.forAgent('agent_a')?.bearerToken()).toBe(ACCESS_KEY)
   })
 })
 

--- a/src/shared/lib/platform-attribution/index.ts
+++ b/src/shared/lib/platform-attribution/index.ts
@@ -5,6 +5,7 @@ import { and, desc, eq } from 'drizzle-orm'
 import { db } from '@shared/lib/db'
 import { authAccount } from '@shared/lib/db/schema'
 import { getPlatformAccessToken, getStoredPlatformMemberId } from '@shared/lib/services/platform-auth-service'
+import { getAgentOwnerUserId } from '@shared/lib/services/agent-owner'
 import { decodeOrgIdFromToken } from '@shared/lib/platform-auth/decode-org-id'
 
 import { getRequestUserId } from './request-context'
@@ -119,6 +120,17 @@ export const attribution = {
   },
   current(): Attribution | null {
     return attributionContext.getStore()?.auth ?? fromCurrentRequest()
+  },
+  // Container cold start: ambient scope, else the agent owner, else the stored
+  // member. Same fallback chain as trigger minting (SUP-765); null only when
+  // nothing resolves, so callers never bake a bare org token by accident (SUP-805).
+  forAgent(agentSlug: string): Attribution | null {
+    const ambient = attributionContext.getStore()?.auth ?? fromCurrentRequest()
+    if (ambient) return ambient
+    const ownerUserId = getAgentOwnerUserId(agentSlug)
+    return buildAttribution(
+      ownerUserId ? resolveMemberIdForUserId(ownerUserId) : getStoredPlatformMemberId(),
+    )
   },
   requiresActingMember,
 } as const


### PR DESCRIPTION
Linear: [SUP-805](https://linear.app/datawizz/issue/SUP-805/llm-usage-without-member-id-is-admitted-but-never-billed-5percent-of)
Companion: [platform#418](https://github.com/SkillfulAgents/platform/pull/418) (bills the residual no-member usage to the org pool).

## Bug

In cloud (org JWT) mode, the platform LLM token is baked into `ANTHROPIC_AUTH_TOKEN` once per container start (`buildAgentEnv` → `PlatformLlmProvider.getContainerEnvVars`) and shared by every session in that container until it restarts.

`getContainerEnvVars` did `attribution.current()?.bearerToken() ?? this.getEffectiveApiKey()`. When the container was started from a code path with no ambient attribution — scheduler / trigger / chat integration with a null `createdByUserId`, a user with no `authAccount(platform)` row, or a recovery/startup path not wrapped in `runWithRequestUser` — the `??` fell through to the **bare org JWT** with no `::memberId`. The proxy admits that as `org_runtime` with `memberId: null`, the billing gate only checks org-level keys, and Metronome zero-rated the events (no `seat_id`).

Prod ClickHouse, last 30d: no-member share grew 1% → 8.2% of rows, $749 this week (5.4% of USD). 4831 sessions purely no-member vs 55 mixed (container-level, not per-request); minute-of-hour peaks at 0/1/15/30/45 (scheduler cold starts).

## Repro

1. Cloud deployment (`AUTH_MODE=true`, org JWT).
2. Let a container idle-stop, then let a scheduled task whose creator has no platform `authAccount` row start it.
3. Every `/v1/messages` from that container carries `Authorization: Bearer <jwt>` with no `::memberId`; ClickHouse rows land with `member_id = ''`.

## Change

- `platform-attribution/index.ts`: new `attribution.forAgent(agentSlug)` — ambient scope (`runWithAttribution` / request user), else the agent owner (`getAgentOwnerUserId`), else `getStoredPlatformMemberId()`. Same chain the trigger-mint path uses (`message-persister.ts` `resolvePlatformMemberForSession`, SUP-765). Returns null only when nothing resolves under an org token; returns a member-less attribution for opaque keys (local behaviour unchanged).
- `llm-provider/platform-provider.ts`: `getContainerEnvVars(agent)` uses `forAgent(agent.id)` when an identity is given. If an org token still resolves no member, `console.warn` + `captureMessage` (`area: platform-attribution`, `op: container.env.no_member`) before falling back to the bare token, so the residual is visible in Sentry.
- Tests: 7 cases for the `forAgent` chain (precedence, each fallback, null under org token, pass-through for access key); 4 cases for the provider cold-start token (agent-resolved, ambient, reported fallback, no report for access key).

## Deliberately not in this PR

- **Rebuilding env when the acting member changes on a running container.** The token is per-container, so a container started by member A runs member B's scheduled task under A. That is the pre-existing cloud attribution-collapse problem, not the billing hole, and restarting a live container to swap tokens kills in-flight sessions. Needs its own design (per-session token or idle-only rebuild). Filed as follow-up on SUP-805.
- Making `/v1/messages` `member: "required"` on the proxy (Composio-style 400). Do that after this ships and no-member traffic is ~0, otherwise every already-running container with a bare token breaks.

## Checks

- `tsc --noEmit` clean
- `eslint` on changed files clean
- `vitest run src/shared/lib/platform-attribution src/shared/lib/llm-provider/platform-provider.test.ts` 54/54
- Not verified: end-to-end on a cloud deployment. The check that would verify it: after rollout, `SELECT count() FROM llm_usage_events WHERE member_id = '' AND created_at > <deploy time>` trends to zero for orgs on the new version.

Made with [Cursor](https://cursor.com)