### PR TITLE
End the platform login launch when the stored token changes (SUP-807)

### DIFF
--- a/src/renderer/components/settings/platform-tab.tsx
+++ b/src/renderer/components/settings/platform-tab.tsx
@@ -8,6 +8,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui
 import { Progress } from '@renderer/components/ui/progress'
 import { ErrorBoundary } from '@renderer/components/ui/error-boundary'
 import { RequestError } from '@renderer/components/messages/request-error'
+import { OAuthFlowCancel } from '@renderer/components/connections/oauth-flow-cancel'
 import { ProfileSection } from './profile-section'
 import { useUser } from '@renderer/context/user-context'
 import { usePlatformConnect, useSavePlatformAccessKey } from '@renderer/hooks/use-platform-auth'
@@ -392,10 +393,12 @@ function AccessKeyInput({ onClose }: { onClose: () => void }) {
 interface NotConnectedEmptyStateProps {
   readOnly: boolean
   isLaunching: boolean
+  canCancel: boolean
   onConnect: () => void
+  onCancel: () => void
 }
 
-function NotConnectedEmptyState({ readOnly, isLaunching, onConnect }: NotConnectedEmptyStateProps) {
+function NotConnectedEmptyState({ readOnly, isLaunching, canCancel, onConnect, onCancel }: NotConnectedEmptyStateProps) {
   const [showKeyInput, setShowKeyInput] = useState(false)
 
   return (
@@ -422,6 +425,7 @@ function NotConnectedEmptyState({ readOnly, isLaunching, onConnect }: NotConnect
                 <Button size="sm" variant="outline" onClick={() => setShowKeyInput(true)}>
                   Add access key
                 </Button>
+                <OAuthFlowCancel visible={canCancel} onCancel={onCancel} testId="platform-cancel-connect" />
               </div>
             )}
           </div>
@@ -434,11 +438,13 @@ function NotConnectedEmptyState({ readOnly, isLaunching, onConnect }: NotConnect
 interface ReconnectRowProps {
   readOnly: boolean
   isLaunching: boolean
+  canCancel: boolean
   connectLabel: string
   onReconnect: () => void
+  onCancel: () => void
 }
 
-function ReconnectRow({ readOnly, isLaunching, connectLabel, onReconnect }: ReconnectRowProps) {
+function ReconnectRow({ readOnly, isLaunching, canCancel, connectLabel, onReconnect, onCancel }: ReconnectRowProps) {
   const [showInput, setShowInput] = useState(false)
 
   if (showInput) {
@@ -478,6 +484,7 @@ function ReconnectRow({ readOnly, isLaunching, connectLabel, onReconnect }: Reco
               Add key
             </Button>
           )}
+          <OAuthFlowCancel visible={canCancel} onCancel={onCancel} testId="platform-cancel-reconnect" />
         </div>
       </div>
     </div>
@@ -496,6 +503,8 @@ function formatTimestamp(value: string | null): string {
 export function PlatformTab({ readOnly = false }: PlatformTabProps) {
   const {
     handleConnect,
+    cancelConnect,
+    canCancel,
     isLaunching,
     error,
     message,
@@ -598,7 +607,9 @@ export function PlatformTab({ readOnly = false }: PlatformTabProps) {
           <NotConnectedEmptyState
             readOnly={readOnly}
             isLaunching={isLaunching}
+            canCancel={canCancel}
             onConnect={handleConnect}
+            onCancel={cancelConnect}
           />
         )}
       </div>
@@ -625,8 +636,10 @@ export function PlatformTab({ readOnly = false }: PlatformTabProps) {
           <ReconnectRow
             readOnly={readOnly}
             isLaunching={isLaunching}
+            canCancel={canCancel}
             connectLabel={connectLabel}
             onReconnect={handleConnect}
+            onCancel={cancelConnect}
           />
         </div>
       )}

--- a/src/renderer/components/wizard/welcome-step.tsx
+++ b/src/renderer/components/wizard/welcome-step.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 
 import { Button } from '@renderer/components/ui/button'
+import { OAuthFlowCancel } from '@renderer/components/connections/oauth-flow-cancel'
 import { RequestError } from '@renderer/components/messages/request-error'
 import { ManualAccessKeyInput } from '@renderer/components/settings/manual-access-key-input'
 import { useSettings, useUpdateSettings } from '@renderer/hooks/use-settings'
@@ -22,6 +23,8 @@ export function WelcomeStep({ onChoosePlatform, onContinueToManualSetup }: Welco
   const updateSettings = useUpdateSettings()
   const {
     handleConnect,
+    cancelConnect,
+    canCancel,
     isLaunching,
     error: platformError,
     isConnected: isPlatformConnected,
@@ -152,7 +155,10 @@ export function WelcomeStep({ onChoosePlatform, onContinueToManualSetup }: Welco
               </p>
             )}
             {isLaunching && (
-              <ManualAccessKeyInput prefixText="Log in issues?" className="text-sm text-muted-foreground" />
+              <div className="flex items-center gap-3 max-w-[380px] text-sm text-muted-foreground">
+                <ManualAccessKeyInput prefixText="Log in issues?" className="flex-1" />
+                <OAuthFlowCancel visible={canCancel} onCancel={cancelConnect} testId="wizard-cancel-login" />
+              </div>
             )}
           </div>
         )}

--- a/src/renderer/hooks/use-platform-auth.launching.test.tsx
+++ b/src/renderer/hooks/use-platform-auth.launching.test.tsx
@@ -1,35 +1,131 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 
+// A test can hold the next /initiate open so a launch stays pending.
+const initiateGate = vi.hoisted(() => ({
+  hold: null as Promise<void> | null,
+  onEnter: null as (() => void) | null,
+}))
 vi.mock('@renderer/lib/api', () => ({
   apiFetch: vi.fn(async (path: string) => {
     if (path === '/api/platform-auth') return { ok: true, json: async () => ({ connected: true, updatedAt: 't1' }) }
-    if (path.endsWith('/initiate')) return { ok: true, json: async () => ({ loginUrl: 'https://platform.test/login' }) }
+    if (path.endsWith('/initiate')) {
+      const hold = initiateGate.hold
+      initiateGate.hold = null
+      initiateGate.onEnter?.()
+      if (hold) await hold
+      return { ok: true, json: async () => ({ loginUrl: 'https://platform.test/login' }) }
+    }
     return { ok: true, json: async () => ({}) }
   }),
 }))
 
+const popupMocks = vi.hoisted(() => ({ navigate: vi.fn(async () => {}), close: vi.fn() }))
+vi.mock('@renderer/lib/oauth-popup', () => ({
+  prepareOAuthPopup: () => ({ navigate: popupMocks.navigate, close: popupMocks.close }),
+}))
+
 import { usePlatformConnect } from './use-platform-auth'
+import { OAUTH_ABORT_DELAY_MS } from './use-delayed-oauth-abort'
+
+async function renderConnected() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+  const { result } = renderHook(() => usePlatformConnect(), { wrapper })
+  await waitFor(() => expect(result.current.isConnected).toBe(true))
+  return { result, client }
+}
+
+async function renderLaunched({ fakeTimers = false } = {}) {
+  const rendered = await renderConnected()
+  // Only the launch itself runs under fake timers; waitFor needs real ones.
+  if (fakeTimers) vi.useFakeTimers()
+  await act(async () => { await rendered.result.current.handleConnect() })
+  expect(rendered.result.current.isLaunching).toBe(true)
+  return rendered
+}
 
 // Web mode: the login callback never arrives here (the deep link lands in the
-// desktop app), so a saved token is the only thing that can end a launch.
+// desktop app), so a saved token or the user's Cancel are the only things that
+// can end a launch.
 describe('usePlatformConnect launching state in a browser window', () => {
-  it('ends the launch when the stored token changes by any path', async () => {
-    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={client}>{children}</QueryClientProvider>
-    )
-    const { result } = renderHook(() => usePlatformConnect(), { wrapper })
-    await waitFor(() => expect(result.current.isConnected).toBe(true))
+  afterEach(() => {
+    vi.useRealTimers()
+    initiateGate.hold = null
+    initiateGate.onEnter = null
+    popupMocks.close.mockReset()
+    popupMocks.navigate.mockClear()
+  })
 
-    await act(async () => { await result.current.handleConnect() })
-    expect(result.current.isLaunching).toBe(true)
+  it('ends the launch when the stored token changes by any path', async () => {
+    const { result, client } = await renderLaunched()
 
     // An access key saved meanwhile: the status query carries a new updatedAt.
     act(() => { client.setQueryData(['platform-auth'], { connected: true, updatedAt: 't2' }) })
     await waitFor(() => expect(result.current.isLaunching).toBe(false))
+  })
+
+  it('offers Cancel after the delay, and Cancel closes the window and ends the launch', async () => {
+    const { result } = await renderLaunched({ fakeTimers: true })
+
+    act(() => { vi.advanceTimersByTime(OAUTH_ABORT_DELAY_MS - 1) })
+    expect(result.current.canCancel).toBe(false)
+
+    act(() => { vi.advanceTimersByTime(1) })
+    expect(result.current.canCancel).toBe(true)
+
+    act(() => { result.current.cancelConnect() })
+    expect(popupMocks.close).toHaveBeenCalledTimes(1)
+    expect(result.current.isLaunching).toBe(false)
+    expect(result.current.canCancel).toBe(false)
+  })
+
+  it('drops a launch request that resolves after Cancel', async () => {
+    const { result } = await renderConnected()
+    let release!: () => void
+    initiateGate.hold = new Promise<void>((resolve) => { release = resolve })
+    const initiatePending = new Promise<void>((resolve) => { initiateGate.onEnter = resolve })
+
+    let launch!: Promise<void>
+    act(() => { launch = result.current.handleConnect() })
+    await act(async () => { await initiatePending })
+
+    act(() => { result.current.cancelConnect() })
+    expect(result.current.isLaunching).toBe(false)
+
+    release()
+    await act(async () => { await launch })
+    expect(popupMocks.navigate).not.toHaveBeenCalled()
+    expect(result.current.isLaunching).toBe(false)
+  })
+
+  it('lets a launch that ended early fail late without touching the retry started after it', async () => {
+    const { result, client } = await renderConnected()
+    let fail!: () => void
+    initiateGate.hold = new Promise<void>((_, reject) => { fail = () => reject(new Error('late failure')) })
+    const initiatePending = new Promise<void>((resolve) => { initiateGate.onEnter = resolve })
+
+    let first!: Promise<void>
+    act(() => { first = result.current.handleConnect() })
+    await act(async () => { await initiatePending })
+
+    // An access key saved while the first request is still pending ends that launch...
+    act(() => { client.setQueryData(['platform-auth'], { connected: true, updatedAt: 't2' }) })
+    await waitFor(() => expect(result.current.isLaunching).toBe(false))
+
+    // ...and the user launches again. The first request then fails.
+    await act(async () => { await result.current.handleConnect() })
+    expect(result.current.isLaunching).toBe(true)
+    fail()
+    await act(async () => { await first })
+
+    expect(result.current.isLaunching).toBe(true)
+    expect(result.current.error).toBeNull()
+    expect(popupMocks.navigate).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/hooks/use-platform-auth.launching.test.tsx
+++ b/src/renderer/hooks/use-platform-auth.launching.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+
+vi.mock('@renderer/lib/api', () => ({
+  apiFetch: vi.fn(async (path: string) => {
+    if (path === '/api/platform-auth') return { ok: true, json: async () => ({ connected: true, updatedAt: 't1' }) }
+    if (path.endsWith('/initiate')) return { ok: true, json: async () => ({ loginUrl: 'https://platform.test/login' }) }
+    return { ok: true, json: async () => ({}) }
+  }),
+}))
+
+import { usePlatformConnect } from './use-platform-auth'
+
+// Web mode: the login callback never arrives here (the deep link lands in the
+// desktop app), so a saved token is the only thing that can end a launch.
+describe('usePlatformConnect launching state in a browser window', () => {
+  it('ends the launch when the stored token changes by any path', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+    const { result } = renderHook(() => usePlatformConnect(), { wrapper })
+    await waitFor(() => expect(result.current.isConnected).toBe(true))
+
+    await act(async () => { await result.current.handleConnect() })
+    expect(result.current.isLaunching).toBe(true)
+
+    // An access key saved meanwhile: the status query carries a new updatedAt.
+    act(() => { client.setQueryData(['platform-auth'], { connected: true, updatedAt: 't2' }) })
+    await waitFor(() => expect(result.current.isLaunching).toBe(false))
+  })
+})

--- a/src/renderer/hooks/use-platform-auth.ts
+++ b/src/renderer/hooks/use-platform-auth.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tansta
 
 import { apiFetch } from '@renderer/lib/api'
 import { useUpdateSettings } from '@renderer/hooks/use-settings'
+import { useDelayedOAuthAbort } from '@renderer/hooks/use-delayed-oauth-abort'
 import { prepareOAuthPopup } from '@renderer/lib/oauth-popup'
 import type {
   PlatformAuthSource,
@@ -272,6 +273,15 @@ export function usePlatformConnect(options?: PlatformConnectOptions) {
   const [error, setError] = useState<string | null>(null)
   const [message, setMessage] = useState<string | null>(null)
   const wasConnected = !!platformAuth?.connected
+  // Each launch gets an attempt number; a request that settles after a newer
+  // attempt started (or after Cancel) is stale and must not touch state.
+  const attemptRef = useRef(0)
+  const abortConnectRef = useRef<(() => void) | null>(null)
+  const canCancel = useDelayedOAuthAbort(isLaunching)
+
+  const cancelConnect = useCallback(() => {
+    abortConnectRef.current?.()
+  }, [])
 
   const onSuccessRef = useRef(options?.onSuccess)
   onSuccessRef.current = options?.onSuccess
@@ -319,6 +329,13 @@ export function usePlatformConnect(options?: PlatformConnectOptions) {
 
   const handleConnect = useCallback(async () => {
     const popup = prepareOAuthPopup()
+    const attempt = ++attemptRef.current
+    const stale = () => attempt !== attemptRef.current
+    abortConnectRef.current = () => {
+      attemptRef.current++
+      popup.close()
+      setIsLaunching(false)
+    }
     setError(null)
     setMessage(null)
     setIsLaunching(true)
@@ -327,9 +344,12 @@ export function usePlatformConnect(options?: PlatformConnectOptions) {
       if (wasConnected) {
         await revokePlatformToken.mutateAsync({ clearLocal: false }).catch(() => ({ success: false }))
       }
+      if (stale()) return
       const result = await initiateLogin.mutateAsync()
+      if (stale()) return
       await popup.navigate(result.loginUrl)
     } catch (err) {
+      if (stale()) return
       popup.close()
       setIsLaunching(false)
       setError(err instanceof Error ? err.message : 'Failed to open platform login.')
@@ -338,7 +358,9 @@ export function usePlatformConnect(options?: PlatformConnectOptions) {
 
   return {
     handleConnect,
-    isLaunching: isLaunching || initiateLogin.isPending,
+    cancelConnect,
+    canCancel,
+    isLaunching,
     error,
     message,
     isConnected: !!platformAuth?.connected,

--- a/src/renderer/hooks/use-platform-auth.ts
+++ b/src/renderer/hooks/use-platform-auth.ts
@@ -278,6 +278,19 @@ export function usePlatformConnect(options?: PlatformConnectOptions) {
   const successMessageRef = useRef(options?.successMessage)
   successMessageRef.current = options?.successMessage
 
+  // In a browser window the login callback is a deep link that lands in the
+  // desktop app, so nothing here ever ends the launch. A token saved by any
+  // path (access key included) bumps updatedAt and ends the wait.
+  const updatedAt = platformAuth?.updatedAt
+  const seenUpdatedAtRef = useRef(updatedAt)
+  useEffect(() => {
+    if (updatedAt === seenUpdatedAtRef.current) return
+    seenUpdatedAtRef.current = updatedAt
+    // On desktop the callback owns the launch; a metadata refresh mid-login must not end it.
+    if (window.electronAPI?.onPlatformAuthCallback) return
+    setIsLaunching(false)
+  }, [updatedAt])
+
   usePlatformAuthCallbackListener((params) => {
     setIsLaunching(false)
     if (params.success) {


### PR DESCRIPTION
In a browser window, clicking Reconnect on the Account tab left the button on "Opening browser…" forever, and adding an access key afterwards did not clear it. The platform login callback is a deep link that lands in the desktop app, so the launch state in the web app never heard back. Now any change to the stored token's timestamp ends the launch in a browser window, while on desktop the callback keeps ownership as before. A login window closed by mistake had no way back either, on desktop or web, so after 10 seconds the same Cancel link the OAuth connection flows use appears next to the button and ends the launch so Reconnect can be clicked again.

Closes https://linear.app/datawizz/issue/SUP-807/reconnect-from-a-browser-window-leaves-the-account-tab-on-opening

How it works:

- The connect hook watches the platform auth status query's `updatedAt`. When it changes after mount, the launching flag clears.
- The effect returns early when the desktop callback bridge exists, so a metadata refresh mid-login cannot end a launch the callback owns.
- The connect hook owns the cancel: it holds the login popup, runs the existing `useDelayedOAuthAbort` timer off the launching flag, and exposes `cancelConnect` and `canCancel`. Cancel closes the popup and clears the launch. A launch request that resolves or fails after Cancel is ignored, so it cannot navigate or clobber a retry.
- The Account tab (both the empty state and the Reconnect row) and the onboarding wizard render the shared `OAuthFlowCancel` link.
- Hook tests: a token change ends the launch; Cancel appears at 10 s (off at 9,999 ms) and ends the launch; a cancelled request that fails late neither navigates nor errors.

## Screenshots

| Light | Dark |
| --- | --- |
| ![Account tab (connected), Cancel after 10 s (light)](https://github.com/user-attachments/assets/78d74dca-8135-40ca-9c61-802489dbe428) | ![Account tab (connected), Cancel after 10 s (dark)](https://github.com/user-attachments/assets/a9fce407-3ae3-4c5a-a624-cde7bab0e076) |
| ![Account tab, Cancel after 10 s (light)](https://github.com/user-attachments/assets/32462cdc-2fa3-4c65-ac3f-7f53a1ade5dc) | ![Account tab, Cancel after 10 s (dark)](https://github.com/user-attachments/assets/408ac9d3-bbbf-4cc4-98c9-8f4511c5729e) |
| ![Onboarding wizard, Cancel after 10 s (light)](https://github.com/user-attachments/assets/577a0493-1bbe-4627-a8a3-866bf669cfe0) | ![Onboarding wizard, Cancel after 10 s (dark)](https://github.com/user-attachments/assets/bc1bd33a-ef33-42ce-85f6-d103eba369ae) |
