### PR TITLE
fix(computer-use): bump agent-computer to 0.0.12 for a working Windows daemon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@hono/node-server": "^1.13.7",
         "@hono/zod-validator": "^0.8.0",
         "@sentry/node": "^10.48.0",
-        "@skillful-agents/agent-computer": "^0.0.11",
+        "@skillful-agents/agent-computer": "^0.0.12",
         "@slack/bolt": "^4.7.0",
         "archiver": "^7.0.1",
         "better-sqlite3": "^12.8.0",
@@ -8533,9 +8533,9 @@
       }
     },
     "node_modules/@skillful-agents/agent-computer": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@skillful-agents/agent-computer/-/agent-computer-0.0.11.tgz",
-      "integrity": "sha512-clev1Ztpz9njQW+KczVHGmwDnN6Lw4sT2ybrkI5lM7+0PSTWPQScR0aIOZY2oXn2e9t3D2UTlhncF4nKx8yl9A==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@skillful-agents/agent-computer/-/agent-computer-0.0.12.tgz",
+      "integrity": "sha512-PGO99lgcc/FS3njpdfB34TmbzEhFJYDa6E2uoN/IrwzKq40U/kl3Dw2LQ1PeOR32NgcuO1Vp+CXhOhripYaRRQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@hono/node-server": "^1.13.7",
     "@hono/zod-validator": "^0.8.0",
     "@sentry/node": "^10.48.0",
-    "@skillful-agents/agent-computer": "^0.0.11",
+    "@skillful-agents/agent-computer": "^0.0.12",
     "@slack/bolt": "^4.7.0",
     "archiver": "^7.0.1",
     "better-sqlite3": "^12.8.0",


### PR DESCRIPTION
## Summary

Computer use on Windows failed on every call with:

```
Computer use request failed: Error executing windows: Daemon pipe did not become available within 5000ms
```

Root cause was upstream: `@skillful-agents/agent-computer` 0.0.11 shipped `ac-core-win32-{x64,arm64}.exe` as ~150 KB .NET apphost stubs that expect an `ac-core.dll` beside them. The daemon died at launch with `The application to execute does not exist: ...ac-core.dll`, so the bridge's 5 s named-pipe probe timed out.

Fixed upstream in [SkillfulAgents/agent-computer v0.0.12](https://github.com/SkillfulAgents/agent-computer/releases/tag/v0.0.12): every `-r win-*` publish is now a single self-contained exe, and the release workflow verifies that before uploading.

This PR bumps the dependency to `^0.0.12`. A caret on a 0.0.x version only matches that exact patch, so the bump is required.

## Verification

- Installed 0.0.12 binaries run standalone (`--version`, `--daemon`, JSON-RPC over `\.\pipe\ac-daemon`).
- End to end from the **packaged** Gamut app on Windows arm64: an agent's `computer_windows` request was approved through `/computer-use`, Gamut spawned the new daemon from `app.asar.unpacked`, and the agent received the window list.
- `npm run typecheck` and `npm run lint` clean (lint warnings pre-existing).
- Lockfile diff is limited to this package.

## Notes

- The repo's `.npmrc` 7-day `min-release-age` cooldown was overridden for this one install (our own package, published minutes earlier). `npm ci` installs from the lockfile without re-resolving; a dry run under the cooldown succeeded.
- Follow-up: the package is now ~133 MB because each Windows exe bundles the WindowsDesktop runtime, and `asarUnpack` ships all four platform binaries in every installer. Worth splitting into per-platform optional deps later.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B78e6gDbuk6m3XFsBN8bUD
