### PR TITLE
Show agent members in headers and sidebar with live updates

### DIFF
--- a/e2e/auth/specs/collaboration-members.spec.ts
+++ b/e2e/auth/specs/collaboration-members.spec.ts
@@ -97,9 +97,11 @@ test('members share one live roster while invitation and revocation follow permi
     const image = new PNG({ width: 32, height: 32 })
     image.data.fill(160)
     expect((await viewer.request.put('/api/profile/avatar', { headers: { 'Content-Type': 'image/png' }, data: PNG.sync.write(image) })).ok()).toBeTruthy()
+    expect((await viewer.request.post('/api/auth/update-user', { headers: { Origin: baseURL! }, data: { name: 'Victoria Viewer' } })).ok()).toBeTruthy()
+    // Other members see the updated photo and name on their next reload.
+    await page.reload()
     const viewerFace = ownerStack.getByTestId(`agent-member-${users[1].id}`)
     await expect(viewerFace.locator('img')).toHaveAttribute('src', /\/api\/profile\/images\//)
-    expect((await viewer.request.post('/api/auth/update-user', { headers: { Origin: baseURL! }, data: { name: 'Victoria Viewer' } })).ok()).toBeTruthy()
     await expect(viewerFace).toHaveAttribute('aria-label', /Victoria Viewer/)
     await ownerStack.getByTestId(`agent-member-${users[0].id}`).hover()
     await expect(page.getByRole('tooltip').filter({ hasText: users[0].email })).toBeVisible()

--- a/e2e/auth/specs/collaboration-members.spec.ts
+++ b/e2e/auth/specs/collaboration-members.spec.ts
@@ -27,6 +27,16 @@ test('members share one live roster while invitation and revocation follow permi
     await expect(ownerStack).toHaveCount(0)
     await expect(page.getByTestId(`sidebar-members-${agent.slug}`)).toHaveCount(0)
 
+    // The stretched name link must not cover the status icon's native tooltip.
+    const agentLink = page.getByTestId(`agent-item-${agent.slug}`)
+    const status = page.locator('[data-sidebar="menu-button"]').filter({ has: agentLink }).getByTestId('agent-status')
+    await status.hover()
+    expect(await status.evaluate((element) => {
+      const bounds = element.getBoundingClientRect()
+      return element.contains(document.elementFromPoint(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2))
+    })).toBe(true)
+    await expect(status).toHaveAttribute('title', 'sleeping')
+
     // Private agents retain Share; the same pane stays open when the first invite makes it shared.
     await page.getByTestId('agent-share-button').click()
     const sharing = page.getByTestId('agent-share-popover')
@@ -126,6 +136,17 @@ test('members share one live roster while invitation and revocation follow permi
     await expect(ownerStack.getByTestId('agent-members-overflow')).toHaveText('+1')
     expect((await users[2].context.request.post(`${endpoint}/leave`)).ok()).toBeTruthy()
     await expect(ownerStack.getByTestId('agent-members-overflow')).toHaveCount(0)
+
+    // The first signup is the deployment admin. Removing their explicit ACL
+    // hides the sidebar entry but preserves access to the open agent page.
+    expect((await page.request.patch(`${endpoint}/access/${users[3].id}`, { data: { role: 'owner' } })).ok()).toBeTruthy()
+    expect((await users[3].context.request.delete(`${endpoint}/access/${users[0].id}`)).ok()).toBeTruthy()
+    await expect(agentLink).toHaveCount(0)
+    await expect(page).toHaveURL(new RegExp(`/agents/[^/]*${agent.slug}$`))
+    await expect(ownerStack.getByTestId(`agent-member-${users[0].id}`)).toHaveCount(0)
+    await expect(ownerStack.getByTestId(`agent-member-${users[3].id}`)).toBeVisible()
+    expect((await page.request.get(`${endpoint}/members`)).status()).toBe(200)
+    expect((await page.request.get(`${endpoint}/access`)).status()).toBe(200)
   } finally {
     await Promise.all(contexts.map((context) => context.close()))
   }

--- a/e2e/auth/specs/collaboration-members.spec.ts
+++ b/e2e/auth/specs/collaboration-members.spec.ts
@@ -23,10 +23,11 @@ test('members share one live roster while invitation and revocation follow permi
     const endpoint = `/api/agents/${agent.slug}`
     await page.goto(`/agents/${agent.slug}`)
     const ownerStack = page.getByTestId('agent-member-stack')
-    await expect(ownerStack.getByTestId(`agent-member-${users[0].id}`)).toBeVisible({ timeout: 15_000 })
-    await expect(ownerStack.getByTestId('agent-members-overflow')).toHaveCount(0)
+    await expect(page.getByTestId('agent-share-button')).toHaveText('Share', { timeout: 15_000 })
+    await expect(ownerStack).toHaveCount(0)
+    await expect(page.getByTestId(`sidebar-members-${agent.slug}`)).toHaveCount(0)
 
-    // The new + still opens Invite / Publish / Export, and invitation works through it.
+    // Private agents retain Share; the same pane stays open when the first invite makes it shared.
     await page.getByTestId('agent-share-button').click()
     const sharing = page.getByTestId('agent-share-popover')
     await expect(sharing.getByRole('tab', { name: 'Publish', exact: true })).toBeVisible()
@@ -37,7 +38,9 @@ test('members share one live roster while invitation and revocation follow permi
     await page.getByRole('option', { name: 'Viewer Can view sessions only' }).click()
     await sharing.getByRole('button', { name: 'Invite', exact: true }).click()
     await expect(ownerStack.getByTestId(`agent-member-${users[1].id}`)).toBeVisible()
+    await expect(sharing).toBeVisible()
     await page.keyboard.press('Escape')
+    await expect(sharing).not.toBeVisible()
 
     const viewer = await users[1].context.newPage()
     await viewer.goto(`/agents/${agent.slug}`)
@@ -48,8 +51,30 @@ test('members share one live roster while invitation and revocation follow permi
     expect((await viewer.request.post(`${endpoint}/access`, { data: { userId: users[7].id, role: 'owner' } })).status()).toBe(403)
     expect((await users[7].context.request.get(`${endpoint}/members`)).status()).toBe(403)
 
+    await viewer.getByTestId(`sidebar-members-${agent.slug}`).click()
+    await expect(viewer.getByTestId(`sidebar-members-invite-${agent.slug}`)).toHaveCount(0)
+    await viewer.keyboard.press('Escape')
+
+    // Sidebar Invite targets its agent while leaving the current page in place.
+    await page.goto('/')
+    const sidebarStack = page.getByTestId(`sidebar-members-${agent.slug}`)
+    const sidebarRoster = page.getByTestId(`sidebar-members-list-${agent.slug}`)
+    await sidebarStack.click()
+    await page.getByTestId(`sidebar-members-invite-${agent.slug}`).click()
+    await expect(sharing.getByTestId('invite-search-input')).toBeFocused()
+    await sharing.getByTestId('invite-search-input').fill(users[2].email)
+    await sharing.getByTestId(`invite-user-result-${users[2].id}`).click()
+    await sharing.getByTestId('invite-add-button').click()
+    await expect(sidebarRoster.getByRole('listitem')).toHaveCount(3)
+    await expect(page).toHaveURL(`${baseURL}/`)
+    await page.keyboard.press('Escape')
+    await expect(sharing).not.toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(sidebarRoster).not.toBeVisible()
+    await page.goto(`/agents/${agent.slug}`)
+
     // A second window refreshes without opening Share or reloading the page.
-    for (const member of users.slice(2, 7)) {
+    for (const member of users.slice(3, 7)) {
       expect((await page.request.post(`${endpoint}/access`, { data: { userId: member.id, role: 'user' } })).ok()).toBeTruthy()
     }
     await expect(ownerStack.getByTestId('agent-members-overflow')).toHaveText('+2')

--- a/e2e/auth/specs/collaboration-members.spec.ts
+++ b/e2e/auth/specs/collaboration-members.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect, type BrowserContext } from '@playwright/test'
+import { PNG } from 'pngjs'
+
+test('members share one live roster while invitation and revocation follow permissions', async ({ browser, page, baseURL }) => {
+  test.setTimeout(90_000)
+  const contexts: BrowserContext[] = []
+  const stamp = Date.now()
+  const users: { id: string; name: string; email: string; context: BrowserContext }[] = []
+  try {
+    for (const [index, name] of ['Olivia Owner', 'Vic Viewer', 'Uma User', 'Nora Patel', 'Eli Brooks', 'Sam Rivera', 'Maya Chen', 'Unrelated User'].entries()) {
+      const context = index === 0 ? page.context() : await browser.newContext({ baseURL })
+      if (index > 0) contexts.push(context)
+      const email = `members-${stamp}-${index}@example.test`
+      const response = await context.request.post('/api/auth/sign-up/email', { data: { name, email, password: 'CollaborationTesting123!' } })
+      expect(response.ok()).toBeTruthy()
+      const { user } = await response.json()
+      users.push({ id: user.id, name, email, context })
+      expect((await context.request.put('/api/user-settings', { data: { setupCompleted: true } })).ok()).toBeTruthy()
+    }
+    const created = await page.request.post('/api/agents', { data: { name: 'Collaboration Members' } })
+    expect(created.ok()).toBeTruthy()
+    const agent = await created.json()
+    const endpoint = `/api/agents/${agent.slug}`
+    await page.goto(`/agents/${agent.slug}`)
+    const ownerStack = page.getByTestId('agent-member-stack')
+    await expect(ownerStack.getByTestId(`agent-member-${users[0].id}`)).toBeVisible({ timeout: 15_000 })
+    await expect(ownerStack.getByTestId('agent-members-overflow')).toHaveCount(0)
+
+    // The new + still opens Invite / Publish / Export, and invitation works through it.
+    await page.getByTestId('agent-share-button').click()
+    const sharing = page.getByTestId('agent-share-popover')
+    await expect(sharing.getByRole('tab', { name: 'Publish', exact: true })).toBeVisible()
+    await expect(sharing.getByRole('tab', { name: 'Export', exact: true })).toBeVisible()
+    await sharing.getByPlaceholder('Invite by name or email...').fill(users[1].email)
+    await sharing.getByTestId(`invite-user-result-${users[1].id}`).click()
+    await sharing.getByRole('combobox').first().click()
+    await page.getByRole('option', { name: 'Viewer Can view sessions only' }).click()
+    await sharing.getByRole('button', { name: 'Invite', exact: true }).click()
+    await expect(ownerStack.getByTestId(`agent-member-${users[1].id}`)).toBeVisible()
+    await page.keyboard.press('Escape')
+
+    const viewer = await users[1].context.newPage()
+    await viewer.goto(`/agents/${agent.slug}`)
+    await expect(viewer.getByTestId('agent-member-stack')).toBeVisible()
+    await expect(viewer.getByTestId('agent-share-button')).toHaveCount(0)
+    await expect(viewer.getByTestId('view-only-banner')).toBeVisible()
+    expect((await viewer.request.get(`${endpoint}/access`)).status()).toBe(403)
+    expect((await viewer.request.post(`${endpoint}/access`, { data: { userId: users[7].id, role: 'owner' } })).status()).toBe(403)
+    expect((await users[7].context.request.get(`${endpoint}/members`)).status()).toBe(403)
+
+    // A second window refreshes without opening Share or reloading the page.
+    for (const member of users.slice(2, 7)) {
+      expect((await page.request.post(`${endpoint}/access`, { data: { userId: member.id, role: 'user' } })).ok()).toBeTruthy()
+    }
+    await expect(ownerStack.getByTestId('agent-members-overflow')).toHaveText('+2')
+    await expect(viewer.getByTestId('agent-members-overflow')).toHaveText('+2')
+    await viewer.getByTestId('agent-members-overflow').click()
+    await expect(viewer.getByTestId('agent-members-list').getByRole('listitem')).toHaveCount(7)
+    await expect(viewer.getByTestId('agent-members-list')).toContainText(users[6].email)
+    await viewer.keyboard.press('Escape')
+
+    const image = new PNG({ width: 32, height: 32 })
+    image.data.fill(160)
+    expect((await viewer.request.put('/api/profile/avatar', { headers: { 'Content-Type': 'image/png' }, data: PNG.sync.write(image) })).ok()).toBeTruthy()
+    const viewerFace = ownerStack.getByTestId(`agent-member-${users[1].id}`)
+    await expect(viewerFace.locator('img')).toHaveAttribute('src', /\/api\/profile\/images\//)
+    expect((await viewer.request.post('/api/auth/update-user', { headers: { Origin: baseURL! }, data: { name: 'Victoria Viewer' } })).ok()).toBeTruthy()
+    await expect(viewerFace).toHaveAttribute('aria-label', /Victoria Viewer/)
+    await ownerStack.getByTestId(`agent-member-${users[0].id}`).hover()
+    await expect(page.getByRole('tooltip').filter({ hasText: users[0].email })).toBeVisible()
+    await viewerFace.hover()
+    await expect(page.getByRole('tooltip').filter({ hasText: users[1].email })).toBeVisible()
+    await expect(page.getByRole('tooltip').filter({ hasText: users[0].email })).toHaveCount(0)
+    await viewerFace.focus()
+    await expect(page.getByRole('tooltip').filter({ hasText: users[1].email })).toBeVisible()
+    await page.keyboard.press('Escape')
+
+    expect((await page.request.patch(`${endpoint}/access/${users[1].id}`, { data: { role: 'owner' } })).ok()).toBeTruthy()
+    await expect(viewer.getByTestId('agent-share-button')).toBeVisible()
+    expect((await page.request.patch(`${endpoint}/access/${users[1].id}`, { data: { role: 'user' } })).ok()).toBeTruthy()
+    await expect(viewer.getByTestId('agent-share-button')).toHaveCount(0)
+    await expect(viewer.getByTestId('view-only-banner')).toHaveCount(0)
+
+    // A touch viewport can inspect names, respects reduced motion, and keeps + reachable.
+    const touch = await browser.newContext({ baseURL, storageState: await page.context().storageState(), viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true, reducedMotion: 'reduce' })
+    contexts.push(touch)
+    const mobile = await touch.newPage()
+    await mobile.goto(`/agents/${agent.slug}`)
+    const mobileFace = mobile.getByTestId(`agent-member-${users[1].id}`)
+    await mobileFace.tap()
+    await expect(mobile.getByRole('tooltip')).toContainText(users[1].email)
+    expect(await mobileFace.getByTestId('member-avatar-visual').evaluate((element) => getComputedStyle(element).transitionProperty)).toBe('none')
+    const inviteBounds = await mobile.getByTestId('agent-share-button').boundingBox()
+    expect(inviteBounds!.x).toBeGreaterThanOrEqual(0)
+    expect(inviteBounds!.x + inviteBounds!.width).toBeLessThanOrEqual(390)
+
+    expect((await page.request.delete(`${endpoint}/access/${users[1].id}`)).ok()).toBeTruthy()
+    await expect(viewer).toHaveURL(`${baseURL}/`)
+    await expect(viewer.getByTestId('agent-member-stack')).toHaveCount(0)
+    expect((await viewer.request.get(`${endpoint}/members`)).status()).toBe(403)
+    await expect(ownerStack.getByTestId('agent-members-overflow')).toHaveText('+1')
+    expect((await users[2].context.request.post(`${endpoint}/leave`)).ok()).toBeTruthy()
+    await expect(ownerStack.getByTestId('agent-members-overflow')).toHaveCount(0)
+  } finally {
+    await Promise.all(contexts.map((context) => context.close()))
+  }
+})

--- a/e2e/auth/specs/collaboration-members.spec.ts
+++ b/e2e/auth/specs/collaboration-members.spec.ts
@@ -137,16 +137,23 @@ test('members share one live roster while invitation and revocation follow permi
     expect((await users[2].context.request.post(`${endpoint}/leave`)).ok()).toBeTruthy()
     await expect(ownerStack.getByTestId('agent-members-overflow')).toHaveCount(0)
 
-    // The first signup is the deployment admin. Removing their explicit ACL
-    // hides the sidebar entry but preserves access to the open agent page.
+    // Other specs may have created the deployment's first user. Check the
+    // actual deployment role instead of treating the agent owner as an admin.
+    const session = await (await page.request.get('/api/auth/get-session')).json()
+    const isDeploymentAdmin = session.user.role === 'admin'
     expect((await page.request.patch(`${endpoint}/access/${users[3].id}`, { data: { role: 'owner' } })).ok()).toBeTruthy()
     expect((await users[3].context.request.delete(`${endpoint}/access/${users[0].id}`)).ok()).toBeTruthy()
     await expect(agentLink).toHaveCount(0)
-    await expect(page).toHaveURL(new RegExp(`/agents/[^/]*${agent.slug}$`))
-    await expect(ownerStack.getByTestId(`agent-member-${users[0].id}`)).toHaveCount(0)
-    await expect(ownerStack.getByTestId(`agent-member-${users[3].id}`)).toBeVisible()
-    expect((await page.request.get(`${endpoint}/members`)).status()).toBe(200)
-    expect((await page.request.get(`${endpoint}/access`)).status()).toBe(200)
+    if (isDeploymentAdmin) {
+      await expect(page).toHaveURL(new RegExp(`/agents/[^/]*${agent.slug}$`))
+      await expect(ownerStack.getByTestId(`agent-member-${users[0].id}`)).toHaveCount(0)
+      await expect(ownerStack.getByTestId(`agent-member-${users[3].id}`)).toBeVisible()
+    } else {
+      await expect(page).toHaveURL(`${baseURL}/`)
+      await expect(ownerStack).toHaveCount(0)
+    }
+    expect((await page.request.get(`${endpoint}/members`)).status()).toBe(isDeploymentAdmin ? 200 : 403)
+    expect((await page.request.get(`${endpoint}/access`)).status()).toBe(isDeploymentAdmin ? 200 : 403)
   } finally {
     await Promise.all(contexts.map((context) => context.close()))
   }

--- a/e2e/auth/specs/collaboration-roster-batching.spec.ts
+++ b/e2e/auth/specs/collaboration-roster-batching.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test'
+import { agentMembersBatchRequestSchema } from '../../../src/shared/lib/agent-members-schema'
+
+test('sidebar rosters load and refresh together without per-agent requests', async ({ browser, page, baseURL }) => {
+  const stamp = Date.now()
+  const peer = await browser.newContext({ baseURL })
+  try {
+    const ownerSignup = await page.request.post('/api/auth/sign-up/email', {
+      data: { name: 'Roster Owner', email: `roster-owner-${stamp}@example.test`, password: 'RosterTesting123!' },
+    })
+    expect(ownerSignup.ok()).toBeTruthy()
+    expect((await page.request.put('/api/user-settings', { data: { setupCompleted: true } })).ok()).toBeTruthy()
+    const peerSignup = await peer.request.post('/api/auth/sign-up/email', {
+      data: { name: 'Roster Peer', email: `roster-peer-${stamp}@example.test`, password: 'RosterTesting123!' },
+    })
+    expect(peerSignup.ok()).toBeTruthy()
+    const peerUser = (await peerSignup.json()).user
+    const slugs: string[] = []
+    for (let i = 0; i < 5; i++) {
+      const created = await page.request.post('/api/agents', { data: { name: `Batch Agent ${i}` } })
+      expect(created.ok()).toBeTruthy()
+      const agent = await created.json()
+      slugs.push(agent.slug)
+      expect((await page.request.post(`/api/agents/${agent.slug}/access`, { data: { userId: peerUser.id, role: 'viewer' } })).ok()).toBeTruthy()
+    }
+
+    const batches: string[][] = []
+    const individual: string[] = []
+    page.on('request', request => {
+      const path = new URL(request.url()).pathname
+      if (path === '/api/agents/members/batch') batches.push(agentMembersBatchRequestSchema.parse(request.postDataJSON()).agentSlugs)
+      else if (/\/api\/agents\/[^/]+\/members$/.test(path)) individual.push(path)
+    })
+    await page.goto('/')
+    for (const slug of slugs) {
+      await expect(page.getByTestId(`sidebar-members-${slug}`).locator('[role="img"]')).toHaveCount(2)
+    }
+    expect(batches).toHaveLength(1)
+    expect(new Set(batches[0])).toEqual(new Set(slugs))
+    expect(individual).toEqual([])
+
+    // The peer's profile hint invalidates all five active per-agent caches.
+    const refresh = page.waitForResponse(response => response.url().endsWith('/api/agents/members/batch'))
+    expect((await peer.request.post('/api/auth/update-user', { headers: { Origin: baseURL! }, data: { name: 'Updated Roster Peer' } })).ok()).toBeTruthy()
+    expect((await refresh).ok()).toBeTruthy()
+    for (const slug of slugs) {
+      await expect(page.getByTestId(`sidebar-members-${slug}`).locator('[role="img"][aria-label="Updated Roster Peer"]')).toBeVisible()
+    }
+    expect(batches).toHaveLength(2)
+    expect(new Set(batches[1])).toEqual(new Set(slugs))
+
+    // Opening the header and member popover reuses the refreshed roster cache.
+    await page.getByTestId(`agent-item-${slugs[0]}`).click()
+    await expect(page.getByTestId('agent-member-stack').locator('[role="img"][aria-label="Updated Roster Peer"]')).toBeVisible()
+    await page.getByTestId(`sidebar-members-${slugs[0]}`).hover()
+    await expect(page.getByTestId(`sidebar-members-list-${slugs[0]}`)).toContainText('Updated Roster Peer')
+    expect(batches).toHaveLength(2)
+    expect(individual).toEqual([])
+  } finally {
+    await peer.close()
+  }
+})

--- a/e2e/auth/specs/collaboration-roster-batching.spec.ts
+++ b/e2e/auth/specs/collaboration-roster-batching.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { agentMembersBatchRequestSchema } from '../../../src/shared/lib/agent-members-schema'
 
-test('sidebar rosters load and refresh together without per-agent requests', async ({ browser, page, baseURL }) => {
+test('sidebar rosters batch loads and pick up profile changes on reload', async ({ browser, page, baseURL }) => {
   const stamp = Date.now()
   const peer = await browser.newContext({ baseURL })
   try {
@@ -39,10 +39,13 @@ test('sidebar rosters load and refresh together without per-agent requests', asy
     expect(new Set(batches[0])).toEqual(new Set(slugs))
     expect(individual).toEqual([])
 
-    // The peer's profile hint invalidates all five active per-agent caches.
-    const refresh = page.waitForResponse(response => response.url().endsWith('/api/agents/members/batch'))
+    // Profile edits don't push roster refreshes; the next load reads the new data.
     expect((await peer.request.post('/api/auth/update-user', { headers: { Origin: baseURL! }, data: { name: 'Updated Roster Peer' } })).ok()).toBeTruthy()
-    expect((await refresh).ok()).toBeTruthy()
+    for (const slug of slugs) {
+      await expect(page.getByTestId(`sidebar-members-${slug}`).locator('[role="img"][aria-label="Roster Peer"]')).toBeVisible()
+    }
+    expect(batches).toHaveLength(1)
+    await page.reload()
     for (const slug of slugs) {
       await expect(page.getByTestId(`sidebar-members-${slug}`).locator('[role="img"][aria-label="Updated Roster Peer"]')).toBeVisible()
     }

--- a/e2e/specs/cmd-hint-navigation.spec.ts
+++ b/e2e/specs/cmd-hint-navigation.spec.ts
@@ -148,7 +148,7 @@ test.describe('Cmd-hold sidebar navigation hints', () => {
 
     await holdModifierForHints(page)
     try {
-      const badge = getAgentItem(page, agent).locator(HINT_BADGES)
+      const badge = page.locator('[data-sidebar="menu-button"]').filter({ has: getAgentItem(page, agent) }).locator(HINT_BADGES)
       await expect(badge).toBeVisible()
       const digit = hintNumber(await badge.getAttribute('data-testid'))
 
@@ -173,7 +173,7 @@ test.describe('Cmd-hold sidebar navigation hints', () => {
 
     await holdModifierForHints(page)
     try {
-      const agentBadge = getAgentItem(page, agent).locator(HINT_BADGES)
+      const agentBadge = page.locator('[data-sidebar="menu-button"]').filter({ has: getAgentItem(page, agent) }).locator(HINT_BADGES)
       await expect(agentBadge).toBeVisible()
       const agentDigit = hintNumber(await agentBadge.getAttribute('data-testid'))
 

--- a/src/api/middleware/auth.ts
+++ b/src/api/middleware/auth.ts
@@ -1,5 +1,5 @@
 import type { Context, Next, MiddlewareHandler } from 'hono'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { runWithOptionalUser, runWithRequestUser } from '@shared/lib/platform-attribution'
 import { db } from '@shared/lib/db'
@@ -140,6 +140,16 @@ function resolvedAgentSlug(c: Context): string {
   return (c.get('agentId' as never) as string | undefined) ?? c.req.param('id')!
 }
 
+/** AgentRead's policy for a collection of already-resolved IDs, in one ACL query. */
+export function getReadableAgentIds(c: Context, agentIds: readonly string[]): Set<string> {
+  if (!isAuthMode()) return new Set(agentIds)
+  const user = getUser(c)
+  if (isAdmin(user)) return new Set(agentIds)
+  if (!agentIds.length) return new Set()
+  const rows = db.select({ agentSlug: agentAcl.agentSlug, role: agentAcl.role }).from(agentAcl)
+    .where(and(eq(agentAcl.userId, user.id), inArray(agentAcl.agentSlug, [...agentIds]))).all()
+  return new Set(rows.filter(row => hasMinRole(row.role, 'viewer')).map(row => row.agentSlug))
+}
 
 /**
  * AgentRead — user has any role on the agent (viewer+).

--- a/src/api/routes/agent-members.integration.test.ts
+++ b/src/api/routes/agent-members.integration.test.ts
@@ -73,6 +73,24 @@ describe('authorized agent roster', () => {
     for (const name of ['owner', 'admin']) expect((await get(name, 'access')).status).toBe(200)
   })
 
+  it('sends a membership change when a removed deployment admin retains access', async () => {
+    const { agentAcl } = await import('@shared/lib/db/schema')
+    db.db.insert(agentAcl).values({ id: randomUUID(), userId: people.admin.id, agentSlug, role: 'viewer', createdAt: new Date() }).run()
+    const received: CollaborationEvent[] = []
+    const stop = events.subscribeCollaborationEvents(people.admin.id, (event) => { received.push(event) })
+    try {
+      db.sqlite.prepare('DELETE FROM agent_acl WHERE agent_slug = ? AND user_id = ?').run(agentSlug, people.admin.id)
+      service.notifyAgentMembersChanged(agentSlug, people.admin.id)
+      expect(received).toEqual([{ type: 'agent_members_changed', agentSlug }])
+      expect((await get('admin')).status).toBe(200)
+      expect((await get('admin', 'access')).status).toBe(200)
+      expect(service.listAgentMembers(agentSlug).some((member) => member.id === people.admin.id)).toBe(false)
+    } finally {
+      stop()
+      db.sqlite.prepare('DELETE FROM agent_acl WHERE agent_slug = ? AND user_id = ?').run(agentSlug, people.admin.id)
+    }
+  })
+
   it('scopes profile and membership hints and delivers revocation after removing access', async () => {
     const received = Object.fromEntries(Object.keys(people).map((name) => [name, [] as CollaborationEvent[]]))
     const stops = Object.keys(people).map((name) => events.subscribeCollaborationEvents(people[name].id, (event) => { received[name].push(event) }))

--- a/src/api/routes/agent-members.integration.test.ts
+++ b/src/api/routes/agent-members.integration.test.ts
@@ -1,0 +1,101 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { Hono } from 'hono'
+import { randomUUID } from 'node:crypto'
+import type { CollaborationEvent } from '@shared/lib/agent-members-schema'
+
+let directory: string
+let db: typeof import('@shared/lib/db')
+let authModule: typeof import('@shared/lib/auth')
+let service: typeof import('@shared/lib/services/agent-members-service')
+let events: typeof import('@shared/lib/services/collaboration-events')
+let app: Hono
+const agentSlug = '0123456789'
+const people: Record<string, { id: string; token: string }> = {}
+
+beforeAll(async () => {
+  directory = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-members-'))
+  fs.mkdirSync(path.join(directory, 'agents', agentSlug), { recursive: true })
+  fs.writeFileSync(path.join(directory, 'settings.json'), JSON.stringify({ auth: { signupMode: 'open', requireAdminApproval: false } }))
+  vi.stubEnv('SUPERAGENT_DATA_DIR', directory)
+  vi.stubEnv('AUTH_MODE', 'true')
+  vi.stubEnv('AUTH_PROVIDERS_JSON', '[]')
+  vi.stubEnv('BETTER_AUTH_SECRET', 'member-test-secret-0123456789abcdef0123456789abcdef')
+  db = await import('@shared/lib/db')
+  authModule = await import('@shared/lib/auth')
+  service = await import('@shared/lib/services/agent-members-service')
+  events = await import('@shared/lib/services/collaboration-events')
+  const { Authenticated, ResolveAgent, AgentAdmin } = await import('../middleware/auth')
+  const members = (await import('./agent-members')).default
+  app = new Hono()
+  app.use('/api/agents/:id/*', Authenticated(), ResolveAgent())
+  app.route('/api/agents/:id/members', members)
+  app.get('/api/agents/:id/access', AgentAdmin(), (c) => c.json({ management: true }))
+  for (const name of ['admin', 'owner', 'user', 'viewer', 'outsider']) {
+    const result = await authModule.getAuth().api.signUpEmail({ body: { name, email: `${name}@example.test`, password: 'MemberTesting123!' } })
+    people[name] = { id: result.user.id, token: result.token! }
+  }
+  const { agentAcl } = await import('@shared/lib/db/schema')
+  for (const [index, role] of ['owner', 'user', 'viewer'].entries()) {
+    db.db.insert(agentAcl).values({ id: randomUUID(), userId: people[role].id, agentSlug, role: role as 'owner' | 'user' | 'viewer', createdAt: new Date(index * 1000) }).run()
+  }
+})
+afterAll(() => {
+  authModule.resetAuth()
+  db.sqlite.close()
+  vi.unstubAllEnvs()
+  fs.rmSync(directory, { recursive: true, force: true })
+})
+function get(name: string | null, resource = 'members', slug = agentSlug) {
+  return app.request(`/api/agents/${slug}/${resource}`, name ? { headers: { authorization: `Bearer ${people[name].token}` } } : {})
+}
+
+describe('authorized agent roster', () => {
+  it('returns the same minimal, ordered roster for owners, users, viewers, and admins', async () => {
+    const override = '/api/profile/images/00000000-0000-4000-8000-000000000001.png'
+    db.sqlite.prepare('UPDATE user SET image = ?, avatar_override = ? WHERE id = ?').run('https://example.test/provider.png', override, people.viewer.id)
+    for (const name of ['owner', 'user', 'viewer', 'admin']) {
+      const response = await get(name, 'members', `launch-${agentSlug}`)
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual(['owner', 'user', 'viewer'].map((role) => ({
+        id: people[role].id, name: role, email: `${role}@example.test`, role, image: role === 'viewer' ? override : null,
+      })))
+    }
+  })
+
+  it('rejects unauthenticated, unrelated, and missing-agent reads without relaxing management permissions', async () => {
+    expect((await get(null)).status).toBe(401)
+    expect((await get('outsider')).status).toBe(403)
+    expect((await get('viewer', 'members', 'does-not-exist')).status).toBe(404)
+    for (const name of ['user', 'viewer', 'outsider']) expect((await get(name, 'access')).status).toBe(403)
+    for (const name of ['owner', 'admin']) expect((await get(name, 'access')).status).toBe(200)
+  })
+
+  it('scopes profile and membership hints and delivers revocation after removing access', async () => {
+    const received = Object.fromEntries(Object.keys(people).map((name) => [name, [] as CollaborationEvent[]]))
+    const stops = Object.keys(people).map((name) => events.subscribeCollaborationEvents(people[name].id, (event) => { received[name].push(event) }))
+    try {
+      service.notifyUserProfileChanged(people.viewer.id)
+      for (const name of ['owner', 'user', 'viewer']) expect(received[name]).toEqual([{ type: 'user_profile_changed', userId: people.viewer.id }])
+      expect(received.outsider).toEqual([])
+      expect(received.admin).toEqual([])
+      // A real Better Auth profile update uses the same audience.
+      await (await authModule.getAuth().$context).internalAdapter.updateUser(people.viewer.id, { name: 'Updated Viewer' })
+      expect(received.owner).toHaveLength(2)
+      db.sqlite.prepare('DELETE FROM agent_acl WHERE agent_slug = ? AND user_id = ?').run(agentSlug, people.viewer.id)
+      service.notifyAgentMembersChanged(agentSlug, people.viewer.id)
+      expect(received.owner.at(-1)).toEqual({ type: 'agent_members_changed', agentSlug })
+      expect(received.user.at(-1)).toEqual({ type: 'agent_members_changed', agentSlug })
+      expect(received.viewer.at(-1)).toEqual({ type: 'agent_access_revoked', agentSlug })
+      expect((await get('viewer')).status).toBe(403)
+      service.notifyUserProfileChanged(people.owner.id)
+      expect(received.viewer).toHaveLength(3)
+      expect(received.outsider).toEqual([])
+      expect(received.admin).toEqual([])
+    } finally {
+      stops.forEach((stop) => stop())
+    }
+  })
+})

--- a/src/api/routes/agent-members.integration.test.ts
+++ b/src/api/routes/agent-members.integration.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { Hono } from 'hono'
 import { randomUUID } from 'node:crypto'
 import Database from 'better-sqlite3'
+import { PNG } from 'pngjs'
 import { MAX_AGENT_MEMBERS_BATCH_SIZE, type CollaborationEvent } from '@shared/lib/agent-members-schema'
 import { persistedSettingsSchema } from '@shared/lib/config/settings-schema'
 
@@ -150,6 +151,29 @@ describe('authorized agent roster', () => {
     }
   })
 
+  it('reads updated profiles on the next roster request without broadcasting changes', async () => {
+    const { setAvatar } = await import('@shared/lib/services/profile-avatar-service')
+    const received: CollaborationEvent[] = []
+    const stops = Object.values(people).map(person => events.subscribeCollaborationEvents(person.id, event => { received.push(event) }))
+    const image = new PNG({ width: 4, height: 4 })
+    image.data.fill(160)
+    try {
+      await (await authModule.getAuth().$context).internalAdapter.updateUser(people.viewer.id, { name: 'Updated Viewer', image: 'https://example.test/new.png' })
+      const avatar = await setAvatar(people.viewer.id, PNG.sync.write(image))
+      expect(received).toEqual([])
+      const uploaded = await (await get('owner')).json()
+      expect(uploaded).toContainEqual(expect.objectContaining({ id: people.viewer.id, name: 'Updated Viewer', image: avatar }))
+      await setAvatar(people.viewer.id, null)
+      expect(received).toEqual([])
+      const restored = await (await batch('owner', [agentSlug, secondAgent])).json()
+      for (const slug of [agentSlug, secondAgent]) {
+        expect(restored[slug].members).toContainEqual(expect.objectContaining({ id: people.viewer.id, name: 'Updated Viewer', image: 'https://example.test/new.png' }))
+      }
+    } finally {
+      stops.forEach(stop => stop())
+    }
+  })
+
   it('sends a membership change when a removed deployment admin retains access', async () => {
     const { agentAcl } = await import('@shared/lib/db/schema')
     db.db.insert(agentAcl).values({ id: randomUUID(), userId: people.admin.id, agentSlug, role: 'viewer', createdAt: new Date() }).run()
@@ -168,27 +192,17 @@ describe('authorized agent roster', () => {
     }
   })
 
-  it('scopes profile and membership hints and delivers revocation after removing access', async () => {
+  it('scopes membership hints and delivers revocation after removing access', async () => {
     const received = Object.fromEntries(Object.keys(people).map((name) => [name, [] as CollaborationEvent[]]))
     const stops = Object.keys(people).map((name) => events.subscribeCollaborationEvents(people[name].id, (event) => { received[name].push(event) }))
     try {
-      service.notifyUserProfileChanged(people.viewer.id)
-      for (const name of ['owner', 'user', 'viewer']) expect(received[name]).toEqual([{ type: 'user_profile_changed', userId: people.viewer.id }])
-      expect(received.outsider).toEqual([])
-      expect(received.admin).toEqual([])
-      // A real Better Auth profile update uses the same audience.
-      await (await authModule.getAuth().$context).internalAdapter.updateUser(people.viewer.id, { name: 'Updated Viewer' })
-      expect(received.owner).toHaveLength(2)
       db.sqlite.prepare('DELETE FROM agent_acl WHERE agent_slug = ? AND user_id = ?').run(agentSlug, people.viewer.id)
       service.notifyAgentMembersChanged(agentSlug, people.viewer.id)
-      expect(received.owner.at(-1)).toEqual({ type: 'agent_members_changed', agentSlug })
-      expect(received.user.at(-1)).toEqual({ type: 'agent_members_changed', agentSlug })
-      expect(received.viewer.at(-1)).toEqual({ type: 'agent_access_revoked', agentSlug })
+      expect(received.owner).toEqual([{ type: 'agent_members_changed', agentSlug }])
+      expect(received.user).toEqual([{ type: 'agent_members_changed', agentSlug }])
+      expect(received.viewer).toEqual([{ type: 'agent_access_revoked', agentSlug }])
       expect((await get('viewer')).status).toBe(403)
       expect((await (await batch('viewer', [agentSlug, secondAgent])).json())[agentSlug]).toEqual({ status: 403 })
-      db.sqlite.prepare('DELETE FROM agent_acl WHERE agent_slug = ? AND user_id = ?').run(secondAgent, people.viewer.id)
-      service.notifyUserProfileChanged(people.owner.id)
-      expect(received.viewer).toHaveLength(3)
       expect(received.outsider).toEqual([])
       expect(received.admin).toEqual([])
     } finally {

--- a/src/api/routes/agent-members.integration.test.ts
+++ b/src/api/routes/agent-members.integration.test.ts
@@ -4,7 +4,9 @@ import os from 'node:os'
 import path from 'node:path'
 import { Hono } from 'hono'
 import { randomUUID } from 'node:crypto'
-import type { CollaborationEvent } from '@shared/lib/agent-members-schema'
+import Database from 'better-sqlite3'
+import { MAX_AGENT_MEMBERS_BATCH_SIZE, type CollaborationEvent } from '@shared/lib/agent-members-schema'
+import { persistedSettingsSchema } from '@shared/lib/config/settings-schema'
 
 let directory: string
 let db: typeof import('@shared/lib/db')
@@ -13,12 +15,17 @@ let service: typeof import('@shared/lib/services/agent-members-service')
 let events: typeof import('@shared/lib/services/collaboration-events')
 let app: Hono
 const agentSlug = '0123456789'
+const secondAgent = '9876543210'
+const privateAgent = 'private-agent'
+const emptyAgent = 'empty-agent'
 const people: Record<string, { id: string; token: string }> = {}
 
 beforeAll(async () => {
   directory = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-members-'))
-  fs.mkdirSync(path.join(directory, 'agents', agentSlug), { recursive: true })
-  fs.writeFileSync(path.join(directory, 'settings.json'), JSON.stringify({ auth: { signupMode: 'open', requireAdminApproval: false } }))
+  for (const slug of [agentSlug, secondAgent, privateAgent, emptyAgent]) {
+    fs.mkdirSync(path.join(directory, 'agents', slug), { recursive: true })
+  }
+  fs.writeFileSync(path.join(directory, 'settings.json'), JSON.stringify(persistedSettingsSchema.parse({ auth: { signupMode: 'open', requireAdminApproval: false } })))
   vi.stubEnv('SUPERAGENT_DATA_DIR', directory)
   vi.stubEnv('AUTH_MODE', 'true')
   vi.stubEnv('AUTH_PROVIDERS_JSON', '[]')
@@ -28,9 +35,11 @@ beforeAll(async () => {
   service = await import('@shared/lib/services/agent-members-service')
   events = await import('@shared/lib/services/collaboration-events')
   const { Authenticated, ResolveAgent, AgentAdmin } = await import('../middleware/auth')
-  const members = (await import('./agent-members')).default
+  const { default: members, agentMembersBatch } = await import('./agent-members')
   app = new Hono()
-  app.use('/api/agents/:id/*', Authenticated(), ResolveAgent())
+  app.use('/api/agents/*', Authenticated())
+  app.route('/api/agents/members/batch', agentMembersBatch)
+  app.use('/api/agents/:id/*', ResolveAgent())
   app.route('/api/agents/:id/members', members)
   app.get('/api/agents/:id/access', AgentAdmin(), (c) => c.json({ management: true }))
   for (const name of ['admin', 'owner', 'user', 'viewer', 'outsider']) {
@@ -41,6 +50,12 @@ beforeAll(async () => {
   for (const [index, role] of ['owner', 'user', 'viewer'].entries()) {
     db.db.insert(agentAcl).values({ id: randomUUID(), userId: people[role].id, agentSlug, role: role as 'owner' | 'user' | 'viewer', createdAt: new Date(index * 1000) }).run()
   }
+  db.db.insert(agentAcl).values([
+    { id: randomUUID(), userId: people.viewer.id, agentSlug: secondAgent, role: 'owner', createdAt: new Date(0) },
+    { id: randomUUID(), userId: people.owner.id, agentSlug: secondAgent, role: 'viewer', createdAt: new Date(1000) },
+    { id: randomUUID(), userId: people.outsider.id, agentSlug: privateAgent, role: 'owner', createdAt: new Date(0) },
+  ]).run()
+
 })
 afterAll(() => {
   authModule.resetAuth()
@@ -50,6 +65,15 @@ afterAll(() => {
 })
 function get(name: string | null, resource = 'members', slug = agentSlug) {
   return app.request(`/api/agents/${slug}/${resource}`, name ? { headers: { authorization: `Bearer ${people[name].token}` } } : {})
+}
+
+
+function batch(name: string | null, agentSlugs: string[]) {
+  return app.request('/api/agents/members/batch', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...(name ? { authorization: `Bearer ${people[name].token}` } : {}) },
+    body: JSON.stringify({ agentSlugs }),
+  })
 }
 
 describe('authorized agent roster', () => {
@@ -71,6 +95,59 @@ describe('authorized agent roster', () => {
     expect((await get('viewer', 'members', 'does-not-exist')).status).toBe(404)
     for (const name of ['user', 'viewer', 'outsider']) expect((await get(name, 'access')).status).toBe(403)
     for (const name of ['owner', 'admin']) expect((await get(name, 'access')).status).toBe(200)
+  })
+
+  it('batches authorized rosters and isolates forbidden or missing agents', async () => {
+    for (const name of ['owner', 'viewer', 'user', 'admin']) {
+      const response = await batch(name, [agentSlug, `launch-${secondAgent}`, privateAgent, 'missing', agentSlug])
+      expect(response.status).toBe(200)
+      const result = await response.json()
+      expect(Object.keys(result)).toHaveLength(4)
+      expect(result[agentSlug]).toEqual({ status: 200, members: await (await get(name)).json() })
+      expect(result[`launch-${secondAgent}`]).toEqual(name === 'user'
+        ? { status: 403 }
+        : { status: 200, members: await (await get(name, 'members', secondAgent)).json() })
+      expect(result[privateAgent]).toEqual(name === 'admin'
+        ? { status: 200, members: await (await get(name, 'members', privateAgent)).json() }
+        : { status: 403 })
+      expect(result.missing).toEqual({ status: 404 })
+    }
+    expect(await (await batch('outsider', [agentSlug, secondAgent])).json()).toEqual({
+      [agentSlug]: { status: 403 }, [secondAgent]: { status: 403 },
+    })
+    expect(await (await batch('admin', [emptyAgent])).json()).toEqual({ [emptyAgent]: { status: 200, members: [] } })
+  })
+
+  it('loads multiple rosters in two data queries with distinct per-agent roles and stable order', () => {
+    const prepare = vi.spyOn(Database.prototype, 'prepare')
+    try {
+      const result = service.listAgentMembersByAgent([agentSlug, secondAgent, emptyAgent, agentSlug])
+      expect(prepare).toHaveBeenCalledTimes(2) // One membership query and one shared user lookup.
+      expect(result[agentSlug].map(member => member.id)).toEqual([people.owner.id, people.user.id, people.viewer.id])
+      expect(result[secondAgent].map(member => [member.id, member.role])).toEqual([
+        [people.viewer.id, 'owner'], [people.owner.id, 'viewer'],
+      ])
+      expect(result[emptyAgent]).toEqual([])
+      expect(result[secondAgent][0].image).toBe(result[agentSlug][2].image)
+      prepare.mockClear()
+      expect(service.listAgentMembersByAgent([])).toEqual({})
+      expect(prepare).not.toHaveBeenCalled()
+    } finally {
+      prepare.mockRestore()
+    }
+  })
+
+  it('requires a session, limits batch size, and disables batch reads outside auth mode', async () => {
+    expect((await batch(null, [agentSlug])).status).toBe(401)
+    expect((await batch('owner', [])).status).toBe(400)
+    expect((await batch('owner', Array(MAX_AGENT_MEMBERS_BATCH_SIZE + 1).fill(agentSlug))).status).toBe(400)
+    expect((await batch('owner', ['a'.repeat(40_000)])).status).toBe(413)
+    vi.stubEnv('AUTH_MODE', 'false')
+    try {
+      expect((await batch(null, [agentSlug])).status).toBe(404)
+    } finally {
+      vi.stubEnv('AUTH_MODE', 'true')
+    }
   })
 
   it('sends a membership change when a removed deployment admin retains access', async () => {
@@ -108,6 +185,8 @@ describe('authorized agent roster', () => {
       expect(received.user.at(-1)).toEqual({ type: 'agent_members_changed', agentSlug })
       expect(received.viewer.at(-1)).toEqual({ type: 'agent_access_revoked', agentSlug })
       expect((await get('viewer')).status).toBe(403)
+      expect((await (await batch('viewer', [agentSlug, secondAgent])).json())[agentSlug]).toEqual({ status: 403 })
+      db.sqlite.prepare('DELETE FROM agent_acl WHERE agent_slug = ? AND user_id = ?').run(secondAgent, people.viewer.id)
       service.notifyUserProfileChanged(people.owner.id)
       expect(received.viewer).toHaveLength(3)
       expect(received.outsider).toEqual([])

--- a/src/api/routes/agent-members.ts
+++ b/src/api/routes/agent-members.ts
@@ -1,7 +1,11 @@
 import { Hono } from 'hono'
-import { AgentRead, getAgentId } from '../middleware/auth'
+import { AgentRead, getAgentId, getReadableAgentIds } from '../middleware/auth'
+import { bodyLimit } from 'hono/body-limit'
+import { zValidator } from '@hono/zod-validator'
+import { agentMembersBatchRequestSchema, agentMembersBatchResponseSchema } from '@shared/lib/agent-members-schema'
+import { resolveAgentId } from '@shared/lib/utils/file-storage'
 import { isAuthMode } from '@shared/lib/auth/mode'
-import { listAgentMembers } from '@shared/lib/services/agent-members-service'
+import { listAgentMembers, listAgentMembersByAgent } from '@shared/lib/services/agent-members-service'
 
 // Mounted after Authenticated() and ResolveAgent() in the agent router.
 const agentMembers = new Hono()
@@ -10,3 +14,21 @@ agentMembers.get('/', AgentRead(), (c) => {
   return c.json(listAgentMembers(getAgentId(c)))
 })
 export default agentMembers
+
+// Collection route: mounted after Authenticated(), before /:id/* resolution.
+export const agentMembersBatch = new Hono().post('/',
+  bodyLimit({ maxSize: 32 * 1024 }),
+  zValidator('json', agentMembersBatchRequestSchema),
+  async (c) => {
+    if (!isAuthMode()) return c.notFound()
+    const slugs = [...new Set(c.req.valid('json').agentSlugs)]
+    const resolved = await Promise.all(slugs.map(async slug => [slug, await resolveAgentId(slug)] as const))
+    const ids = [...new Set(resolved.flatMap(([, id]) => id ? [id] : []))]
+    const readable = getReadableAgentIds(c, ids)
+    const members = listAgentMembersByAgent([...readable])
+    return c.json(agentMembersBatchResponseSchema.parse(Object.fromEntries(resolved.map(([slug, id]) => [
+      slug,
+      !id ? { status: 404 } : !readable.has(id) ? { status: 403 } : { status: 200, members: members[id] },
+    ]))))
+  },
+)

--- a/src/api/routes/agent-members.ts
+++ b/src/api/routes/agent-members.ts
@@ -1,0 +1,12 @@
+import { Hono } from 'hono'
+import { AgentRead, getAgentId } from '../middleware/auth'
+import { isAuthMode } from '@shared/lib/auth/mode'
+import { listAgentMembers } from '@shared/lib/services/agent-members-service'
+
+// Mounted after Authenticated() and ResolveAgent() in the agent router.
+const agentMembers = new Hono()
+agentMembers.get('/', AgentRead(), (c) => {
+  if (!isAuthMode()) return c.notFound()
+  return c.json(listAgentMembers(getAgentId(c)))
+})
+export default agentMembers

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -1,3 +1,4 @@
+vi.mock('@shared/lib/services/agent-members-service', () => ({ notifyAgentMembersChanged: vi.fn(), listAgentMembers: vi.fn(() => []) }))
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Hono } from 'hono'
 import { runInNewContext } from 'node:vm'

--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -288,6 +288,13 @@ vi.mock('drizzle-orm', () => ({
   or: (...args: unknown[]) => args,
 }))
 
+vi.mock('@shared/lib/services/user-profile-service', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@shared/lib/services/user-profile-service')>(),
+  getUserSummaries: vi.fn(),
+  userExists: vi.fn(),
+}))
+import { getUserSummaries, userExists } from '@shared/lib/services/user-profile-service'
+
 // Auth
 const mockIsAuthMode = vi.fn().mockReturnValue(false)
 const mockInsertAuthor = vi.fn().mockResolvedValue(true)
@@ -649,6 +656,8 @@ function createApp() {
 }
 
 beforeEach(() => {
+  vi.mocked(getUserSummaries).mockReturnValue(new Map())
+  vi.mocked(userExists).mockReturnValue(true)
   mockAuthorizedAgentRole = 'owner'
   vi.mocked(sessionIsKnown).mockResolvedValue(true)
 })
@@ -2111,10 +2120,7 @@ describe('ACL — POST /:id/access (invite user)', () => {
   })
 
   it('returns 404 when target user does not exist', async () => {
-    // db.select().from(userTable).where().limit(1) → no user found
-    mockDbSelectFrom.mockReturnValueOnce({
-      where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) })),
-    })
+    vi.mocked(userExists).mockReturnValue(false)
 
     const res = await postJson(app, INVITE_URL, { userId: 'nonexistent', role: 'user' })
     expect(res.status).toBe(404)
@@ -2123,11 +2129,7 @@ describe('ACL — POST /:id/access (invite user)', () => {
   })
 
   it('returns 409 when user already has access', async () => {
-    // First query: user exists
-    mockDbSelectFrom.mockReturnValueOnce({
-      where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([{ id: 'user-1' }])) })),
-    })
-    // Second query: ACL entry already exists
+    // ACL entry already exists
     mockDbSelectFrom.mockReturnValueOnce({
       where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([{ id: 'acl-1' }])) })),
     })
@@ -2139,11 +2141,7 @@ describe('ACL — POST /:id/access (invite user)', () => {
   })
 
   it('returns 201 on successful invite', async () => {
-    // First query: user exists
-    mockDbSelectFrom.mockReturnValueOnce({
-      where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([{ id: 'user-1' }])) })),
-    })
-    // Second query: no existing ACL
+    // No existing ACL
     mockDbSelectFrom.mockReturnValueOnce({
       where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) })),
     })
@@ -2157,9 +2155,6 @@ describe('ACL — POST /:id/access (invite user)', () => {
   })
 
   it.each(['owner', 'user', 'viewer'])('accepts valid role: %s', async (role) => {
-    mockDbSelectFrom.mockReturnValueOnce({
-      where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([{ id: 'user-1' }])) })),
-    })
     mockDbSelectFrom.mockReturnValueOnce({
       where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) })),
     })
@@ -3987,36 +3982,40 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
     expect(mockDbSelectFrom).not.toHaveBeenCalled()
   })
 
-  it('annotates user messages with sender info in auth mode', async () => {
-    mockIsAuthMode.mockReturnValue(true)
-    mockTransformMessages.mockReturnValue([
-      { id: 'msg-1', type: 'user', content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
-      { id: 'msg-2', type: 'assistant', content: { text: 'hello' }, toolCalls: [], createdAt: new Date() },
-    ])
+  it.each(['', '?limit=2', '?after=previous'])(
+    'annotates user messages with sender info in auth mode (%s)', async (query) => {
+      mockIsAuthMode.mockReturnValue(true)
+      const messages = [
+        { id: 'msg-1', type: 'user' as const, content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
+        { id: 'msg-2', type: 'assistant' as const, content: { text: 'hello' }, toolCalls: [], createdAt: new Date() },
+      ]
+      mockTransformMessages.mockReturnValue(messages)
+      vi.mocked(getSessionMessagesPage).mockResolvedValue({ messages, nextCursor: null })
+      vi.mocked(getSessionMessagesDelta).mockResolvedValue({ messages, anchor: null })
 
-    // Mock the DB select chain for author lookup: db.select().from().innerJoin().where()
-    mockDbSelectFrom.mockReturnValue({
-      innerJoin: () => ({
-        where: () => Promise.resolve([
-          { messageId: 'msg-1', userId: 'user-1', userName: 'Alice', userEmail: 'alice@example.com', image: 'https://example.com/alice.png' },
-        ]),
-      }),
-    })
+      mockDbSelectFrom.mockReturnValue({
+        where: () => Promise.resolve([{ messageId: 'msg-1', userId: 'user-1' }]),
+      })
+      vi.mocked(getUserSummaries).mockReturnValue(new Map([['user-1', {
+        id: 'user-1', name: 'Alice', email: 'alice@example.com', image: 'https://example.com/alice.png',
+      }]]))
 
-    const res = await getReq(app, URL)
-    expect(res.status).toBe(200)
+      const res = await getReq(app, `${URL}${query}`)
+      expect(res.status).toBe(200)
 
-    const body = await res.json()
-    // User message should have sender
-    expect(body[0].sender).toEqual({
-      id: 'user-1',
-      name: 'Alice',
-      email: 'alice@example.com',
-      image: 'https://example.com/alice.png',
-    })
-    // Assistant message should not have sender
-    expect(body[1].sender).toBeUndefined()
-  })
+      const response = await res.json()
+      const body = query ? response.messages : response
+      // User message should have sender
+      expect(body[0].sender).toEqual({
+        id: 'user-1',
+        name: 'Alice',
+        email: 'alice@example.com',
+        image: 'https://example.com/alice.png',
+      })
+      // Assistant message should not have sender
+      expect(body[1].sender).toBeUndefined()
+    },
+  )
 
   it('handles sessions with no author records gracefully', async () => {
     mockIsAuthMode.mockReturnValue(true)
@@ -4025,11 +4024,7 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
     ])
 
     // DB returns no author records (messages from before feature was added)
-    mockDbSelectFrom.mockReturnValue({
-      innerJoin: () => ({
-        where: () => Promise.resolve([]),
-      }),
-    })
+    mockDbSelectFrom.mockReturnValue({ where: () => Promise.resolve([]) })
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(200)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1,4 +1,4 @@
-import agentMembers from './agent-members'
+import agentMembers, { agentMembersBatch } from './agent-members'
 import { notifyAgentMembersChanged } from '@shared/lib/services/agent-members-service'
 import { getUserSummaries, searchUserSummaries, toUserSender, userExists, type UserSenderSource } from '@shared/lib/services/user-profile-service'
 import { Hono, type Context } from 'hono'
@@ -903,6 +903,9 @@ export async function resolveInterruptedSubagents(
 const agents = new Hono()
 
 agents.use('*', Authenticated())
+
+// Collection roster reads must be mounted before /:id/* resolution.
+agents.route('/members/batch', agentMembersBatch)
 
 // ============================================================
 // Routes that must be registered BEFORE /:id middleware

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1,3 +1,5 @@
+import agentMembers from './agent-members'
+import { notifyAgentMembersChanged } from '@shared/lib/services/agent-members-service'
 import { getUserImage, type UserImageFields } from '@shared/lib/user-profile-schema'
 import { Hono, type Context } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
@@ -1570,6 +1572,8 @@ agents.put('/:id/preferences', AgentAdmin(), async (c) => {
 // Agent Access (ACL) endpoints
 // ============================================================
 
+agents.route('/:id/members', agentMembers)
+
 // GET /api/agents/:id/access - List users with roles on this agent
 agents.get('/:id/access', AgentAdmin(), async (c) => {
   try {
@@ -1635,6 +1639,7 @@ agents.post('/:id/access', AgentAdmin(), async (c) => {
       createdAt: new Date(),
     })
 
+    notifyAgentMembersChanged(slug)
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent_access', objectId: slug, action: 'granted', details: { targetUserId: userId, role } })
     return c.json({ ok: true }, 201)
   } catch (error) {
@@ -1688,6 +1693,7 @@ agents.patch('/:id/access/:userId', AgentAdmin(), async (c) => {
       const status = error.includes('does not have access') ? 404 : 400
       return c.json({ error }, status)
     }
+    notifyAgentMembersChanged(slug)
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent_access', objectId: slug, action: 'changed', details: { targetUserId: targetUserId, role } })
     return c.json({ ok: true })
   } catch (error) {
@@ -1735,6 +1741,7 @@ agents.delete('/:id/access/:userId', AgentAdmin(), async (c) => {
       const status = error.includes('does not have access') ? 404 : 400
       return c.json({ error }, status)
     }
+    notifyAgentMembersChanged(slug, targetUserId)
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent_access', objectId: slug, action: 'revoked', details: { targetUserId } })
     return c.body(null, 204)
   } catch (error) {
@@ -1779,6 +1786,7 @@ agents.post('/:id/leave', AgentRead(), async (c) => {
     if (error) {
       return c.json({ error }, 400)
     }
+    notifyAgentMembersChanged(slug, userId)
     logAuditEvent({ userId: getCurrentUserId(c), object: 'agent_access', objectId: slug, action: 'revoked', details: { targetUserId: userId } })
     return c.body(null, 204)
   } catch (error) {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1,6 +1,6 @@
 import agentMembers from './agent-members'
 import { notifyAgentMembersChanged } from '@shared/lib/services/agent-members-service'
-import { getUserImage, type UserImageFields } from '@shared/lib/user-profile-schema'
+import { getUserSummaries, searchUserSummaries, toUserSender, userExists, type UserSenderSource } from '@shared/lib/services/user-profile-service'
 import { Hono, type Context } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import { streamSSE } from 'hono/streaming'
@@ -118,8 +118,8 @@ import {
   listPendingWakesByAgent,
 } from '@shared/lib/services/scheduled-task-service'
 import { db } from '@shared/lib/db'
-import { connectedAccounts, agentConnectedAccounts, proxyAuditLog, remoteMcpServers, agentRemoteMcps, mcpAuditLog, agentAcl, user as userTable, messageAuthor, apiScopePolicies, mcpToolPolicies } from '@shared/lib/db/schema'
-import { eq, and, inArray, notInArray, desc, count, or, sql, type AnyColumn } from 'drizzle-orm'
+import { connectedAccounts, agentConnectedAccounts, proxyAuditLog, remoteMcpServers, agentRemoteMcps, mcpAuditLog, agentAcl, messageAuthor, apiScopePolicies, mcpToolPolicies } from '@shared/lib/db/schema'
+import { eq, and, inArray, desc, count } from 'drizzle-orm'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { getViewerUserId, ownerScope } from '@shared/lib/auth/ownership'
@@ -1583,15 +1583,14 @@ agents.get('/:id/access', AgentAdmin(), async (c) => {
         userId: agentAcl.userId,
         role: agentAcl.role,
         createdAt: agentAcl.createdAt,
-        userName: userTable.name,
-        userEmail: userTable.email,
-        image: userTable.image,
-        avatarOverride: userTable.avatarOverride,
       })
       .from(agentAcl)
-      .innerJoin(userTable, eq(agentAcl.userId, userTable.id))
       .where(eq(agentAcl.agentSlug, slug))
-    return c.json(rows.map(({ avatarOverride, ...row }) => ({ ...row, image: getUserImage({ ...row, avatarOverride }) })))
+    const profiles = getUserSummaries(rows.map(row => row.userId))
+    return c.json(rows.flatMap(row => {
+      const profile = profiles.get(row.userId)
+      return profile ? [{ ...row, userName: profile.name, userEmail: profile.email, image: profile.image }] : []
+    }))
   } catch (error) {
     console.error('Failed to fetch agent access:', error)
     return c.json({ error: 'Failed to fetch agent access' }, 500)
@@ -1612,12 +1611,7 @@ agents.post('/:id/access', AgentAdmin(), async (c) => {
     }
 
     // Check user exists
-    const [targetUser] = await db
-      .select({ id: userTable.id })
-      .from(userTable)
-      .where(eq(userTable.id, userId))
-      .limit(1)
-    if (!targetUser) {
+    if (!userExists(userId)) {
       return c.json({ error: 'User not found' }, 404)
     }
 
@@ -1811,26 +1805,7 @@ agents.get('/:id/access/search-users', AgentAdmin(), async (c) => {
 
     const excludeIds = existingUserIds.map((r) => r.userId)
 
-    // Search users by name or email (SQLite LIKE is case-insensitive by default)
-    // Escape LIKE wildcards to prevent pattern injection (e.g. searching "%"
-    // matching all users); the ESCAPE clause is required for the backslashes
-    // to act as escapes rather than literals.
-    const escaped = query ? query.replace(/[\\%_]/g, '\\$&') : ''
-    const matchesQuery = (column: AnyColumn) =>
-      sql`${column} LIKE ${`%${escaped}%`} ESCAPE '\\'`
-    const users = await db
-      .select({ id: userTable.id, name: userTable.name, email: userTable.email, image: userTable.image, avatarOverride: userTable.avatarOverride })
-      .from(userTable)
-      .where(
-        and(
-          // Exclude access holders in the WHERE so they don't eat limit slots
-          excludeIds.length ? notInArray(userTable.id, excludeIds) : undefined,
-          escaped ? or(matchesQuery(userTable.name), matchesQuery(userTable.email)) : undefined
-        )
-      )
-      .limit(50)
-
-    return c.json(users.map(({ avatarOverride, ...person }) => ({ ...person, image: getUserImage({ ...person, avatarOverride }) })))
+    return c.json(searchUserSummaries(query, excludeIds))
   } catch (error) {
     console.error('Failed to search users:', error)
     return c.json({ error: 'Failed to search users' }, 500)
@@ -2293,26 +2268,17 @@ async function annotateAndRecoverMessages(
     .select({
       messageId: messageAuthor.id,
       userId: messageAuthor.userId,
-      userName: userTable.name,
-      userEmail: userTable.email,
-      image: userTable.image,
-      avatarOverride: userTable.avatarOverride,
     })
     .from(messageAuthor)
-    .innerJoin(userTable, eq(messageAuthor.userId, userTable.id))
     .where(and(eq(messageAuthor.sessionId, sessionId), inArray(messageAuthor.id, userMessageIds)))
 
-  const authorMap = new Map(authors.map((a) => [a.messageId, a]))
+  const profiles = getUserSummaries(authors.map(author => author.userId))
+  const authorMap = new Map(authors.map(author => [author.messageId, profiles.get(author.userId)]))
   for (const msg of transformed) {
     if (msg.type !== 'user') continue
     const author = authorMap.get(msg.id)
     if (author) {
-      msg.sender = {
-        id: author.userId,
-        name: author.userName,
-        email: author.userEmail,
-        image: getUserImage(author),
-      }
+      msg.sender = author
     }
   }
 }
@@ -2478,27 +2444,18 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
           .select({
             messageId: messageAuthor.id,
             userId: messageAuthor.userId,
-            userName: userTable.name,
-            userEmail: userTable.email,
-            image: userTable.image,
-            avatarOverride: userTable.avatarOverride,
           })
           .from(messageAuthor)
-          .innerJoin(userTable, eq(messageAuthor.userId, userTable.id))
           .where(eq(messageAuthor.sessionId, sessionId))
 
-        const authorMap = new Map(authors.map((a) => [a.messageId, a]))
+        const profiles = getUserSummaries(authors.map(author => author.userId))
+        const authorMap = new Map(authors.map(author => [author.messageId, profiles.get(author.userId)]))
 
         for (const msg of transformed) {
           if (msg.type !== 'user') continue
           const author = authorMap.get(msg.id)
           if (author) {
-            msg.sender = {
-              id: author.userId,
-              name: author.userName,
-              email: author.userEmail,
-              image: getUserImage(author),
-            }
+            msg.sender = author
           }
         }
       }
@@ -2762,11 +2719,10 @@ async function persistAndBroadcastUserMessage(
     agentSlug: args.agentSlug,
     userId,
   })
-  const user = c.get('user' as never) as { id: string; name: string } & UserImageFields
   messagePersister.broadcastSessionEvent(args.agentSlug, args.sessionId, {
     type: 'user_message',
     content: args.content,
-    sender: { id: user.id, name: user.name, image: getUserImage(user) },
+    sender: toUserSender(c.get('user' as never) as UserSenderSource),
     uuid: args.messageUuid,
     queued: args.queued,
   })
@@ -2977,7 +2933,6 @@ agents.post('/:id/sessions/:sessionId/typing', AgentUser(), async (c) => {
   if (!isAuthMode()) return c.json({ ok: true })
 
   const sessionId = c.req.param('sessionId')
-  const user = c.get('user' as never) as { id: string; name: string } & UserImageFields
 
   // Otherwise this puts the caller's name in the typing indicator of a session
   // in someone else's agent.
@@ -2987,7 +2942,7 @@ agents.post('/:id/sessions/:sessionId/typing', AgentUser(), async (c) => {
 
   messagePersister.broadcastSessionEvent(getAgentId(c), sessionId, {
     type: 'user_typing',
-    sender: { id: user.id, name: user.name, image: getUserImage(user) },
+    sender: toUserSender(c.get('user' as never) as UserSenderSource),
   })
 
   return c.json({ ok: true })

--- a/src/api/routes/notifications.stream.test.ts
+++ b/src/api/routes/notifications.stream.test.ts
@@ -245,10 +245,10 @@ describe('collaboration hints over the existing stream', () => {
       for (const client of clients) expect(await client.waitForData('"type":"connected"')).toBe(true)
       collaborationEvents.publishCollaborationEvent(['owner'], { type: 'agent_members_changed', agentSlug: 'private-agent' })
       collaborationEvents.publishCollaborationEvent(['removed'], { type: 'agent_access_revoked', agentSlug: 'private-agent' })
-      collaborationEvents.publishCollaborationEvent(['unrelated'], { type: 'user_profile_changed', userId: 'unrelated' })
+      collaborationEvents.publishCollaborationEvent(['unrelated'], { type: 'agent_members_changed', agentSlug: 'unrelated-agent' })
       expect(await clients[0].waitForData('agent_members_changed')).toBe(true)
       expect(await clients[1].waitForData('agent_access_revoked')).toBe(true)
-      expect(await clients[2].waitForData('user_profile_changed')).toBe(true)
+      expect(await clients[2].waitForData('unrelated-agent')).toBe(true)
       expect(clients[2].received()).not.toContain('private-agent')
       expect(clients[0].received()).not.toContain('agent_access_revoked')
     } finally {

--- a/src/api/routes/notifications.stream.test.ts
+++ b/src/api/routes/notifications.stream.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono'
 import { serve } from '@hono/node-server'
 import http from 'node:http'
 import type { AddressInfo } from 'node:net'
+import type { Context } from 'hono'
+import * as collaborationEvents from '@shared/lib/services/collaboration-events'
 
 /**
  * The notifications SSE stream over a real HTTP listener.
@@ -18,12 +20,13 @@ import type { AddressInfo } from 'node:net'
 
 // Observable stand-in for the persister's global-client registry, with the
 // exact semantics of the real one (Set membership + unsubscribe deletes).
-const { globalClients, abortBeforeHandler } = vi.hoisted(() => ({
+const { globalClients, abortBeforeHandler, authMode } = vi.hoisted(() => ({
   globalClients: new Set<(data: unknown) => void>(),
   // When true, the streamSSE wrapper below aborts the stream BEFORE the
   // route's handler body runs — deterministically reproducing a client that
   // disconnected during handler setup, i.e. before onAbort is registered.
   abortBeforeHandler: { value: false },
+  authMode: { value: false },
 }))
 
 // Transparent pass-through around streamSSE, except it can pre-abort the
@@ -56,11 +59,11 @@ vi.mock('@shared/lib/container/message-persister', () => ({
   },
 }))
 
-vi.mock('@shared/lib/auth/mode', () => ({ isAuthMode: () => false }))
+vi.mock('@shared/lib/auth/mode', () => ({ isAuthMode: () => authMode.value }))
 
 // Auth middleware: no-op in tests
 vi.mock('../middleware/auth', () => ({
-  Authenticated: () => async (_c: unknown, next: () => Promise<void>) => next(),
+  Authenticated: () => async (c: Context, next: () => Promise<void>) => { c.set('user', { id: c.req.header('x-test-user') }); return next() },
   HasNotificationAccess: () => async (_c: unknown, next: () => Promise<void>) => next(),
 }))
 
@@ -121,6 +124,7 @@ afterAll(async () => {
 afterEach(() => {
   globalClients.clear()
   abortBeforeHandler.value = false
+  authMode.value = false
 })
 
 /** Poll until `predicate` holds or `timeoutMs` elapses. */
@@ -134,14 +138,14 @@ async function waitFor(predicate: () => boolean, timeoutMs = 3000): Promise<bool
 }
 
 /** Open the SSE endpoint over a real socket; resolves once bytes can be read. */
-function connectSSE(): Promise<{
+function connectSSE(userId = 'local'): Promise<{
   received: () => string
   destroy: () => void
   waitForData: (needle: string, timeoutMs?: number) => Promise<boolean>
 }> {
   return new Promise((resolve, reject) => {
     const req = http.get(
-      { host: '127.0.0.1', port, path: '/api/notifications/stream', headers: { Accept: 'text/event-stream' } },
+      { host: '127.0.0.1', port, path: '/api/notifications/stream', headers: { Accept: 'text/event-stream', 'x-test-user': userId } },
       (res) => {
         let buffer = ''
         res.on('data', (chunk: Buffer) => {
@@ -222,5 +226,35 @@ describe('GET /api/notifications/stream teardown', () => {
 
     expect(globalClients.size).toBe(0)
     expect(await waitFor(() => clearedKeepAlives.size === createdKeepAlives.size)).toBe(true)
+  })
+})
+
+
+describe('collaboration hints over the existing stream', () => {
+  it('delivers only to the targeted users and releases subscriptions on socket close', async () => {
+    authMode.value = true
+    const originalSubscribe = collaborationEvents.subscribeCollaborationEvents
+    const stops: ReturnType<typeof vi.fn>[] = []
+    const spy = vi.spyOn(collaborationEvents, 'subscribeCollaborationEvents').mockImplementation((...args) => {
+      const stop = vi.fn(originalSubscribe(...args))
+      stops.push(stop)
+      return stop
+    })
+    const clients = await Promise.all(['owner', 'removed', 'unrelated'].map((userId) => connectSSE(userId)))
+    try {
+      for (const client of clients) expect(await client.waitForData('"type":"connected"')).toBe(true)
+      collaborationEvents.publishCollaborationEvent(['owner'], { type: 'agent_members_changed', agentSlug: 'private-agent' })
+      collaborationEvents.publishCollaborationEvent(['removed'], { type: 'agent_access_revoked', agentSlug: 'private-agent' })
+      collaborationEvents.publishCollaborationEvent(['unrelated'], { type: 'user_profile_changed', userId: 'unrelated' })
+      expect(await clients[0].waitForData('agent_members_changed')).toBe(true)
+      expect(await clients[1].waitForData('agent_access_revoked')).toBe(true)
+      expect(await clients[2].waitForData('user_profile_changed')).toBe(true)
+      expect(clients[2].received()).not.toContain('private-agent')
+      expect(clients[0].received()).not.toContain('agent_access_revoked')
+    } finally {
+      clients.forEach((client) => client.destroy())
+      expect(await waitFor(() => stops.length === 3 && stops.every((stop) => stop.mock.calls.length === 1))).toBe(true)
+      spy.mockRestore()
+    }
   })
 })

--- a/src/api/routes/notifications.ts
+++ b/src/api/routes/notifications.ts
@@ -1,3 +1,4 @@
+import { subscribeCollaborationEvents } from '@shared/lib/services/collaboration-events'
 /**
  * Notifications API Routes
  *
@@ -48,6 +49,7 @@ notificationsRouter.get('/stream', async (c) => {
   return streamSSE(c, async (stream) => {
     let pingInterval: ReturnType<typeof setInterval> | null = null
     let unsubscribe: (() => void) | null = null
+    let unsubscribeCollaboration: (() => void) | undefined
 
     try {
       // Subscribe to global notifications
@@ -70,6 +72,12 @@ notificationsRouter.get('/stream', async (c) => {
           console.error('Error sending global notification SSE:', error)
         }
       })
+
+      if (user) {
+        unsubscribeCollaboration = subscribeCollaborationEvents(user.id, async (data) => {
+          await stream.writeSSE({ data: JSON.stringify(data), event: 'message' })
+        })
+      }
 
       // Send initial connection message
       await stream.writeSSE({
@@ -102,6 +110,7 @@ notificationsRouter.get('/stream', async (c) => {
     } finally {
       if (pingInterval) clearInterval(pingInterval)
       if (unsubscribe) unsubscribe()
+      unsubscribeCollaboration?.()
     }
   })
 })

--- a/src/api/routes/profile.integration.test.ts
+++ b/src/api/routes/profile.integration.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { Hono } from 'hono'
 import { PNG } from 'pngjs'
 import { SignJWT } from 'jose'
+import Database from 'better-sqlite3'
 
 let directory: string
 let db: typeof import('@shared/lib/db')
@@ -73,6 +74,24 @@ describe('profile avatar API', () => {
     expect((await app.request('/api/profile/avatar', { method: 'DELETE', headers })).status).toBe(200)
     expect(db.sqlite.prepare('SELECT image, avatar_override FROM user').get()).toEqual({ image: 'https://example.com/provider.png', avatar_override: null })
     expect((await app.request(avatarOverride, { headers })).status).toBe(404)
+  })
+
+  it('validates uploaded image references with a covering index lookup', async () => {
+    const signedIn = await login()
+    const { avatarOverride } = await (await upload(signedIn.token!)).json()
+    const prepare = vi.spyOn(Database.prototype, 'prepare')
+    try {
+      expect((await app.request(avatarOverride, { headers: { authorization: `Bearer ${signedIn.token}` } })).status).toBe(200)
+      const lookup = prepare.mock.calls.find(([query]) => query.includes('where "user"."avatar_override" ='))?.[0]
+      expect(lookup).toBeDefined()
+      // Explain the actual image route query against the fully migrated DB.
+      const plan = db.sqlite.prepare(`EXPLAIN QUERY PLAN ${lookup!}`).all(avatarOverride, 1)
+      expect(plan).toEqual([expect.objectContaining({
+        detail: expect.stringContaining('USING COVERING INDEX user_avatar_override_idx'),
+      })])
+    } finally {
+      prepare.mockRestore()
+    }
   })
 
   it('removes the stored photo when the user is deleted', async () => {

--- a/src/api/routes/profile.ts
+++ b/src/api/routes/profile.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { Hono } from 'hono'
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { db } from '@shared/lib/db'
 import { user } from '@shared/lib/db/schema'
 import { bodyLimit } from 'hono/body-limit'
@@ -34,9 +34,10 @@ profile.delete('/avatar', async (c) => {
 profile.get('/images/:filename', async (c) => {
   const filename = avatarFilenameSchema.safeParse(c.req.param('filename'))
   if (!filename.success) return c.notFound()
-  const owner = db.select({ id: user.id }).from(user)
-    .where(eq(user.avatarOverride, `/api/profile/images/${filename.data}`)).get()
-  if (!owner) return c.notFound()
+  // Only check existence so the avatar index covers the entire lookup.
+  const activeAvatar = db.select({ exists: sql`1` }).from(user)
+    .where(eq(user.avatarOverride, `/api/profile/images/${filename.data}`)).limit(1).get()
+  if (!activeAvatar) return c.notFound()
   try {
     const bytes = await fs.readFile(path.join(avatarDirectory(), filename.data))
     c.header('Content-Type', 'image/png')

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -1,3 +1,5 @@
+import { AgentMemberStack } from '@renderer/components/agents/agent-member-stack'
+import { Plus } from 'lucide-react'
 
 import { useState, useRef, useMemo, useCallback, useEffect } from 'react'
 import { cn } from '@shared/lib/utils/cn'
@@ -96,7 +98,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
   }, [introStagger, setJustCreatedSlug])
   const startOnboardingSession = useStartOnboardingSession()
   const draftsStore = useDraftsStore()
-  const { canUseAgent, canAdminAgent } = useUser()
+  const { canUseAgent, canAdminAgent, isAuthMode, isAdmin } = useUser()
   const isViewOnly = !canUseAgent(agent.slug)
   const isOwner = canAdminAgent(agent.slug)
   const replacedDashboards = useMemo(
@@ -406,10 +408,18 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
                 />
               </div>
             </AgentContextMenu>
-            {/* Share (ACL + publish) lives on the header, not in settings. Owners
-                only; outside auth mode everyone is an owner and the popover
-                shows just the Publish pane. */}
-            {isOwner && <AgentSharePopover ref={shareRef} agentSlug={agent.slug} agentName={agent.name} />}
+            {isAuthMode ? (
+              <AgentMemberStack
+                agentSlug={agent.slug}
+                inviteControl={(isOwner || isAdmin) ? (
+                  <AgentSharePopover ref={shareRef} agentSlug={agent.slug} agentName={agent.name} trigger={
+                    <Button type="button" size="icon" variant="outline" className="h-8 w-8 shrink-0 rounded-full" aria-label="Share agent" title="Invite, publish, or export" data-testid="agent-share-button">
+                      <Plus className="h-4 w-4" />
+                    </Button>
+                  } />
+                ) : undefined}
+              />
+            ) : isOwner && <AgentSharePopover ref={shareRef} agentSlug={agent.slug} agentName={agent.name} />}
             {/* Three-dot = the same agent menu a right-click on the title (or
                 the sidebar row) opens, so the two never drift apart. A click
                 replays as a contextmenu event on the title's trigger, anchored

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -411,12 +411,12 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
             {isAuthMode ? (
               <AgentMemberStack
                 agentSlug={agent.slug}
-                inviteControl={(isOwner || isAdmin) ? (
-                  <AgentSharePopover ref={shareRef} agentSlug={agent.slug} agentName={agent.name} trigger={
+                renderShareControl={(isOwner || isAdmin) ? (isShared) => (
+                  <AgentSharePopover ref={shareRef} agentSlug={agent.slug} agentName={agent.name} trigger={isShared ? (
                     <Button type="button" size="icon" variant="outline" className="h-8 w-8 shrink-0 rounded-full bg-background ring-2 ring-background focus-visible:ring-ring" aria-label="Share agent" title="Invite, publish, or export" data-testid="agent-share-button">
                       <Plus className="h-4 w-4" />
                     </Button>
-                  } />
+                  ) : undefined} />
                 ) : undefined}
               />
             ) : isOwner && <AgentSharePopover ref={shareRef} agentSlug={agent.slug} agentName={agent.name} />}

--- a/src/renderer/components/agents/agent-home/agent-home.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.tsx
@@ -413,7 +413,7 @@ export function AgentHome({ agent, onSessionCreated }: AgentHomeProps) {
                 agentSlug={agent.slug}
                 inviteControl={(isOwner || isAdmin) ? (
                   <AgentSharePopover ref={shareRef} agentSlug={agent.slug} agentName={agent.name} trigger={
-                    <Button type="button" size="icon" variant="outline" className="h-8 w-8 shrink-0 rounded-full" aria-label="Share agent" title="Invite, publish, or export" data-testid="agent-share-button">
+                    <Button type="button" size="icon" variant="outline" className="h-8 w-8 shrink-0 rounded-full bg-background ring-2 ring-background focus-visible:ring-ring" aria-label="Share agent" title="Invite, publish, or export" data-testid="agent-share-button">
                       <Plus className="h-4 w-4" />
                     </Button>
                   } />

--- a/src/renderer/components/agents/agent-member-stack.test.tsx
+++ b/src/renderer/components/agents/agent-member-stack.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { AgentMember } from '@shared/lib/agent-members-schema'
+import { AgentMemberStack } from './agent-member-stack'
+import { useAgentMembers } from '@renderer/hooks/use-agent-members'
+
+vi.mock('@renderer/hooks/use-agent-members', () => ({ useAgentMembers: vi.fn() }))
+vi.mock('@renderer/lib/env', () => ({ getApiBaseUrl: () => '' }))
+afterEach(cleanup)
+const members: AgentMember[] = Array.from({ length: 8 }, (_, i) => ({ id: `member-${i}`, name: `Person ${i}`, email: `person-${i}@example.test`, image: null, role: i === 0 ? 'owner' : 'viewer' }))
+function roster(count: number) {
+  vi.mocked(useAgentMembers).mockReturnValue({ data: members.slice(0, count), isLoading: false, isError: false } as ReturnType<typeof useAgentMembers>)
+}
+
+describe('AgentMemberStack', () => {
+  it.each([0, 1, 5, 8])('fits a roster of %i without exposing an invite action to readers', (count) => {
+    roster(count)
+    render(<AgentMemberStack agentSlug="agent-one" />)
+    expect(screen.queryAllByTestId(/^agent-member-member-/)).toHaveLength(Math.min(count, 5))
+    expect(screen.queryByTestId('agent-members-overflow') !== null).toBe(count > 5)
+    expect(screen.queryByRole('button', { name: 'Share agent' })).toBeNull()
+  })
+
+  it('opens the full read-only roster from overflow and retains the separate invite control', () => {
+    roster(8)
+    render(<AgentMemberStack agentSlug="agent-one" inviteControl={<button>Share agent</button>} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Show all 8 members' }))
+    expect(screen.getAllByRole('listitem')).toHaveLength(8)
+    expect(screen.getByText('person-7@example.test')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Share agent' })).toBeTruthy()
+  })
+
+  it('shows a name and email on keyboard focus and touch/click', async () => {
+    roster(1)
+    render(<AgentMemberStack agentSlug="agent-one" />)
+    const face = screen.getByTestId('agent-member-member-0')
+    fireEvent.focus(face)
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('person-0@example.test')
+    fireEvent.blur(face)
+    fireEvent.click(face)
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Person 0')
+  })
+
+  it('offers retry when the roster fails rather than presenting an empty roster', () => {
+    const refetch = vi.fn()
+    vi.mocked(useAgentMembers).mockReturnValue({ data: undefined, isLoading: false, isError: true, refetch } as unknown as ReturnType<typeof useAgentMembers>)
+    render(<AgentMemberStack agentSlug="agent-one" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry members' }))
+    expect(refetch).toHaveBeenCalledOnce()
+    expect(screen.queryByText('No members')).toBeNull()
+  })
+})

--- a/src/renderer/components/agents/agent-member-stack.test.tsx
+++ b/src/renderer/components/agents/agent-member-stack.test.tsx
@@ -17,14 +17,14 @@ describe('AgentMemberStack', () => {
   it.each([0, 1, 5, 8])('fits a roster of %i without exposing an invite action to readers', (count) => {
     roster(count)
     render(<AgentMemberStack agentSlug="agent-one" />)
-    expect(screen.queryAllByTestId(/^agent-member-member-/)).toHaveLength(Math.min(count, 5))
+    expect(screen.queryAllByTestId(/^agent-member-member-/)).toHaveLength(count > 1 ? Math.min(count, 5) : 0)
     expect(screen.queryByTestId('agent-members-overflow') !== null).toBe(count > 5)
     expect(screen.queryByRole('button', { name: 'Share agent' })).toBeNull()
   })
 
   it('opens the full read-only roster from overflow and retains the separate invite control', () => {
     roster(8)
-    render(<AgentMemberStack agentSlug="agent-one" inviteControl={<button>Share agent</button>} />)
+    render(<AgentMemberStack agentSlug="agent-one" renderShareControl={() => <button>Share agent</button>} />)
     fireEvent.click(screen.getByRole('button', { name: 'Show all 8 members' }))
     expect(screen.getAllByRole('listitem')).toHaveLength(8)
     expect(screen.getByText('person-7@example.test')).toBeTruthy()
@@ -32,7 +32,7 @@ describe('AgentMemberStack', () => {
   })
 
   it('shows a name and email on keyboard focus and touch/click', async () => {
-    roster(1)
+    roster(2)
     render(<AgentMemberStack agentSlug="agent-one" />)
     const face = screen.getByTestId('agent-member-member-0')
     fireEvent.focus(face)

--- a/src/renderer/components/agents/agent-member-stack.tsx
+++ b/src/renderer/components/agents/agent-member-stack.tsx
@@ -1,0 +1,85 @@
+import { useState, type ReactNode } from 'react'
+import { Users } from 'lucide-react'
+import type { AgentMember } from '@shared/lib/agent-members-schema'
+import { useAgentMembers } from '@renderer/hooks/use-agent-members'
+import { UserAvatar } from '@renderer/components/ui/user-avatar'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/components/ui/tooltip'
+
+function MemberFace({ member, open, offset, onOpenChange }: {
+  member: AgentMember; open: boolean; offset: number; onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <Tooltip open={open} onOpenChange={onOpenChange} disableHoverableContent>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={`${member.name || member.email}, ${member.email}, ${member.role}`}
+          onClick={() => onOpenChange(true)}
+          className="group/member relative -ml-2 first:ml-0 flex h-8 w-8 shrink-0 items-center justify-center rounded-full hover:z-10 focus:z-10 focus-visible:outline-none"
+          data-testid={`agent-member-${member.id}`}
+        >
+          {/* Keep the hit areas stationary when spacing the faces. Moving the
+              buttons themselves can leave the pointer over the previous face. */}
+          <span className="pointer-events-none flex rounded-full ring-2 ring-background transition-transform duration-150 group-focus-visible/member:ring-ring motion-reduce:transition-none" style={{ transform: `translate(${offset}px, ${open ? -4 : 0}px)` }} data-testid="member-avatar-visual">
+            <UserAvatar user={member} size={28} />
+          </span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-[min(20rem,calc(100vw-2rem))] break-words">
+        <p className="font-medium">{member.name || member.email}</p>
+        <p className="text-xs opacity-80">{member.email}</p>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export function AgentMemberStack({ agentSlug, inviteControl }: { agentSlug: string; inviteControl?: ReactNode }) {
+  const { data: members, isLoading, isError, refetch } = useAgentMembers(agentSlug)
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const activeIndex = members?.findIndex((member) => member.id === activeId) ?? -1
+  return (
+    <div className="flex shrink-0 items-center gap-2" data-testid="agent-member-stack" role="group" aria-label="Agent members">
+      {isLoading ? <span role="status" className="text-xs text-muted-foreground">Loading members…</span>
+        : isError ? <button className="text-xs text-muted-foreground underline" onClick={() => void refetch()}>Retry members</button>
+        : members?.length ? (
+          <TooltipProvider delayDuration={150}>
+            <div className="flex items-center px-2 py-1">
+              {members.slice(0, 5).map((member, index) => (
+                <MemberFace
+                  key={member.id} member={member} open={activeId === member.id}
+                  offset={activeIndex < 0 || activeIndex === index ? 0 : index < activeIndex ? -8 : 8}
+                  onOpenChange={(open) => setActiveId((current) => open ? member.id : current === member.id ? null : current)}
+                />
+              ))}
+              {members.length > 5 && (
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <button type="button" className="relative ml-3 flex h-8 min-w-8 items-center justify-center rounded-full border bg-background px-1.5 text-xs font-medium hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" aria-label={`Show all ${members.length} members`} data-testid="agent-members-overflow">
+                      +{members.length - 5}
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent align="end" className="w-72 max-w-[calc(100vw-2rem)] p-2" data-testid="agent-members-list">
+                    <p className="px-2 py-1 text-xs font-medium">{members.length} members</p>
+                    <ul className="max-h-72 overflow-y-auto" aria-label="All agent members">
+                      {members.map((member) => (
+                        <li key={member.id} className="flex items-center gap-2 px-2 py-2">
+                          <UserAvatar user={member} />
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-xs font-medium">{member.name || member.email}</p>
+                            <p className="truncate text-[11px] text-muted-foreground">{member.email}</p>
+                          </div>
+                          <span className="text-[11px] capitalize text-muted-foreground">{member.role}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </PopoverContent>
+                </Popover>
+              )}
+            </div>
+          </TooltipProvider>
+        ) : <span className="flex items-center gap-1 text-xs text-muted-foreground"><Users className="h-4 w-4" />No members</span>}
+      {inviteControl}
+    </div>
+  )
+}

--- a/src/renderer/components/agents/agent-member-stack.tsx
+++ b/src/renderer/components/agents/agent-member-stack.tsx
@@ -1,5 +1,4 @@
 import { useState, type ReactNode } from 'react'
-import { Users } from 'lucide-react'
 import type { AgentMember } from '@shared/lib/agent-members-schema'
 import { useAgentMembers } from '@renderer/hooks/use-agent-members'
 import { UserAvatar } from '@renderer/components/ui/user-avatar'
@@ -34,15 +33,21 @@ function MemberFace({ member, open, offset, onOpenChange }: {
   )
 }
 
-export function AgentMemberStack({ agentSlug, inviteControl }: { agentSlug: string; inviteControl?: ReactNode }) {
+export function AgentMemberStack({ agentSlug, renderShareControl }: {
+  agentSlug: string
+  renderShareControl?: (isShared: boolean) => ReactNode
+}) {
   const { data: members, isLoading, isError, refetch } = useAgentMembers(agentSlug)
   const [activeId, setActiveId] = useState<string | null>(null)
   const activeIndex = members?.findIndex((member) => member.id === activeId) ?? -1
+  const isShared = (members?.length ?? 0) > 1
+  const shareControl = renderShareControl?.(isShared)
+  if (!isLoading && !isError && !isShared && !shareControl) return null
   return (
-    <div className="flex shrink-0 items-center px-2 py-1" data-testid="agent-member-stack" role="group" aria-label="Agent members">
-      {isLoading ? <span role="status" className="mr-4 text-xs text-muted-foreground">Loading members…</span>
-        : isError ? <button className="mr-4 text-xs text-muted-foreground underline" onClick={() => void refetch()}>Retry members</button>
-        : members?.length ? (
+    <div className={isShared ? "flex shrink-0 items-center px-2 py-1" : "flex shrink-0 items-center gap-2"} data-testid={isShared ? "agent-member-stack" : undefined} role={isShared ? "group" : undefined} aria-label={isShared ? "Agent members" : undefined}>
+      {isLoading ? <span role="status" className={isShared ? "mr-4 text-xs text-muted-foreground" : "text-xs text-muted-foreground"}>Loading members…</span>
+        : isError ? <button className={isShared ? "mr-4 text-xs text-muted-foreground underline" : "text-xs text-muted-foreground underline"} onClick={() => void refetch()}>Retry members</button>
+        : isShared && members ? (
           <TooltipProvider delayDuration={150}>
             {members.slice(0, 5).map((member, index) => (
               <MemberFace
@@ -76,10 +81,10 @@ export function AgentMemberStack({ agentSlug, inviteControl }: { agentSlug: stri
               </Popover>
             )}
           </TooltipProvider>
-        ) : <span className="mr-4 flex items-center gap-1 text-xs text-muted-foreground"><Users className="h-4 w-4" />No members</span>}
-      {inviteControl && (
-        <div className="relative -ml-2 first:ml-0 flex shrink-0 transition-transform duration-150 motion-reduce:transition-none hover:z-10 focus-within:z-10" style={{ transform: `translateX(${activeIndex < 0 ? 0 : 8}px)` }}>
-          {inviteControl}
+        ) : null}
+      {shareControl && (
+        <div className={isShared ? "relative -ml-2 first:ml-0 flex shrink-0 transition-transform duration-150 motion-reduce:transition-none hover:z-10 focus-within:z-10" : "flex shrink-0"} style={isShared ? { transform: `translateX(${activeIndex < 0 ? 0 : 8}px)` } : undefined}>
+          {shareControl}
         </div>
       )}
     </div>

--- a/src/renderer/components/agents/agent-member-stack.tsx
+++ b/src/renderer/components/agents/agent-member-stack.tsx
@@ -39,47 +39,49 @@ export function AgentMemberStack({ agentSlug, inviteControl }: { agentSlug: stri
   const [activeId, setActiveId] = useState<string | null>(null)
   const activeIndex = members?.findIndex((member) => member.id === activeId) ?? -1
   return (
-    <div className="flex shrink-0 items-center gap-2" data-testid="agent-member-stack" role="group" aria-label="Agent members">
-      {isLoading ? <span role="status" className="text-xs text-muted-foreground">Loading members…</span>
-        : isError ? <button className="text-xs text-muted-foreground underline" onClick={() => void refetch()}>Retry members</button>
+    <div className="flex shrink-0 items-center px-2 py-1" data-testid="agent-member-stack" role="group" aria-label="Agent members">
+      {isLoading ? <span role="status" className="mr-4 text-xs text-muted-foreground">Loading members…</span>
+        : isError ? <button className="mr-4 text-xs text-muted-foreground underline" onClick={() => void refetch()}>Retry members</button>
         : members?.length ? (
           <TooltipProvider delayDuration={150}>
-            <div className="flex items-center px-2 py-1">
-              {members.slice(0, 5).map((member, index) => (
-                <MemberFace
-                  key={member.id} member={member} open={activeId === member.id}
-                  offset={activeIndex < 0 || activeIndex === index ? 0 : index < activeIndex ? -8 : 8}
-                  onOpenChange={(open) => setActiveId((current) => open ? member.id : current === member.id ? null : current)}
-                />
-              ))}
-              {members.length > 5 && (
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <button type="button" className="relative ml-3 flex h-8 min-w-8 items-center justify-center rounded-full border bg-background px-1.5 text-xs font-medium hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" aria-label={`Show all ${members.length} members`} data-testid="agent-members-overflow">
-                      +{members.length - 5}
-                    </button>
-                  </PopoverTrigger>
-                  <PopoverContent align="end" className="w-72 max-w-[calc(100vw-2rem)] p-2" data-testid="agent-members-list">
-                    <p className="px-2 py-1 text-xs font-medium">{members.length} members</p>
-                    <ul className="max-h-72 overflow-y-auto" aria-label="All agent members">
-                      {members.map((member) => (
-                        <li key={member.id} className="flex items-center gap-2 px-2 py-2">
-                          <UserAvatar user={member} />
-                          <div className="min-w-0 flex-1">
-                            <p className="truncate text-xs font-medium">{member.name || member.email}</p>
-                            <p className="truncate text-[11px] text-muted-foreground">{member.email}</p>
-                          </div>
-                          <span className="text-[11px] capitalize text-muted-foreground">{member.role}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </PopoverContent>
-                </Popover>
-              )}
-            </div>
+            {members.slice(0, 5).map((member, index) => (
+              <MemberFace
+                key={member.id} member={member} open={activeId === member.id}
+                offset={activeIndex < 0 || activeIndex === index ? 0 : index < activeIndex ? -8 : 8}
+                onOpenChange={(open) => setActiveId((current) => open ? member.id : current === member.id ? null : current)}
+              />
+            ))}
+            {members.length > 5 && (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <button type="button" className="relative -ml-2 flex h-8 min-w-8 shrink-0 items-center justify-center rounded-full border bg-background px-1.5 text-xs font-medium ring-2 ring-background transition-transform duration-150 motion-reduce:transition-none hover:z-10 hover:bg-accent focus:z-10 focus-visible:outline-none focus-visible:ring-ring" style={{ transform: `translateX(${activeIndex < 0 ? 0 : 8}px)` }} aria-label={`Show all ${members.length} members`} data-testid="agent-members-overflow">
+                    +{members.length - 5}
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent align="end" className="w-72 max-w-[calc(100vw-2rem)] p-2" data-testid="agent-members-list">
+                  <p className="px-2 py-1 text-xs font-medium">{members.length} members</p>
+                  <ul className="max-h-72 overflow-y-auto" aria-label="All agent members">
+                    {members.map((member) => (
+                      <li key={member.id} className="flex items-center gap-2 px-2 py-2">
+                        <UserAvatar user={member} />
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-xs font-medium">{member.name || member.email}</p>
+                          <p className="truncate text-[11px] text-muted-foreground">{member.email}</p>
+                        </div>
+                        <span className="text-[11px] capitalize text-muted-foreground">{member.role}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </PopoverContent>
+              </Popover>
+            )}
           </TooltipProvider>
-        ) : <span className="flex items-center gap-1 text-xs text-muted-foreground"><Users className="h-4 w-4" />No members</span>}
-      {inviteControl}
+        ) : <span className="mr-4 flex items-center gap-1 text-xs text-muted-foreground"><Users className="h-4 w-4" />No members</span>}
+      {inviteControl && (
+        <div className="relative -ml-2 first:ml-0 flex shrink-0 transition-transform duration-150 motion-reduce:transition-none hover:z-10 focus-within:z-10" style={{ transform: `translateX(${activeIndex < 0 ? 0 : 8}px)` }}>
+          {inviteControl}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/components/agents/agent-share-popover.tsx
+++ b/src/renderer/components/agents/agent-share-popover.tsx
@@ -1,5 +1,7 @@
+import { useAgentMembers } from '@renderer/hooks/use-agent-members'
+import type { AgentMember } from '@shared/lib/agent-members-schema'
 import { UserAvatar } from '@renderer/components/ui/user-avatar'
-import { forwardRef, useEffect, useImperativeHandle, useState, useRef } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useState, useRef, type ReactNode } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiFetch } from '@renderer/lib/api'
 import { useUser } from '@renderer/context/user-context'
@@ -52,15 +54,6 @@ import {
 } from 'lucide-react'
 import type { AgentRole } from '@shared/lib/types/agent'
 
-interface AccessEntry {
-  userId: string
-  role: AgentRole
-  createdAt: string
-  userName: string
-  userEmail: string
-  image?: string | null
-}
-
 interface SearchUser {
   id: string
   name: string
@@ -71,6 +64,7 @@ interface SearchUser {
 interface AgentSharePopoverProps {
   agentSlug: string
   agentName: string
+  trigger?: ReactNode
 }
 
 /** Imperative surface: lets the agent menu's "Export Agent" open this
@@ -192,7 +186,7 @@ function InviteEducationPane() {
  * becomes a disabled preview pointing at Cloud instead of disappearing.
  */
 export const AgentSharePopover = forwardRef<AgentSharePopoverHandle, AgentSharePopoverProps>(
-  function AgentSharePopover({ agentSlug, agentName }, ref) {
+  function AgentSharePopover({ agentSlug, agentName, trigger }, ref) {
   const queryClient = useQueryClient()
   const { user, isAuthMode } = useUser()
   const [open, setOpen] = useState(false)
@@ -244,21 +238,12 @@ export const AgentSharePopover = forwardRef<AgentSharePopoverHandle, AgentShareP
   }
 
   const invalidateAccess = () => {
-    queryClient.invalidateQueries({ queryKey: ['agent-access', agentSlug] })
+    queryClient.invalidateQueries({ queryKey: ['agent-members', agentSlug] })
     queryClient.invalidateQueries({ queryKey: ['agent-invite-candidates', agentSlug] })
     queryClient.invalidateQueries({ queryKey: ['my-agent-roles'] })
   }
 
-  // Fetch access list (only while open — the popover is mounted with the header)
-  const { data: accessList, isLoading } = useQuery<AccessEntry[]>({
-    queryKey: ['agent-access', agentSlug],
-    queryFn: async () => {
-      const res = await apiFetch(`/api/agents/${agentSlug}/access`)
-      if (!res.ok) throw new Error('Failed to fetch access list')
-      return res.json()
-    },
-    enabled: open && isAuthMode,
-  })
+  const { data: accessList, isLoading, isError: membersError, refetch: refetchMembers } = useAgentMembers(agentSlug, open)
 
   // The server caps results at 50 users, so client-side filtering alone can't
   // find everyone in a larger workspace — re-query with the typed text
@@ -359,7 +344,7 @@ export const AgentSharePopover = forwardRef<AgentSharePopoverHandle, AgentShareP
   const ownerCount = accessList?.filter((e) => e.role === 'owner').length ?? 0
 
   const selectedIds = new Set(selectedUsers.map((u) => u.id))
-  const accessIds = new Set(accessList?.map((e) => e.userId) ?? [])
+  const accessIds = new Set(accessList?.map((e) => e.id) ?? [])
   const filter = searchQuery.trim().toLowerCase()
   // Candidates are already ACL-filtered server-side; re-filter here so the list
   // updates instantly after an invite (before the refetch lands).
@@ -373,7 +358,7 @@ export const AgentSharePopover = forwardRef<AgentSharePopoverHandle, AgentShareP
   // section while searching.
   const matchedAccess = filter
     ? (accessList ?? []).filter(
-        (e) => e.userName.toLowerCase().includes(filter) || e.userEmail.toLowerCase().includes(filter)
+        (e) => e.name.toLowerCase().includes(filter) || e.email.toLowerCase().includes(filter)
       )
     : []
 
@@ -386,22 +371,22 @@ export const AgentSharePopover = forwardRef<AgentSharePopoverHandle, AgentShareP
   }
 
   // Shared by the default people list and the "Already shared with" section.
-  const renderAccessEntry = (entry: AccessEntry) => {
+  const renderAgentMember = (entry: AgentMember) => {
     const isLastOwner = entry.role === 'owner' && ownerCount <= 1
-    const isSelf = entry.userId === user?.id
+    const isSelf = entry.id === user?.id
     return (
       <div
-        key={entry.userId}
+        key={entry.id}
         className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-accent/50"
-        data-testid={`access-entry-${entry.userId}`}
+        data-testid={`access-entry-${entry.id}`}
       >
-        <UserAvatar user={{ id: entry.userId, name: entry.userName, image: entry.image }} />
+        <UserAvatar user={entry} />
         <div className="min-w-0 flex-1">
           <div className="truncate text-[11px]">
-            {entry.userName}
+            {entry.name}
             {isSelf && <span className="text-muted-foreground"> (You)</span>}
           </div>
-          <div className="truncate text-[11px] text-muted-foreground">{entry.userEmail}</div>
+          <div className="truncate text-[11px] text-muted-foreground">{entry.email}</div>
         </div>
         <TooltipProvider>
           <Tooltip>
@@ -413,15 +398,15 @@ export const AgentSharePopover = forwardRef<AgentSharePopoverHandle, AgentShareP
                   value={entry.role}
                   onValueChange={(role) => {
                     if (role === REMOVE_SENTINEL) {
-                      removeAccess.mutate(entry.userId)
+                      removeAccess.mutate(entry.id)
                     } else {
-                      changeRole.mutate({ userId: entry.userId, role: role as AgentRole })
+                      changeRole.mutate({ userId: entry.id, role: role as AgentRole })
                     }
                   }}
                 >
                   <SelectTrigger
                     className="h-7 w-auto shrink-0 gap-1 border-none bg-transparent px-1.5 text-[11px] text-muted-foreground shadow-none hover:text-foreground focus:ring-0 focus-visible:ring-1 focus-visible:ring-ring"
-                    data-testid={`access-role-${entry.userId}`}
+                    data-testid={`access-role-${entry.id}`}
                   >
                     <SelectValue>{ROLE_LABELS[entry.role]}</SelectValue>
                   </SelectTrigger>
@@ -434,7 +419,7 @@ export const AgentSharePopover = forwardRef<AgentSharePopoverHandle, AgentShareP
                       value={REMOVE_SENTINEL}
                       disabled={isLastOwner}
                       className="pr-8 text-[11px] text-destructive focus:text-destructive"
-                      data-testid={`access-remove-${entry.userId}`}
+                      data-testid={`access-remove-${entry.id}`}
                     >
                       Remove
                     </SelectItem>
@@ -463,7 +448,7 @@ export const AgentSharePopover = forwardRef<AgentSharePopoverHandle, AgentShareP
       }}
     >
       <PopoverTrigger asChild>
-        <Button
+        {trigger ?? <Button
           type="button"
           size="sm"
           variant="outline"
@@ -472,7 +457,7 @@ export const AgentSharePopover = forwardRef<AgentSharePopoverHandle, AgentShareP
           data-testid="agent-share-button"
         >
           Share
-        </Button>
+        </Button>}
       </PopoverTrigger>
       {/* 28rem = 448px, the `md` token — nearest to the 456px design width */}
       <PopoverContent
@@ -828,6 +813,10 @@ export const AgentSharePopover = forwardRef<AgentSharePopoverHandle, AgentShareP
             <div className="flex items-center justify-center py-6">
               <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
             </div>
+          ) : membersError ? (
+            <div className="px-2 py-4 text-center text-xs text-muted-foreground">
+              Could not load members. <button className="underline" onClick={() => void refetchMembers()}>Try again</button>
+            </div>
           ) : filter ? (
             <>
               {matchedAccess.length > 0 && (
@@ -835,7 +824,7 @@ export const AgentSharePopover = forwardRef<AgentSharePopoverHandle, AgentShareP
                   <p className="px-2 pb-1 pt-0.5 text-[11px] text-muted-foreground">
                     Already shared with
                   </p>
-                  {matchedAccess.map(renderAccessEntry)}
+                  {matchedAccess.map(renderAgentMember)}
                 </>
               )}
               {suggested.length > 0 && (
@@ -889,7 +878,7 @@ export const AgentSharePopover = forwardRef<AgentSharePopoverHandle, AgentShareP
               <p className="px-2 pb-1 pt-0.5 text-[11px] text-muted-foreground">
                 Members with access
               </p>
-              {accessList.map(renderAccessEntry)}
+              {accessList.map(renderAgentMember)}
             </>
           )}
         </div>

--- a/src/renderer/components/agents/sidebar-member-indicator.test.tsx
+++ b/src/renderer/components/agents/sidebar-member-indicator.test.tsx
@@ -70,6 +70,20 @@ describe('SidebarMemberIndicator', () => {
     expect(within(screen.getByRole('dialog')).queryByRole('button')).toBeNull()
   })
 
+  it('keeps the first roster open when pressing Invite blurs the avatar trigger', () => {
+    user.canAdminAgent.mockReturnValue(true)
+    render(<SidebarMemberIndicator {...props} />)
+    const trigger = screen.getByRole('button', { name: '6 members of Shared Agent' })
+    fireEvent.focus(trigger)
+    const invite = screen.getByRole('button', { name: 'Invite' })
+    fireEvent.pointerDown(invite)
+    fireEvent.blur(trigger, { relatedTarget: null })
+    expect(screen.getByRole('dialog')).toBeVisible()
+    expect(invite).toBeInTheDocument()
+    fireEvent.click(invite)
+    expect(screen.getByRole('dialog')).toBeVisible()
+  })
+
   it('counts the overflow circle toward the configurable limit', () => {
     const { rerender } = render(<SidebarMemberIndicator {...props} maxFaces={1} />)
     const trigger = screen.getByRole('button', { name: '6 members of Shared Agent' })

--- a/src/renderer/components/agents/sidebar-member-indicator.test.tsx
+++ b/src/renderer/components/agents/sidebar-member-indicator.test.tsx
@@ -55,9 +55,10 @@ describe('SidebarMemberIndicator', () => {
 
   it.each([
     { count: 3, faces: 3, overflow: null },
-    { count: 4, faces: 2, overflow: '+2' },
-    { count: 6, faces: 2, overflow: '+4' },
-  ])('represents a $count-member team within three circles', ({ count, faces, overflow }) => {
+    { count: 4, faces: 4, overflow: null },
+    { count: 5, faces: 3, overflow: '+2' },
+    { count: 6, faces: 3, overflow: '+3' },
+  ])('represents a $count-member team within four circles', ({ count, faces, overflow }) => {
     roster(members.slice(0, count))
     render(<SidebarMemberIndicator {...props} memberCount={count} />)
     const trigger = screen.getByRole('button', { name: `${count} members of Shared Agent` })

--- a/src/renderer/components/agents/sidebar-member-indicator.test.tsx
+++ b/src/renderer/components/agents/sidebar-member-indicator.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import type { AgentMember } from '@shared/lib/agent-members-schema'
+import { useAgentMembers } from '@renderer/hooks/use-agent-members'
+import { SidebarMemberIndicator } from './sidebar-member-indicator'
+
+vi.mock('@renderer/hooks/use-agent-members', () => ({ useAgentMembers: vi.fn() }))
+vi.mock('@renderer/hooks/use-mobile', () => ({ useIsMobile: () => false }))
+vi.mock('@renderer/lib/env', () => ({ getApiBaseUrl: () => '' }))
+
+const members: AgentMember[] = Array.from({ length: 6 }, (_, i) => ({
+  id: `member-${i}`, name: `Person ${i}`, email: `person-${i}@example.test`, image: null,
+  role: i === 0 ? 'owner' : 'viewer',
+}))
+const props = { agentSlug: 'shared-agent', agentName: 'Shared Agent', memberCount: 6 }
+const refetch = vi.fn()
+function roster(data: AgentMember[] | undefined, state = { isLoading: false, isError: false }) {
+  vi.mocked(useAgentMembers).mockReturnValue({ data, ...state, refetch } as unknown as ReturnType<typeof useAgentMembers>)
+}
+beforeEach(() => { vi.clearAllMocks(); roster(members) })
+afterEach(cleanup)
+
+describe('SidebarMemberIndicator', () => {
+  it.each([
+    { count: 3, faces: 3, overflow: null },
+    { count: 4, faces: 2, overflow: '+2' },
+    { count: 6, faces: 2, overflow: '+4' },
+  ])('represents a $count-member team within three circles', ({ count, faces, overflow }) => {
+    roster(members.slice(0, count))
+    render(<SidebarMemberIndicator {...props} memberCount={count} />)
+    const trigger = screen.getByRole('button', { name: `${count} members of Shared Agent` })
+    expect(within(trigger).getAllByRole('img', { hidden: true })).toHaveLength(faces)
+    if (overflow) expect(trigger).toHaveTextContent(overflow)
+    else expect(trigger).not.toHaveTextContent('+')
+    fireEvent.click(trigger)
+    expect(screen.getAllByRole('listitem')).toHaveLength(count)
+    expect(screen.getByText(`person-${count - 1}@example.test`)).toBeInTheDocument()
+    expect(within(screen.getByRole('dialog')).queryByRole('button')).toBeNull()
+  })
+
+  it('counts the overflow circle toward the configurable limit', () => {
+    const { rerender } = render(<SidebarMemberIndicator {...props} maxFaces={1} />)
+    const trigger = screen.getByRole('button', { name: '6 members of Shared Agent' })
+    expect(within(trigger).queryAllByRole('img', { hidden: true })).toHaveLength(0)
+    expect(trigger).toHaveTextContent('+6')
+    fireEvent.click(trigger)
+    rerender(<SidebarMemberIndicator {...props} maxFaces={4} />)
+    expect(within(trigger).getAllByRole('img', { hidden: true })).toHaveLength(3)
+    expect(trigger).toHaveTextContent('+3')
+    expect(screen.getAllByRole('listitem')).toHaveLength(6)
+  })
+
+  it('shows loading state and fills an already-open roster when members arrive', () => {
+    roster(undefined, { isLoading: true, isError: false })
+    const { rerender } = render(<SidebarMemberIndicator {...props} />)
+    fireEvent.click(screen.getByRole('button', { name: '6 members of Shared Agent' }))
+    expect(screen.getByRole('status')).toHaveTextContent('Loading members')
+    roster(members)
+    rerender(<SidebarMemberIndicator {...props} />)
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.getAllByRole('listitem')).toHaveLength(6)
+  })
+
+  it('allows a failed roster request to be retried', () => {
+    roster(undefined, { isLoading: false, isError: true })
+    render(<SidebarMemberIndicator {...props} />)
+    fireEvent.click(screen.getByRole('button', { name: '6 members of Shared Agent' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Retry members' }))
+    expect(refetch).toHaveBeenCalledOnce()
+    expect(screen.queryByRole('list')).toBeNull()
+  })
+
+  it('does not pass trigger activation to the sortable row', () => {
+    const startDrag = vi.fn()
+    render(<div role="button" tabIndex={0} aria-label="Drag agent" onPointerDown={startDrag} onKeyDown={startDrag}><SidebarMemberIndicator {...props} /></div>)
+    const trigger = screen.getByRole('button', { name: '6 members of Shared Agent' })
+    fireEvent.pointerDown(trigger)
+    fireEvent.keyDown(trigger, { key: ' ', code: 'Space' })
+    fireEvent.keyDown(trigger, { key: 'Enter', code: 'Enter' })
+    fireEvent.click(trigger)
+    expect(startDrag).not.toHaveBeenCalled()
+  })
+
+  it('updates an open roster and hides it when the agent becomes private', () => {
+    const { rerender } = render(<SidebarMemberIndicator {...props} />)
+    fireEvent.click(screen.getByRole('button', { name: '6 members of Shared Agent' }))
+    roster(members.slice(0, 3).map(member => member.id === 'member-1' ? { ...member, name: 'Updated Person' } : member))
+    rerender(<SidebarMemberIndicator {...props} />)
+    expect(screen.getByText('Updated Person')).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(3)
+    expect(screen.getByRole('button', { name: '3 members of Shared Agent' })).not.toHaveTextContent('+')
+    roster(members.slice(0, 1))
+    rerender(<SidebarMemberIndicator {...props} />)
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(screen.queryByRole('list')).toBeNull()
+  })
+})

--- a/src/renderer/components/agents/sidebar-member-indicator.test.tsx
+++ b/src/renderer/components/agents/sidebar-member-indicator.test.tsx
@@ -3,11 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import type { AgentMember } from '@shared/lib/agent-members-schema'
 import { useAgentMembers } from '@renderer/hooks/use-agent-members'
+import { AgentSharePopover } from './agent-share-popover'
 import { SidebarMemberIndicator } from './sidebar-member-indicator'
 
 vi.mock('@renderer/hooks/use-agent-members', () => ({ useAgentMembers: vi.fn() }))
 vi.mock('@renderer/hooks/use-mobile', () => ({ useIsMobile: () => false }))
 vi.mock('@renderer/lib/env', () => ({ getApiBaseUrl: () => '' }))
+vi.mock('./agent-share-popover', () => ({ AgentSharePopover: vi.fn(({ trigger }) => trigger) }))
+const user = { isAuthMode: true, isAdmin: false, canAdminAgent: vi.fn((_slug: string) => false) }
+vi.mock('@renderer/context/user-context', () => ({ useUser: () => user }))
 
 const members: AgentMember[] = Array.from({ length: 6 }, (_, i) => ({
   id: `member-${i}`, name: `Person ${i}`, email: `person-${i}@example.test`, image: null,
@@ -18,10 +22,37 @@ const refetch = vi.fn()
 function roster(data: AgentMember[] | undefined, state = { isLoading: false, isError: false }) {
   vi.mocked(useAgentMembers).mockReturnValue({ data, ...state, refetch } as unknown as ReturnType<typeof useAgentMembers>)
 }
-beforeEach(() => { vi.clearAllMocks(); roster(members) })
+beforeEach(() => {
+  vi.clearAllMocks()
+  user.isAuthMode = true
+  user.isAdmin = false
+  user.canAdminAgent.mockReturnValue(false)
+  roster(members)
+})
 afterEach(cleanup)
 
 describe('SidebarMemberIndicator', () => {
+  it.each([
+    { isAdmin: false, isOwner: true, canInvite: true },
+    { isAdmin: true, isOwner: false, canInvite: true },
+    { isAdmin: false, isOwner: false, canInvite: false },
+  ])('offers invitations for owner=$isOwner, admin=$isAdmin', ({ isAdmin, isOwner, canInvite }) => {
+    user.isAdmin = isAdmin
+    user.canAdminAgent.mockImplementation(slug => slug === props.agentSlug && isOwner)
+    render(<SidebarMemberIndicator {...props} />)
+    fireEvent.click(screen.getByRole('button', { name: '6 members of Shared Agent' }))
+    if (canInvite) {
+      expect(screen.getByRole('button', { name: 'Invite' })).toBeVisible()
+      expect(vi.mocked(AgentSharePopover).mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+        agentSlug: props.agentSlug,
+        agentName: props.agentName,
+      }))
+    } else {
+      expect(screen.queryByRole('button', { name: 'Invite' })).toBeNull()
+      expect(AgentSharePopover).not.toHaveBeenCalled()
+    }
+  })
+
   it.each([
     { count: 3, faces: 3, overflow: null },
     { count: 4, faces: 2, overflow: '+2' },

--- a/src/renderer/components/agents/sidebar-member-indicator.tsx
+++ b/src/renderer/components/agents/sidebar-member-indicator.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useRef, useState } from 'react'
+import { cn } from '@shared/lib/utils/cn'
+import { useAgentMembers } from '@renderer/hooks/use-agent-members'
+import { useIsMobile } from '@renderer/hooks/use-mobile'
+import { UserAvatar } from '@renderer/components/ui/user-avatar'
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
+
+const AVATAR_SIZE = 16
+const OVERFLOW_SIZE = 17
+
+/** A compact member stack with a read-only roster, independent of navigation. */
+export function SidebarMemberIndicator({ agentSlug, agentName, memberCount, maxFaces = 3, selected = false }: {
+  agentSlug: string
+  agentName: string
+  memberCount: number
+  /** Total circle limit, including the overflow circle when needed. */
+  maxFaces?: number
+  selected?: boolean
+}) {
+  const { data: members, isLoading, isError, refetch } = useAgentMembers(agentSlug, memberCount > 1)
+  const isMobile = useIsMobile()
+  const [open, setOpen] = useState(false)
+  const [pinned, setPinned] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const count = members?.length ?? memberCount
+  const circleLimit = Math.max(1, maxFaces)
+  const faces = members?.slice(0, count > circleLimit ? circleLimit - 1 : circleLimit) ?? []
+  const remaining = count - faces.length
+  const ringColor = selected ? 'ring-sidebar-accent' : 'ring-sidebar'
+
+  function clearTimer() {
+    if (timer.current !== null) clearTimeout(timer.current)
+    timer.current = null
+  }
+  function close() {
+    clearTimer()
+    setOpen(false)
+    setPinned(false)
+  }
+  function leave() {
+    clearTimer()
+    if (!pinned && document.activeElement !== triggerRef.current) {
+      timer.current = setTimeout(() => setOpen(false), 160)
+    }
+  }
+  useEffect(() => () => {
+    if (timer.current !== null) clearTimeout(timer.current)
+  }, [])
+
+  if (count < 2) return null
+
+  return (
+    <Popover open={open} onOpenChange={next => next ? setOpen(true) : close()}>
+      <PopoverTrigger asChild>
+        <button
+          ref={triggerRef}
+          type="button"
+          className="relative z-10 inline-flex h-7 shrink-0 items-center justify-center rounded-md outline-none transition-colors hover:bg-sidebar-accent focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+          aria-label={`${count} members of ${agentName}`}
+          data-testid={`sidebar-members-${agentSlug}`}
+          onPointerDown={event => event.stopPropagation()}
+          onKeyDown={event => {
+            // Keep the surrounding sortable row from treating roster activation
+            // as the beginning of a keyboard drag.
+            if (event.key === ' ' || event.key === 'Enter') event.stopPropagation()
+          }}
+          onPointerEnter={event => {
+            if (event.pointerType === 'touch' || event.buttons !== 0) return
+            clearTimer()
+            timer.current = setTimeout(() => setOpen(true), 180)
+          }}
+          onPointerLeave={leave}
+          onFocus={() => { clearTimer(); setOpen(true) }}
+          onBlur={event => {
+            if (!pinned && !contentRef.current?.contains(event.relatedTarget)) {
+              clearTimer()
+              setOpen(false)
+            }
+          }}
+          onClick={event => {
+            event.preventDefault()
+            clearTimer()
+            setOpen(!pinned)
+            setPinned(!pinned)
+          }}
+        >
+          <span aria-hidden="true" className="pointer-events-none flex items-center pl-0.5 pr-1">
+            {faces.map(member => (
+              <UserAvatar key={member.id} user={member} size={AVATAR_SIZE} className={cn('-ml-1 first:ml-0 ring-1', ringColor)} />
+            ))}
+            {remaining > 0 && (
+              <span
+                className={cn('relative -ml-1 first:ml-0 inline-flex shrink-0 items-center justify-center rounded-full bg-[color-mix(in_srgb,hsl(var(--sidebar-foreground))_15%,hsl(var(--sidebar-background)))] text-[8px] font-medium leading-none tabular-nums text-sidebar-foreground ring-1', ringColor)}
+                style={{ width: OVERFLOW_SIZE, height: OVERFLOW_SIZE }}
+              >+{remaining}</span>
+            )}
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        ref={contentRef}
+        align="start"
+        side={isMobile ? 'bottom' : 'right'}
+        sideOffset={12}
+        collisionPadding={12}
+        className="w-[304px] max-w-[calc(100vw-24px)] p-2"
+        aria-label={`${agentName} members`}
+        data-testid={`sidebar-members-list-${agentSlug}`}
+        onOpenAutoFocus={event => event.preventDefault()}
+        onCloseAutoFocus={event => event.preventDefault()}
+        onPointerEnter={clearTimer}
+        onPointerLeave={leave}
+      >
+        <p className="px-2 py-1.5 text-xs font-medium">{count} members</p>
+        {isLoading && <p role="status" className="px-2 py-3 text-xs text-muted-foreground">Loading members…</p>}
+        {isError && <button type="button" onClick={() => void refetch()} className="m-2 rounded text-xs text-muted-foreground underline outline-none focus-visible:ring-2 focus-visible:ring-ring">Retry members</button>}
+        {members && (
+          <ul className="max-h-80 overflow-y-auto" aria-label="All agent members">
+            {members.map(member => (
+              <li key={member.id} className="flex items-center gap-2 px-2 py-2">
+                <UserAvatar user={member} size={28} />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-xs font-medium">{member.name || member.email}</p>
+                  <p className="truncate text-[11px] text-muted-foreground">{member.email}</p>
+                </div>
+                <span className="text-[11px] capitalize text-muted-foreground">{member.role}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/components/agents/sidebar-member-indicator.tsx
+++ b/src/renderer/components/agents/sidebar-member-indicator.tsx
@@ -13,7 +13,7 @@ const AVATAR_SIZE = 16
 const OVERFLOW_SIZE = 17
 
 /** A compact member stack with roster and invite access, independent of navigation. */
-export function SidebarMemberIndicator({ agentSlug, agentName, memberCount, maxFaces = 3, selected = false }: {
+export function SidebarMemberIndicator({ agentSlug, agentName, memberCount, maxFaces = 4, selected = false }: {
   agentSlug: string
   agentName: string
   memberCount: number

--- a/src/renderer/components/agents/sidebar-member-indicator.tsx
+++ b/src/renderer/components/agents/sidebar-member-indicator.tsx
@@ -1,14 +1,18 @@
 import { useEffect, useRef, useState } from 'react'
+import { UserPlus } from 'lucide-react'
 import { cn } from '@shared/lib/utils/cn'
 import { useAgentMembers } from '@renderer/hooks/use-agent-members'
 import { useIsMobile } from '@renderer/hooks/use-mobile'
+import { useUser } from '@renderer/context/user-context'
+import { AgentSharePopover } from '@renderer/components/agents/agent-share-popover'
+import { Button } from '@renderer/components/ui/button'
 import { UserAvatar } from '@renderer/components/ui/user-avatar'
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover'
 
 const AVATAR_SIZE = 16
 const OVERFLOW_SIZE = 17
 
-/** A compact member stack with a read-only roster, independent of navigation. */
+/** A compact member stack with roster and invite access, independent of navigation. */
 export function SidebarMemberIndicator({ agentSlug, agentName, memberCount, maxFaces = 3, selected = false }: {
   agentSlug: string
   agentName: string
@@ -19,6 +23,8 @@ export function SidebarMemberIndicator({ agentSlug, agentName, memberCount, maxF
 }) {
   const { data: members, isLoading, isError, refetch } = useAgentMembers(agentSlug, memberCount > 1)
   const isMobile = useIsMobile()
+  const { isAuthMode, isAdmin, canAdminAgent } = useUser()
+  const canInvite = isAuthMode && (isAdmin || canAdminAgent(agentSlug))
   const [open, setOpen] = useState(false)
   const [pinned, setPinned] = useState(false)
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -41,7 +47,7 @@ export function SidebarMemberIndicator({ agentSlug, agentName, memberCount, maxF
   }
   function leave() {
     clearTimer()
-    if (!pinned && document.activeElement !== triggerRef.current) {
+    if (!pinned && document.activeElement !== triggerRef.current && !contentRef.current?.contains(document.activeElement)) {
       timer.current = setTimeout(() => setOpen(false), 160)
     }
   }
@@ -113,7 +119,31 @@ export function SidebarMemberIndicator({ agentSlug, agentName, memberCount, maxF
         onPointerEnter={clearTimer}
         onPointerLeave={leave}
       >
-        <p className="px-2 py-1.5 text-xs font-medium">{count} members</p>
+        <div className="flex items-center justify-between gap-2 px-2 py-1.5">
+          <p className="text-xs font-medium">{count} members</p>
+          {canInvite && (
+            <AgentSharePopover
+              agentSlug={agentSlug}
+              agentName={agentName}
+              trigger={(
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="outline"
+                  className="h-6 px-2 text-[11px] [&_svg]:size-3"
+                  data-testid={`sidebar-members-invite-${agentSlug}`}
+                  onClick={() => {
+                    clearTimer()
+                    setPinned(true)
+                  }}
+                >
+                  <UserPlus aria-hidden="true" />
+                  Invite
+                </Button>
+              )}
+            />
+          )}
+        </div>
         {isLoading && <p role="status" className="px-2 py-3 text-xs text-muted-foreground">Loading members…</p>}
         {isError && <button type="button" onClick={() => void refetch()} className="m-2 rounded text-xs text-muted-foreground underline outline-none focus-visible:ring-2 focus-visible:ring-ring">Retry members</button>}
         {members && (

--- a/src/renderer/components/agents/sidebar-member-indicator.tsx
+++ b/src/renderer/components/agents/sidebar-member-indicator.tsx
@@ -132,6 +132,11 @@ export function SidebarMemberIndicator({ agentSlug, agentName, memberCount, maxF
                   variant="outline"
                   className="h-6 px-2 text-[11px] [&_svg]:size-3"
                   data-testid={`sidebar-members-invite-${agentSlug}`}
+                  // Keep the roster mounted if the press blurs its trigger before click.
+                  onPointerDownCapture={() => {
+                    clearTimer()
+                    setPinned(true)
+                  }}
                   onClick={() => {
                     clearTimer()
                     setPinned(true)

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -75,6 +75,11 @@ vi.mock('@renderer/hooks/use-create-untitled-agent', () => ({
   }),
 }))
 
+const mockUseAgentMembers = vi.fn()
+vi.mock('@renderer/hooks/use-agent-members', () => ({
+  useAgentMembers: (...args: unknown[]) => mockUseAgentMembers(...args),
+}))
+
 const mockUseSessions = vi.fn()
 vi.mock('@renderer/hooks/use-sessions', () => ({
   useSessions: (slug: string | null) => mockUseSessions(slug),
@@ -169,7 +174,7 @@ const mockUserContext = {
   isAdmin: true,
   user: null,
   signOut: vi.fn(),
-  agentMemberCount: () => 1,
+  agentMemberCount: vi.fn((_slug: string) => 1),
 }
 vi.mock('@renderer/context/user-context', () => ({
   useUser: () => mockUserContext,
@@ -432,6 +437,10 @@ beforeEach(() => {
     data: slug === 'test-agent' ? [makeSession()] : [],
     isLoading: false,
   }))
+  mockUserContext.isAuthMode = false
+  mockUserContext.user = null
+  mockUserContext.agentMemberCount.mockReturnValue(1)
+  mockUseAgentMembers.mockReturnValue({ data: [], isLoading: false, isError: false })
   mockUnreadCount.mockReturnValue({ data: { count: 0 } })
   mockUserSettings.mockReturnValue({ setupCompleted: true, agentOrder: [] })
   delete mockRuntimeStatus.appVersion
@@ -573,6 +582,36 @@ describe('AppSidebar — layout & top nav', () => {
 })
 
 describe('AppSidebar — agent rows', () => {
+  it('keeps the member roster control beside the agent navigation link', () => {
+    mockUserContext.isAuthMode = true
+    mockUserContext.agentMemberCount.mockImplementation(slug => slug === 'test-agent' ? 4 : 1)
+    mockUseAgentMembers.mockReturnValue({
+      data: Array.from({ length: 4 }, (_, index) => ({ id: `member-${index}`, name: `Person ${index}`, email: `person-${index}@example.test`, image: null, role: 'viewer' })),
+      isLoading: false,
+      isError: false,
+    })
+    renderWithProviders(<AppSidebar />)
+    const link = screen.getByTestId('agent-item-test-agent')
+    const members = screen.getByRole('button', { name: '4 members of Test Agent' })
+    expect(link).not.toContainElement(members)
+    expect(link.parentElement).toContainElement(members)
+    expect(members).toHaveTextContent('+2')
+    expect(screen.queryByTestId('sidebar-members-other-agent')).toBeNull()
+    expect(mockUseAgentMembers).toHaveBeenCalledWith('test-agent', true)
+    expect(mockUseAgentMembers).not.toHaveBeenCalledWith('other-agent', expect.anything())
+  })
+
+  it.each([
+    { auth: true, count: 1 },
+    { auth: false, count: 4 },
+  ])('does not fetch sidebar rosters for auth=$auth and member count=$count', ({ auth, count }) => {
+    mockUserContext.isAuthMode = auth
+    mockUserContext.agentMemberCount.mockReturnValue(count)
+    renderWithProviders(<AppSidebar />)
+    expect(screen.queryByTestId('sidebar-members-test-agent')).toBeNull()
+    expect(mockUseAgentMembers).not.toHaveBeenCalled()
+  })
+
   it('renders agent rows', () => {
     renderWithProviders(<AppSidebar />)
     expect(screen.getByText('Test Agent')).toBeInTheDocument()

--- a/src/renderer/components/layout/app-sidebar.test.tsx
+++ b/src/renderer/components/layout/app-sidebar.test.tsx
@@ -12,7 +12,7 @@ if (typeof localStorage === 'undefined' || !localStorage) {
   Object.defineProperty(globalThis, 'localStorage', { value: stub, configurable: true })
 }
 import { cloneElement, isValidElement, type ReactElement } from 'react'
-import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { pointerWithin } from '@dnd-kit/core'
 import { AppSidebar } from './app-sidebar'
@@ -595,7 +595,8 @@ describe('AppSidebar — agent rows', () => {
     const members = screen.getByRole('button', { name: '4 members of Test Agent' })
     expect(link).not.toContainElement(members)
     expect(link.parentElement).toContainElement(members)
-    expect(members).toHaveTextContent('+2')
+    expect(within(members).getAllByRole('img', { hidden: true })).toHaveLength(4)
+    expect(members).not.toHaveTextContent('+')
     expect(screen.queryByTestId('sidebar-members-other-agent')).toBeNull()
     expect(mockUseAgentMembers).toHaveBeenCalledWith('test-agent', true)
     expect(mockUseAgentMembers).not.toHaveBeenCalledWith('other-agent', expect.anything())

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -1,5 +1,5 @@
 
-import { Bell, ChevronDown, ChevronLeft, ChevronRight, Cloud, Laptop, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, Users, Compass, MoonStar } from 'lucide-react'
+import { Bell, ChevronDown, ChevronLeft, ChevronRight, Cloud, Laptop, Plus, Search, Settings, AlertTriangle, LayoutGrid, SquareMousePointer, LogOut, Compass, MoonStar } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 import { toast } from 'sonner'
 import { cn } from '@shared/lib/utils/cn'
@@ -58,6 +58,7 @@ import { useRuntimeStatus } from '@renderer/hooks/use-runtime-status'
 import { usePlatformAuthStatus } from '@renderer/hooks/use-platform-auth'
 import { useCreateUntitledAgent } from '@renderer/hooks/use-create-untitled-agent'
 import { AgentStatus } from '@renderer/components/agents/agent-status'
+import { SidebarMemberIndicator } from '@renderer/components/agents/sidebar-member-indicator'
 import { WorkingDots, AwaitingDot } from '@renderer/components/agents/status-indicators'
 import { SIDEBAR_TREE_CONNECTORS } from '@renderer/components/ui/tree-connectors'
 import { AgentContextMenu } from '@renderer/components/agents/agent-context-menu'
@@ -460,7 +461,7 @@ const AgentMenuItemInner = React.forwardRef<
 >(({ agent, style, ...rest }, ref) => {
   useRenderTracker('AgentMenuItem')
   const { view } = useRouteLocation()
-  const { agentMemberCount } = useUser()
+  const { isAuthMode, agentMemberCount } = useUser()
   const queryClient = useQueryClient()
   // Route-derived selection (URL is authoritative — correct on a cold reload,
   // and inherently false on the global notifications/home views since they carry
@@ -497,7 +498,8 @@ const AgentMenuItemInner = React.forwardRef<
   }, [isViewingSubItem])
   const [showAll, setShowAll] = useState(false)
   const [showSkeleton, setShowSkeleton] = useState(false)
-  const isShared = agentMemberCount(agent.slug) > 1
+  const memberCount = agentMemberCount(agent.slug)
+  const isShared = isAuthMode && memberCount > 1
 
   // Lazy-load detail data only when expanded
   const { data: sessions, isLoading: sessionsLoading } = useSessions(isOpen ? agent.slug : null)
@@ -554,59 +556,65 @@ const AgentMenuItemInner = React.forwardRef<
 
   return (
     <Collapsible asChild open={isOpen && !isDragActive} onOpenChange={setIsOpen}>
-      <SidebarMenuItem ref={ref} style={style} {...rest} onMouseEnter={handleMouseEnter}>
-        {/*
-          Wrap the row + chevron in a relative box so the absolutely-positioned
-          chevron tracks the row height, not the (potentially expanded) menu
-          item that also contains CollapsibleContent below.
-        */}
-        <div
-          className={cn('relative rounded-md', SIDEBAR_FILE_DROP_CUE)}
-          {...dragHandlers}
-        >
-          <AgentContextMenu agent={agent}>
-            <SidebarMenuButton
-              asChild
-              isActive={isSelected}
-              className="justify-between pl-7"
-              data-testid={`agent-item-${agent.slug}`}
-            >
-              <AppLink ref={hintRef} to="/agents/$slug" params={{ slug: agent.displaySlug }}>
-                <span className="flex items-center gap-1.5 min-w-0">
-                  <span className="truncate text-[13px] font-normal text-sidebar-foreground">{agent.name}</span>
-                  {isShared && <Users className="h-3 w-3 shrink-0 text-muted-foreground" />}
-                </span>
+      <SidebarMenuItem
+        ref={ref}
+        style={style}
+        {...rest}
+        onMouseEnter={handleMouseEnter}
+        // Portaled menus bubble through React, but are outside the draggable row.
+        onPointerDown={event => {
+          if (event.currentTarget.contains(event.target as Node)) rest.onPointerDown?.(event)
+        }}
+        onKeyDown={event => {
+          if (event.currentTarget.contains(event.target as Node)) rest.onKeyDown?.(event)
+        }}
+      >
+        <AgentContextMenu agent={agent}>
+          <SidebarMenuButton
+            asChild
+            isActive={isSelected}
+            className={cn('relative gap-1.5 overflow-visible pl-7', SIDEBAR_FILE_DROP_CUE)}
+          >
+            <div {...dragHandlers}>
+              {/* Stretch the native link across the row; the roster and
+                  chevron sit above it as separate interactive controls. */}
+              <AppLink
+                ref={hintRef}
+                to="/agents/$slug"
+                params={{ slug: agent.displaySlug }}
+                data-testid={`agent-item-${agent.slug}`}
+                data-active={isSelected}
+                className="min-w-0 outline-none after:absolute after:inset-0 after:rounded-md focus-visible:after:ring-2 focus-visible:after:ring-sidebar-ring"
+              >
+                <span className="block truncate text-[13px] font-normal text-sidebar-foreground">{agent.name}</span>
+              </AppLink>
+              {isShared && <SidebarMemberIndicator agentSlug={agent.slug} agentName={agent.name} memberCount={memberCount} selected={isSelected} />}
+              <span className="ml-auto flex shrink-0 items-center">
                 {hint !== null ? (
                   <CmdHintBadge hint={hint} />
                 ) : (
                   <AgentRowIndicator agent={agent} sessions={sessions} isOpen={isOpen} />
                 )}
-              </AppLink>
-            </SidebarMenuButton>
-          </AgentContextMenu>
-          {/*
-            Sibling chevron button overlays its slot in the row so the row stays a
-            single <button> (no nested interactive controls). Only rendered when
-            there is expandable content so agents with no sessions or dashboards
-            do not show an empty chevron.
-          */}
-          {hasExpandableContent && (
-            <button
-              type="button"
-              onClick={handleChevronClick}
-              aria-label={isOpen ? 'Collapse' : 'Expand'}
-              aria-expanded={isOpen}
-              className="absolute left-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded focus-visible:ring-2 focus-visible:ring-sidebar-ring outline-none"
-            >
-              <ChevronRight
-                className={cn(
-                  'h-3.5 w-3.5 text-muted-foreground/60 transition-[color,transform] group-hover/menu-item:text-sidebar-foreground',
-                  isOpen && !isDragActive && 'rotate-90'
-                )}
-              />
-            </button>
-          )}
-        </div>
+              </span>
+              {hasExpandableContent && (
+                <button
+                  type="button"
+                  onClick={handleChevronClick}
+                  aria-label={isOpen ? 'Collapse' : 'Expand'}
+                  aria-expanded={isOpen}
+                  className="absolute left-1.5 top-1/2 z-10 -translate-y-1/2 p-0.5 rounded focus-visible:ring-2 focus-visible:ring-sidebar-ring outline-none"
+                >
+                  <ChevronRight
+                    className={cn(
+                      'h-3.5 w-3.5 text-muted-foreground/60 transition-[color,transform] group-hover/menu-item:text-sidebar-foreground',
+                      isOpen && !isDragActive && 'rotate-90'
+                    )}
+                  />
+                </button>
+              )}
+            </div>
+          </SidebarMenuButton>
+        </AgentContextMenu>
         {hasExpandableContent ? (
           <>
             <CollapsibleContent>

--- a/src/renderer/components/layout/app-sidebar.tsx
+++ b/src/renderer/components/layout/app-sidebar.tsx
@@ -589,13 +589,21 @@ const AgentMenuItemInner = React.forwardRef<
                 <span className="block truncate text-[13px] font-normal text-sidebar-foreground">{agent.name}</span>
               </AppLink>
               {isShared && <SidebarMemberIndicator agentSlug={agent.slug} agentName={agent.name} memberCount={memberCount} selected={isSelected} />}
-              <span className="ml-auto flex shrink-0 items-center">
+              {/* Expose the status title above the stretched link while keeping
+                  clicks (including modifier clicks) native agent navigation. */}
+              <AppLink
+                to="/agents/$slug"
+                params={{ slug: agent.displaySlug }}
+                tabIndex={-1}
+                aria-label={`Open ${agent.name}`}
+                className="relative z-10 ml-auto flex shrink-0 items-center"
+              >
                 {hint !== null ? (
                   <CmdHintBadge hint={hint} />
                 ) : (
                   <AgentRowIndicator agent={agent} sessions={sessions} isOpen={isOpen} />
                 )}
-              </span>
+              </AppLink>
               {hasExpandableContent && (
                 <button
                   type="button"

--- a/src/renderer/components/notifications/global-notification-handler.test.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.test.tsx
@@ -138,6 +138,34 @@ describe('GlobalNotificationHandler — pending-request SSE pathway', () => {
     Reflect.deleteProperty(document, 'visibilityState')
   })
 
+  it('invalidates the current roster on changes and rejects malformed hints', () => {
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+    render(<QueryClientProvider client={queryClient}><GlobalNotificationHandler /></QueryClientProvider>)
+    simulateSSEMessage(getLatestEventSource(), { type: 'agent_members_changed', agentSlug: 'shared-agent' })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['agent-members', 'shared-agent'] })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['my-agent-roles'] })
+    invalidate.mockClear()
+    simulateSSEMessage(getLatestEventSource(), { type: 'agent_members_changed', agentSlug: 42 })
+    expect(invalidate).not.toHaveBeenCalled()
+    simulateSSEMessage(getLatestEventSource(), { type: 'user_profile_changed', userId: 'peer' })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['agent-members'] })
+  })
+
+  it('drops revoked data, updates roles immediately, and leaves the active agent', async () => {
+    const { useRouteLocation } = await import('@renderer/router/use-route-location')
+    vi.mocked(useRouteLocation).mockReturnValue({ selectedAgentSlug: 'launch-0123456789', view: { kind: 'agent' } } as unknown as ReturnType<typeof useRouteLocation>)
+    queryClient.setQueryData(['agents'], [{ slug: '0123456789', displaySlug: 'launch-0123456789' }])
+    queryClient.setQueryData(['agent-members', '0123456789'], [{ id: 'peer' }])
+    queryClient.setQueryData(['agents', 'launch-0123456789'], { name: 'Private' })
+    queryClient.setQueryData(['my-agent-roles'], { '0123456789': { role: 'viewer' }, other: { role: 'user' } })
+    render(<QueryClientProvider client={queryClient}><GlobalNotificationHandler /></QueryClientProvider>)
+    await act(async () => simulateSSEMessage(getLatestEventSource(), { type: 'agent_access_revoked', agentSlug: '0123456789' }))
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/' })
+    expect(queryClient.getQueryData(['my-agent-roles'])).toEqual({ other: { role: 'user' } })
+    expect(queryClient.getQueryData(['agent-members', '0123456789'])).toBeUndefined()
+    expect(queryClient.getQueryData(['agents', 'launch-0123456789'])).toBeUndefined()
+  })
+
   it('user_request_created/resolved invalidate the unified store', () => {
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 

--- a/src/renderer/components/notifications/global-notification-handler.test.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.test.tsx
@@ -47,10 +47,24 @@ vi.mock('@renderer/router/use-route-location', () => ({
   useRouteLocation: vi.fn(() => ({ selectedAgentSlug: null, view: { kind: 'home' } })),
 }))
 
+const { mockSessionNotify, mockAuthState } = vi.hoisted(() => ({
+  mockSessionNotify: vi.fn(),
+  mockAuthState: { user: null as { id: string } | null },
+}))
+
+vi.mock('@renderer/lib/auth-client', () => ({
+  authClient: { $store: { notify: mockSessionNotify } },
+}))
+
+beforeEach(() => {
+  mockSessionNotify.mockClear()
+  mockAuthState.user = null
+})
+
 vi.mock('@renderer/context/user-context', () => ({
   useUser: () => ({
     isAuthMode: false,
-    user: null,
+    user: mockAuthState.user,
     canAccessAgent: () => true,
   }),
 }))
@@ -149,6 +163,15 @@ describe('GlobalNotificationHandler — pending-request SSE pathway', () => {
     expect(invalidate).not.toHaveBeenCalled()
     simulateSSEMessage(getLatestEventSource(), { type: 'user_profile_changed', userId: 'peer' })
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['agent-members'] })
+  })
+
+  it('refreshes the session for the signed-in user’s profile change only', () => {
+    mockAuthState.user = { id: 'current-user' }
+    render(<QueryClientProvider client={queryClient}><GlobalNotificationHandler /></QueryClientProvider>)
+    simulateSSEMessage(getLatestEventSource(), { type: 'user_profile_changed', userId: 'peer' })
+    expect(mockSessionNotify).not.toHaveBeenCalled()
+    simulateSSEMessage(getLatestEventSource(), { type: 'user_profile_changed', userId: 'current-user' })
+    expect(mockSessionNotify).toHaveBeenCalledExactlyOnceWith('$sessionSignal')
   })
 
   it('drops revoked data, updates roles immediately, and leaves the active agent', async () => {
@@ -903,7 +926,8 @@ describe('GlobalNotificationHandler — pending-request SSE pathway', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['my-agent-roles'] })
   })
 
-  it('SSE open invalidates agents and roles, including the first connect', () => {
+  it('only refreshes collaboration queries and the session on reconnect, not first open', () => {
+    mockAuthState.user = { id: 'current-user' }
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 
     render(
@@ -916,12 +940,18 @@ describe('GlobalNotificationHandler — pending-request SSE pathway', () => {
     es.onopen?.()
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['agents'] })
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['my-agent-roles'] })
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ['agent-members'] })
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ['agent-invite-candidates'] })
+    expect(mockSessionNotify).not.toHaveBeenCalled()
 
     invalidateSpy.mockClear()
     es.onerror?.()
     es.onopen?.()
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['agents'] })
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['my-agent-roles'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['agent-members'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['agent-invite-candidates'] })
+    expect(mockSessionNotify).toHaveBeenCalledExactlyOnceWith('$sessionSignal')
     // Mount and a browser-handled reconnect are not outages.
     expect(invalidateSpy).not.toHaveBeenCalledWith({ predicate: isRefetchableAfterOutage })
   })
@@ -966,6 +996,7 @@ describe('stream healing', () => {
   }
 
   it('error at readyState 2 reopens and the reopen refetches everything mounted except LLM-backed queries', async () => {
+    mockAuthState.user = { id: 'current-user' }
     renderHandler()
     expect(MockEventSource.instances).toHaveLength(1)
 
@@ -976,6 +1007,7 @@ describe('stream healing', () => {
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
     getLatestEventSource().onopen?.()
     expect(invalidateSpy).toHaveBeenCalledWith({ predicate: isRefetchableAfterOutage })
+    expect(mockSessionNotify).toHaveBeenCalledExactlyOnceWith('$sessionSignal')
     expect(isRefetchableAfterOutage({ queryKey: ['sessions', 'a1'] })).toBe(true)
     for (const key of ['agent-template-publish-info', 'agent-template-pr-info', 'skill-publish-info', 'skill-pr-info']) {
       expect(isRefetchableAfterOutage({ queryKey: [key, 'a1'] })).toBe(false)

--- a/src/renderer/components/notifications/global-notification-handler.test.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.test.tsx
@@ -47,24 +47,9 @@ vi.mock('@renderer/router/use-route-location', () => ({
   useRouteLocation: vi.fn(() => ({ selectedAgentSlug: null, view: { kind: 'home' } })),
 }))
 
-const { mockSessionNotify, mockAuthState } = vi.hoisted(() => ({
-  mockSessionNotify: vi.fn(),
-  mockAuthState: { user: null as { id: string } | null },
-}))
-
-vi.mock('@renderer/lib/auth-client', () => ({
-  authClient: { $store: { notify: mockSessionNotify } },
-}))
-
-beforeEach(() => {
-  mockSessionNotify.mockClear()
-  mockAuthState.user = null
-})
-
 vi.mock('@renderer/context/user-context', () => ({
   useUser: () => ({
     isAuthMode: false,
-    user: mockAuthState.user,
     canAccessAgent: () => true,
   }),
 }))
@@ -161,17 +146,6 @@ describe('GlobalNotificationHandler — pending-request SSE pathway', () => {
     invalidate.mockClear()
     simulateSSEMessage(getLatestEventSource(), { type: 'agent_members_changed', agentSlug: 42 })
     expect(invalidate).not.toHaveBeenCalled()
-    simulateSSEMessage(getLatestEventSource(), { type: 'user_profile_changed', userId: 'peer' })
-    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['agent-members'] })
-  })
-
-  it('refreshes the session for the signed-in user’s profile change only', () => {
-    mockAuthState.user = { id: 'current-user' }
-    render(<QueryClientProvider client={queryClient}><GlobalNotificationHandler /></QueryClientProvider>)
-    simulateSSEMessage(getLatestEventSource(), { type: 'user_profile_changed', userId: 'peer' })
-    expect(mockSessionNotify).not.toHaveBeenCalled()
-    simulateSSEMessage(getLatestEventSource(), { type: 'user_profile_changed', userId: 'current-user' })
-    expect(mockSessionNotify).toHaveBeenCalledExactlyOnceWith('$sessionSignal')
   })
 
   it('drops revoked data, updates roles immediately, and leaves the active agent', async () => {
@@ -926,8 +900,7 @@ describe('GlobalNotificationHandler — pending-request SSE pathway', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['my-agent-roles'] })
   })
 
-  it('only refreshes collaboration queries and the session on reconnect, not first open', () => {
-    mockAuthState.user = { id: 'current-user' }
+  it('only refreshes collaboration queries on reconnect, not first open', () => {
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 
     render(
@@ -942,7 +915,6 @@ describe('GlobalNotificationHandler — pending-request SSE pathway', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['my-agent-roles'] })
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ['agent-members'] })
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ['agent-invite-candidates'] })
-    expect(mockSessionNotify).not.toHaveBeenCalled()
 
     invalidateSpy.mockClear()
     es.onerror?.()
@@ -951,7 +923,6 @@ describe('GlobalNotificationHandler — pending-request SSE pathway', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['my-agent-roles'] })
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['agent-members'] })
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['agent-invite-candidates'] })
-    expect(mockSessionNotify).toHaveBeenCalledExactlyOnceWith('$sessionSignal')
     // Mount and a browser-handled reconnect are not outages.
     expect(invalidateSpy).not.toHaveBeenCalledWith({ predicate: isRefetchableAfterOutage })
   })
@@ -996,7 +967,6 @@ describe('stream healing', () => {
   }
 
   it('error at readyState 2 reopens and the reopen refetches everything mounted except LLM-backed queries', async () => {
-    mockAuthState.user = { id: 'current-user' }
     renderHandler()
     expect(MockEventSource.instances).toHaveLength(1)
 
@@ -1007,7 +977,6 @@ describe('stream healing', () => {
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
     getLatestEventSource().onopen?.()
     expect(invalidateSpy).toHaveBeenCalledWith({ predicate: isRefetchableAfterOutage })
-    expect(mockSessionNotify).toHaveBeenCalledExactlyOnceWith('$sessionSignal')
     expect(isRefetchableAfterOutage({ queryKey: ['sessions', 'a1'] })).toBe(true)
     for (const key of ['agent-template-publish-info', 'agent-template-pr-info', 'skill-publish-info', 'skill-pr-info']) {
       expect(isRefetchableAfterOutage({ queryKey: [key, 'a1'] })).toBe(false)

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -1,3 +1,7 @@
+import { collaborationEventSchema } from '@shared/lib/agent-members-schema'
+import { authClient } from '@renderer/lib/auth-client'
+import { resolveRouteAgentId } from '@renderer/hooks/use-agents'
+import type { ApiAgent } from '@shared/lib/types/api'
 /**
  * Global Notification Handler
  *
@@ -94,13 +98,17 @@ function isNotificationTypeEnabled(
 export function GlobalNotificationHandler() {
   useRenderTracker('GlobalNotificationHandler')
   const queryClient = useQueryClient()
-  const { view } = useRouteLocation()
+  const { view, selectedAgentSlug } = useRouteLocation()
   const navigate = useNavigate()
   const selectedSessionId = view.kind === 'session' ? view.id : null
   const { data: unreadData } = useUnreadNotificationCount()
   const { data: platformUnreadData } = usePlatformUnreadCount()
   const { data: userSettings } = useUserSettings()
-  const { canAccessAgent } = useUser()
+  const { canAccessAgent, user } = useUser()
+  const userIdRef = useRef(user?.id)
+  userIdRef.current = user?.id
+  const selectedAgentRef = useRef(selectedAgentSlug)
+  selectedAgentRef.current = selectedAgentSlug
   // Use refs to avoid recreating EventSource when reactive values change
   const selectedSessionIdRef = useRef(selectedSessionId)
   selectedSessionIdRef.current = selectedSessionId
@@ -255,6 +263,42 @@ export function GlobalNotificationHandler() {
         const data = JSON.parse(event.data)
 
         switch (data.type) {
+          case 'agent_members_changed':
+          case 'agent_access_revoked':
+          case 'user_profile_changed': {
+            const parsed = collaborationEventSchema.safeParse(data)
+            if (!parsed.success) break
+            const change = parsed.data
+            if (change.type === 'user_profile_changed') {
+              queryClient.invalidateQueries({ queryKey: ['agent-members'] })
+              queryClient.invalidateQueries({ queryKey: ['agent-invite-candidates'] })
+              if (change.userId === userIdRef.current) authClient.$store.notify('$sessionSignal')
+              break
+            }
+            if (change.type === 'agent_access_revoked') {
+              const activeSlug = selectedAgentRef.current
+              const activeId = resolveRouteAgentId(activeSlug ?? undefined, queryClient.getQueryData<ApiAgent[]>(['agents']))
+              if (activeId === change.agentSlug) void navigate({ to: '/' })
+              // Don't retain a revoked roster while refetches are in flight.
+              queryClient.setQueryData(['agent-members', change.agentSlug], [])
+              queryClient.setQueryData<Record<string, unknown>>(['my-agent-roles'], (roles) => {
+                if (!roles) return roles
+                const remaining = { ...roles }
+                delete remaining[change.agentSlug]
+                return remaining
+              })
+              const revokedQueries = { predicate: (query: { queryKey: readonly unknown[] }) =>
+                query.queryKey.includes(change.agentSlug) || (!!activeSlug && activeId === change.agentSlug && query.queryKey.includes(activeSlug)) }
+              void queryClient.cancelQueries(revokedQueries).then(() => queryClient.removeQueries(revokedQueries))
+            } else {
+              queryClient.invalidateQueries({ queryKey: ['agent-members', change.agentSlug] })
+              queryClient.invalidateQueries({ queryKey: ['agent-invite-candidates', change.agentSlug] })
+            }
+            queryClient.invalidateQueries({ queryKey: ['my-agent-roles'] })
+            queryClient.invalidateQueries({ queryKey: ['agents'] })
+            break
+          }
+
           case 'platform_notifications_changed': {
             // A platform notification INSERT arrived over Realtime — refresh
             // the proxy-live inbox + badge (there is no local copy to update).
@@ -632,6 +676,9 @@ export function GlobalNotificationHandler() {
       }
       queryClient.invalidateQueries({ queryKey: ['agents'] })
       queryClient.invalidateQueries({ queryKey: ['my-agent-roles'] })
+      queryClient.invalidateQueries({ queryKey: ['agent-members'] })
+      queryClient.invalidateQueries({ queryKey: ['agent-invite-candidates'] })
+      if (userIdRef.current) authClient.$store.notify('$sessionSignal')
     }
 
     es.onerror = () => {

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -120,6 +120,7 @@ export function GlobalNotificationHandler() {
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const reconnectAttemptRef = useRef(0)
   const wasDeadRef = useRef(false)
+  const hasConnectedRef = useRef(false)
   const streamRef = useRef<EventSource | null>(null)
 
   // Sync dock badge count with unread notifications (macOS Electron only)
@@ -663,10 +664,13 @@ export function GlobalNotificationHandler() {
       }
     }
 
-    // Catch up anything missed while the stream was down, including the
-    // window before the first successful connect.
+    // Agents and roles cover the window before the first connect. Rosters and
+    // the session are already loading on mount; only refresh them after a gap.
     es.onopen = () => {
+      const isReconnect = hasConnectedRef.current || wasDeadRef.current
+      hasConnectedRef.current = true
       reconnectAttemptRef.current = 0
+      if (isReconnect && userIdRef.current) authClient.$store.notify('$sessionSignal')
       if (wasDeadRef.current) {
         // The dead window can be arbitrarily long, and every family this
         // stream feeds may have moved in it. Refetch what is mounted.
@@ -676,9 +680,10 @@ export function GlobalNotificationHandler() {
       }
       queryClient.invalidateQueries({ queryKey: ['agents'] })
       queryClient.invalidateQueries({ queryKey: ['my-agent-roles'] })
-      queryClient.invalidateQueries({ queryKey: ['agent-members'] })
-      queryClient.invalidateQueries({ queryKey: ['agent-invite-candidates'] })
-      if (userIdRef.current) authClient.$store.notify('$sessionSignal')
+      if (isReconnect) {
+        queryClient.invalidateQueries({ queryKey: ['agent-members'] })
+        queryClient.invalidateQueries({ queryKey: ['agent-invite-candidates'] })
+      }
     }
 
     es.onerror = () => {

--- a/src/renderer/components/notifications/global-notification-handler.tsx
+++ b/src/renderer/components/notifications/global-notification-handler.tsx
@@ -1,5 +1,4 @@
 import { collaborationEventSchema } from '@shared/lib/agent-members-schema'
-import { authClient } from '@renderer/lib/auth-client'
 import { resolveRouteAgentId } from '@renderer/hooks/use-agents'
 import type { ApiAgent } from '@shared/lib/types/api'
 /**
@@ -104,9 +103,7 @@ export function GlobalNotificationHandler() {
   const { data: unreadData } = useUnreadNotificationCount()
   const { data: platformUnreadData } = usePlatformUnreadCount()
   const { data: userSettings } = useUserSettings()
-  const { canAccessAgent, user } = useUser()
-  const userIdRef = useRef(user?.id)
-  userIdRef.current = user?.id
+  const { canAccessAgent } = useUser()
   const selectedAgentRef = useRef(selectedAgentSlug)
   selectedAgentRef.current = selectedAgentSlug
   // Use refs to avoid recreating EventSource when reactive values change
@@ -265,17 +262,10 @@ export function GlobalNotificationHandler() {
 
         switch (data.type) {
           case 'agent_members_changed':
-          case 'agent_access_revoked':
-          case 'user_profile_changed': {
+          case 'agent_access_revoked': {
             const parsed = collaborationEventSchema.safeParse(data)
             if (!parsed.success) break
             const change = parsed.data
-            if (change.type === 'user_profile_changed') {
-              queryClient.invalidateQueries({ queryKey: ['agent-members'] })
-              queryClient.invalidateQueries({ queryKey: ['agent-invite-candidates'] })
-              if (change.userId === userIdRef.current) authClient.$store.notify('$sessionSignal')
-              break
-            }
             if (change.type === 'agent_access_revoked') {
               const activeSlug = selectedAgentRef.current
               const activeId = resolveRouteAgentId(activeSlug ?? undefined, queryClient.getQueryData<ApiAgent[]>(['agents']))
@@ -664,13 +654,12 @@ export function GlobalNotificationHandler() {
       }
     }
 
-    // Agents and roles cover the window before the first connect. Rosters and
-    // the session are already loading on mount; only refresh them after a gap.
+    // Agents and roles cover the window before the first connect. Rosters are
+    // already loading on mount; only refresh them after a gap.
     es.onopen = () => {
       const isReconnect = hasConnectedRef.current || wasDeadRef.current
       hasConnectedRef.current = true
       reconnectAttemptRef.current = 0
-      if (isReconnect && userIdRef.current) authClient.$store.notify('$sessionSignal')
       if (wasDeadRef.current) {
         // The dead window can be arbitrarily long, and every family this
         // stream feeds may have moved in it. Refetch what is mounted.

--- a/src/renderer/components/ui/app-link.tsx
+++ b/src/renderer/components/ui/app-link.tsx
@@ -19,6 +19,7 @@ type AppLinkProps = LinkProps & {
   onDoubleClick?: MouseEventHandler<HTMLAnchorElement>
   onKeyDown?: KeyboardEventHandler<HTMLAnchorElement>
   title?: string
+  tabIndex?: number
   draggable?: boolean
   'aria-label'?: string
   'data-testid'?: string

--- a/src/renderer/hooks/use-agent-members.test.tsx
+++ b/src/renderer/hooks/use-agent-members.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { apiFetch } from '@renderer/lib/api'
+import { loadAgentMembers } from '@renderer/lib/agent-members-loader'
+import { MAX_AGENT_MEMBERS_BATCH_SIZE } from '@shared/lib/agent-members-schema'
+import { useAgentMembers } from './use-agent-members'
+
+vi.mock('@renderer/lib/api', () => ({ apiFetch: vi.fn() }))
+vi.mock('@renderer/context/user-context', () => ({ useUser: () => ({ isAuthMode: true }) }))
+const member = { id: 'person', name: 'Ada', email: 'ada@example.test', image: null, role: 'owner' }
+const clients: QueryClient[] = []
+const response = (body: unknown) => new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } })
+
+function setup() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  clients.push(client)
+  const wrapper = ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  return { client, wrapper }
+}
+function fetchRoster(client: QueryClient, slug: string) {
+  return client.fetchQuery({ queryKey: ['agent-members', slug], queryFn: ({ signal }) => loadAgentMembers(client, slug, signal) })
+}
+function requestedBatches(): string[][] {
+  return vi.mocked(apiFetch).mock.calls.map(([, init]) => JSON.parse(init!.body as string).agentSlugs)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(apiFetch).mockImplementation(async (_url, init) => {
+    const { agentSlugs } = JSON.parse(init!.body as string) as { agentSlugs: string[] }
+    return response(Object.fromEntries(agentSlugs.map(slug => [slug, { status: 200, members: [member] }])))
+  })
+})
+afterEach(() => {
+  cleanup()
+  for (const client of clients.splice(0)) client.clear()
+})
+
+describe('batched roster queries', () => {
+  it('shares one request across rows and the header, and batches broad invalidations', async () => {
+    const { client, wrapper } = setup()
+    const { result } = renderHook(() => ({
+      first: useAgentMembers('first'),
+      second: useAgentMembers('second'),
+      header: useAgentMembers('first'),
+      privateAgent: useAgentMembers('private', false),
+    }), { wrapper })
+    await waitFor(() => expect(result.current.second.isSuccess).toBe(true))
+    expect(result.current.first.data).toEqual([member])
+    expect(result.current.header.data).toEqual([member])
+    expect(requestedBatches()).toEqual([['first', 'second']])
+    expect(vi.mocked(apiFetch).mock.calls[0][0]).toBe('/api/agents/members/batch')
+
+    await act(() => client.invalidateQueries({ queryKey: ['agent-members'] }))
+    expect(requestedBatches()).toEqual([['first', 'second'], ['first', 'second']])
+    await act(() => client.invalidateQueries({ queryKey: ['agent-members', 'second'] }))
+    expect(requestedBatches().at(-1)).toEqual(['second'])
+
+    renderHook(() => useAgentMembers('first'), { wrapper })
+    expect(apiFetch).toHaveBeenCalledTimes(3) // The fresh per-agent cache is reusable.
+  })
+
+  it('keeps an inaccessible roster from failing an authorized sibling', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(response({ first: { status: 200, members: [member] }, second: { status: 403 } }))
+    const { wrapper } = setup()
+    const { result } = renderHook(() => ({ first: useAgentMembers('first'), second: useAgentMembers('second') }), { wrapper })
+    await waitFor(() => expect(result.current.second.isError).toBe(true))
+    expect(result.current.first.data).toEqual([member])
+    expect(apiFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels a revoked roster without cancelling its sibling or restoring revoked cache data', async () => {
+    let finish!: (value: Response) => void
+    vi.mocked(apiFetch).mockImplementation(() => new Promise(resolve => { finish = resolve }))
+    const { client } = setup()
+    const revoked = fetchRoster(client, 'revoked').catch(() => undefined)
+    const kept = fetchRoster(client, 'kept')
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1))
+    await client.cancelQueries({ queryKey: ['agent-members', 'revoked'] })
+    client.removeQueries({ queryKey: ['agent-members', 'revoked'] })
+    expect(vi.mocked(apiFetch).mock.calls[0][1]?.signal?.aborted).toBe(false)
+    finish(response({ revoked: { status: 200, members: [member] }, kept: { status: 200, members: [member] } }))
+    await expect(kept).resolves.toEqual([member])
+    await revoked
+    expect(client.getQueryData(['agent-members', 'revoked'])).toBeUndefined()
+  })
+
+  it('aborts shared work on cache clear and excludes cancelled work before dispatch', async () => {
+    const { client } = setup()
+    const queued = fetchRoster(client, 'queued').catch(() => undefined)
+    client.clear()
+    await queued
+    await new Promise(resolve => setTimeout(resolve, 5))
+    expect(apiFetch).not.toHaveBeenCalled()
+
+    vi.mocked(apiFetch).mockImplementation((_url, init) => new Promise((_resolve, reject) => {
+      init!.signal!.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+    }))
+    const pending = [fetchRoster(client, 'first'), fetchRoster(client, 'second')].map(promise => promise.catch(() => undefined))
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1))
+    client.clear()
+    await Promise.all(pending)
+    expect(vi.mocked(apiFetch).mock.calls[0][1]?.signal?.aborted).toBe(true)
+    expect(client.getQueryCache().getAll()).toHaveLength(0)
+  })
+
+  it('keeps different query clients isolated', async () => {
+    const first = setup().client
+    const second = setup().client
+    await Promise.all([fetchRoster(first, 'first'), fetchRoster(second, 'second')])
+    expect(requestedBatches()).toEqual([['first'], ['second']])
+  })
+
+  it('splits large sidebars into bounded batches', async () => {
+    const { client } = setup()
+    await Promise.all(Array.from({ length: MAX_AGENT_MEMBERS_BATCH_SIZE + 1 }, (_, i) => fetchRoster(client, `agent-${i}`)))
+    expect(requestedBatches().map(batch => batch.length)).toEqual([MAX_AGENT_MEMBERS_BATCH_SIZE, 1])
+  })
+
+  it.each([{}, { first: { status: 200, members: [{ ...member, role: 'invalid' }] } }])(
+    'rejects missing or malformed batch results', async body => {
+      vi.mocked(apiFetch).mockResolvedValue(response(body))
+      const { client } = setup()
+      await expect(fetchRoster(client, 'first')).rejects.toThrow()
+      expect(client.getQueryData(['agent-members', 'first'])).toBeUndefined()
+    },
+  )
+
+  it('surfaces transport errors to all affected queries', async () => {
+    vi.mocked(apiFetch).mockRejectedValue(new Error('Network failed'))
+    const { client } = setup()
+    const results = await Promise.allSettled([fetchRoster(client, 'first'), fetchRoster(client, 'second')])
+    expect(results.every(result => result.status === 'rejected')).toBe(true)
+  })
+})

--- a/src/renderer/hooks/use-agent-members.ts
+++ b/src/renderer/hooks/use-agent-members.ts
@@ -1,18 +1,14 @@
-import { useQuery } from '@tanstack/react-query'
-import { apiFetch } from '@renderer/lib/api'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { loadAgentMembers } from '@renderer/lib/agent-members-loader'
 import { useUser } from '@renderer/context/user-context'
-import { agentMembersSchema } from '@shared/lib/agent-members-schema'
 
 /** Sidebar, header, and sharing pane reuse the same live roster per agent. */
 export function useAgentMembers(agentSlug: string, enabled = true) {
   const { isAuthMode } = useUser()
+  const queryClient = useQueryClient()
   return useQuery({
     queryKey: ['agent-members', agentSlug],
-    queryFn: async () => {
-      const response = await apiFetch(`/api/agents/${agentSlug}/members`)
-      if (!response.ok) throw new Error('Could not load members')
-      return agentMembersSchema.parse(await response.json())
-    },
+    queryFn: ({ signal }) => loadAgentMembers(queryClient, agentSlug, signal),
     enabled: isAuthMode && enabled,
     staleTime: 30_000,
   })

--- a/src/renderer/hooks/use-agent-members.ts
+++ b/src/renderer/hooks/use-agent-members.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@renderer/lib/api'
+import { useUser } from '@renderer/context/user-context'
+import { agentMembersSchema } from '@shared/lib/agent-members-schema'
+
+/** The header and sharing pane share one current-agent roster. */
+export function useAgentMembers(agentSlug: string, enabled = true) {
+  const { isAuthMode } = useUser()
+  return useQuery({
+    queryKey: ['agent-members', agentSlug],
+    queryFn: async () => {
+      const response = await apiFetch(`/api/agents/${agentSlug}/members`)
+      if (!response.ok) throw new Error('Could not load members')
+      return agentMembersSchema.parse(await response.json())
+    },
+    enabled: isAuthMode && enabled,
+    staleTime: 30_000,
+  })
+}

--- a/src/renderer/hooks/use-agent-members.ts
+++ b/src/renderer/hooks/use-agent-members.ts
@@ -3,7 +3,7 @@ import { apiFetch } from '@renderer/lib/api'
 import { useUser } from '@renderer/context/user-context'
 import { agentMembersSchema } from '@shared/lib/agent-members-schema'
 
-/** The header and sharing pane share one current-agent roster. */
+/** Sidebar, header, and sharing pane reuse the same live roster per agent. */
 export function useAgentMembers(agentSlug: string, enabled = true) {
   const { isAuthMode } = useUser()
   return useQuery({

--- a/src/renderer/lib/agent-members-loader.ts
+++ b/src/renderer/lib/agent-members-loader.ts
@@ -1,0 +1,88 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { apiFetch } from './api'
+import {
+  MAX_AGENT_MEMBERS_BATCH_SIZE,
+  agentMembersBatchResponseSchema,
+  type AgentMember,
+} from '@shared/lib/agent-members-schema'
+
+type PendingRoster = {
+  agentSlug: string
+  signal: AbortSignal
+  resolve: (members: AgentMember[]) => void
+  reject: (error: unknown) => void
+}
+
+async function fetchBatch(requests: PendingRoster[]) {
+  const controller = new AbortController()
+  const abortIfUnused = () => {
+    if (requests.every(request => request.signal.aborted)) controller.abort()
+  }
+  for (const request of requests) request.signal.addEventListener('abort', abortIfUnused)
+  try {
+    const response = await apiFetch('/api/agents/members/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentSlugs: requests.map(request => request.agentSlug) }),
+      signal: controller.signal,
+    })
+    if (!response.ok) throw new Error('Could not load members')
+    const results = agentMembersBatchResponseSchema.parse(await response.json())
+    for (const request of requests) {
+      if (request.signal.aborted) continue
+      const result = results[request.agentSlug]
+      if (result?.status === 200) request.resolve(result.members)
+      else request.reject(new Error(`Could not load members (${result?.status ?? 'missing result'})`))
+    }
+  } catch (error) {
+    for (const request of requests) request.reject(error)
+  } finally {
+    for (const request of requests) request.signal.removeEventListener('abort', abortIfUnused)
+  }
+}
+
+function createLoader() {
+  let pending: PendingRoster[] = []
+  let timer: ReturnType<typeof setTimeout> | undefined
+  return (agentSlug: string, signal: AbortSignal): Promise<AgentMember[]> => new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason)
+      return
+    }
+    const onAbort = () => reject(signal.reason)
+    signal.addEventListener('abort', onAbort, { once: true })
+    pending.push({
+      agentSlug,
+      signal,
+      resolve: members => {
+        signal.removeEventListener('abort', onAbort)
+        resolve(members)
+      },
+      reject: error => {
+        signal.removeEventListener('abort', onAbort)
+        reject(error)
+      },
+    })
+    // Collect the queries started by one render or cache invalidation together.
+    timer ??= setTimeout(() => {
+      const requests = pending.filter(request => !request.signal.aborted)
+      pending = []
+      timer = undefined
+      for (let start = 0; start < requests.length; start += MAX_AGENT_MEMBERS_BATCH_SIZE) {
+        void fetchBatch(requests.slice(start, start + MAX_AGENT_MEMBERS_BATCH_SIZE))
+      }
+    }, 0)
+  })
+}
+
+// Scope pending work to the cache. Query cancellation on sign-out/revocation
+// rejects just that roster; the shared fetch stops when all callers cancel.
+const loaders = new WeakMap<QueryClient, ReturnType<typeof createLoader>>()
+export function loadAgentMembers(client: QueryClient, agentSlug: string, signal: AbortSignal) {
+  let loader = loaders.get(client)
+  if (!loader) {
+    loader = createLoader()
+    loaders.set(client, loader)
+  }
+  return loader(agentSlug, signal)
+}

--- a/src/shared/lib/agent-members-schema.ts
+++ b/src/shared/lib/agent-members-schema.ts
@@ -11,7 +11,19 @@ export const agentMemberSchema = z.object({
 export const agentMembersSchema = z.array(agentMemberSchema)
 export type AgentMember = z.infer<typeof agentMemberSchema>
 
-// Invalidation hints only. Member details always come from an authorized GET.
+// Bound each read; larger sidebars are split into chunks by the client.
+export const MAX_AGENT_MEMBERS_BATCH_SIZE = 100
+export const agentMembersBatchRequestSchema = z.object({
+  agentSlugs: z.array(z.string().min(1).max(255)).min(1).max(MAX_AGENT_MEMBERS_BATCH_SIZE),
+})
+export const agentMembersByAgentSchema = z.record(z.string(), agentMembersSchema)
+export const agentMembersBatchResponseSchema = z.record(z.string(), z.discriminatedUnion('status', [
+  z.object({ status: z.literal(200), members: agentMembersSchema }),
+  z.object({ status: z.literal(403) }),
+  z.object({ status: z.literal(404) }),
+]))
+
+// Invalidation hints only. Member details always come from an authorized roster read.
 export const collaborationEventSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('agent_members_changed'), agentSlug: z.string().min(1) }),
   z.object({ type: z.literal('agent_access_revoked'), agentSlug: z.string().min(1) }),

--- a/src/shared/lib/agent-members-schema.ts
+++ b/src/shared/lib/agent-members-schema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+import { avatarOverrideSchema, providerImageSchema } from './user-profile-schema'
+
+export const agentMemberSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string(),
+  image: z.union([avatarOverrideSchema, providerImageSchema]).nullable(),
+  role: z.enum(['owner', 'user', 'viewer']),
+})
+export const agentMembersSchema = z.array(agentMemberSchema)
+export type AgentMember = z.infer<typeof agentMemberSchema>
+
+// Invalidation hints only. Member details always come from an authorized GET.
+export const collaborationEventSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('agent_members_changed'), agentSlug: z.string().min(1) }),
+  z.object({ type: z.literal('agent_access_revoked'), agentSlug: z.string().min(1) }),
+  z.object({ type: z.literal('user_profile_changed'), userId: z.string().min(1) }),
+])
+export type CollaborationEvent = z.infer<typeof collaborationEventSchema>

--- a/src/shared/lib/agent-members-schema.ts
+++ b/src/shared/lib/agent-members-schema.ts
@@ -27,6 +27,5 @@ export const agentMembersBatchResponseSchema = z.record(z.string(), z.discrimina
 export const collaborationEventSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('agent_members_changed'), agentSlug: z.string().min(1) }),
   z.object({ type: z.literal('agent_access_revoked'), agentSlug: z.string().min(1) }),
-  z.object({ type: z.literal('user_profile_changed'), userId: z.string().min(1) }),
 ])
 export type CollaborationEvent = z.infer<typeof collaborationEventSchema>

--- a/src/shared/lib/auth/index.ts
+++ b/src/shared/lib/auth/index.ts
@@ -135,12 +135,6 @@ function createAuthInstance() {
         },
     databaseHooks: {
       user: {
-        update: {
-          after: async (updatedUser) => {
-            const { notifyUserProfileChanged } = await import('@shared/lib/services/agent-members-service')
-            notifyUserProfileChanged(updatedUser.id)
-          },
-        },
         delete: {
           after: async (deletedUser) => {
             if (typeof deletedUser.avatarOverride !== 'string') return

--- a/src/shared/lib/auth/index.ts
+++ b/src/shared/lib/auth/index.ts
@@ -135,6 +135,12 @@ function createAuthInstance() {
         },
     databaseHooks: {
       user: {
+        update: {
+          after: async (updatedUser) => {
+            const { notifyUserProfileChanged } = await import('@shared/lib/services/agent-members-service')
+            notifyUserProfileChanged(updatedUser.id)
+          },
+        },
         delete: {
           after: async (deletedUser) => {
             if (typeof deletedUser.avatarOverride !== 'string') return

--- a/src/shared/lib/db/migrations/0041_user_avatar_lookup_index.sql
+++ b/src/shared/lib/db/migrations/0041_user_avatar_lookup_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `user_avatar_override_idx` ON `user` (`avatar_override`);

--- a/src/shared/lib/db/migrations/meta/0041_snapshot.json
+++ b/src/shared/lib/db/migrations/meta/0041_snapshot.json
@@ -1,0 +1,2993 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "79db263d-5071-4d35-bece-8fc699f3372f",
+  "prevId": "253d042e-26a3-4079-9234-86c6c239493b",
+  "tables": {
+    "agent_acl": {
+      "name": "agent_acl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_acl_user_agent_unique": {
+          "name": "agent_acl_user_agent_unique",
+          "columns": [
+            "user_id",
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "agent_acl_agent_slug_idx": {
+          "name": "agent_acl_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_acl_user_id_user_id_fk": {
+          "name": "agent_acl_user_id_user_id_fk",
+          "tableFrom": "agent_acl",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_connected_accounts": {
+      "name": "agent_connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_connected_accounts_unique": {
+          "name": "agent_connected_accounts_unique",
+          "columns": [
+            "agent_slug",
+            "connected_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_connected_accounts_connected_account_id_connected_accounts_id_fk": {
+          "name": "agent_connected_accounts_connected_account_id_connected_accounts_id_fk",
+          "tableFrom": "agent_connected_accounts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "connected_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_remote_mcps": {
+      "name": "agent_remote_mcps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_remote_mcps_unique": {
+          "name": "agent_remote_mcps_unique",
+          "columns": [
+            "agent_slug",
+            "remote_mcp_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "agent_remote_mcps_remote_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "agent_remote_mcps",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "remote_mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_scope_policies": {
+      "name": "api_scope_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_scope_policies_unique": {
+          "name": "api_scope_policies_unique",
+          "columns": [
+            "account_id",
+            "scope"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_scope_policies_account_id_connected_accounts_id_fk": {
+          "name": "api_scope_policies_account_id_connected_accounts_id_fk",
+          "tableFrom": "api_scope_policies",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apns_devices": {
+      "name": "apns_devices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'production'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mobile_device_id": {
+          "name": "mobile_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_tag": {
+          "name": "workspace_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ios'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apns_devices_token_unique": {
+          "name": "apns_devices_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "apns_devices_user_id_idx": {
+          "name": "apns_devices_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "apns_devices_mobile_device_id_idx": {
+          "name": "apns_devices_mobile_device_id_idx",
+          "columns": [
+            "mobile_device_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apns_devices_mobile_device_id_mobile_device_id_fk": {
+          "name": "apns_devices_mobile_device_id_mobile_device_id_fk",
+          "tableFrom": "apns_devices",
+          "tableTo": "mobile_device",
+          "columnsFrom": [
+            "mobile_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_log_object_idx": {
+          "name": "audit_log_object_idx",
+          "columns": [
+            "object"
+          ],
+          "isUnique": false
+        },
+        "audit_log_user_id_idx": {
+          "name": "audit_log_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_provider_account_unique": {
+          "name": "account_provider_account_unique",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "creation_method": {
+          "name": "creation_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "session_device_id_idx": {
+          "name": "session_device_id_idx",
+          "columns": [
+            "device_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_device_id_mobile_device_id_fk": {
+          "name": "session_device_id_mobile_device_id_fk",
+          "tableFrom": "session",
+          "tableTo": "mobile_device",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integration_access": {
+      "name": "chat_integration_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_type": {
+          "name": "chat_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "approval_source": {
+          "name": "approval_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_id": {
+          "name": "first_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_user_name": {
+          "name": "first_user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message_preview": {
+          "name": "first_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_notice_sent_at": {
+          "name": "request_notice_sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_access_unique": {
+          "name": "chat_integration_access_unique",
+          "columns": [
+            "integration_id",
+            "external_chat_id"
+          ],
+          "isUnique": true
+        },
+        "chat_integration_access_status_idx": {
+          "name": "chat_integration_access_status_idx",
+          "columns": [
+            "integration_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_access_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_access_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_access",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "chat_integration_access_status_check": {
+          "name": "chat_integration_access_status_check",
+          "value": "\"chat_integration_access\".\"status\" in ('pending','allowed','denied')"
+        },
+        "chat_integration_access_chat_type_check": {
+          "name": "chat_integration_access_chat_type_check",
+          "value": "\"chat_integration_access\".\"chat_type\" is null or \"chat_integration_access\".\"chat_type\" in ('private','group','supergroup')"
+        },
+        "chat_integration_access_source_check": {
+          "name": "chat_integration_access_source_check",
+          "value": "\"chat_integration_access\".\"approval_source\" is null or \"chat_integration_access\".\"approval_source\" in ('auto_first_contact','owner','migration')"
+        }
+      }
+    },
+    "chat_integration_sessions": {
+      "name": "chat_integration_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_chat_id": {
+          "name": "external_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integration_sessions_integration_id_idx": {
+          "name": "chat_integration_sessions_integration_id_idx",
+          "columns": [
+            "integration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chat_integration_sessions_integration_id_chat_integrations_id_fk": {
+          "name": "chat_integration_sessions_integration_id_chat_integrations_id_fk",
+          "tableFrom": "chat_integration_sessions",
+          "tableTo": "chat_integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_integrations": {
+      "name": "chat_integrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "show_tool_calls": {
+          "name": "show_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "require_approval": {
+          "name": "require_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_timeout": {
+          "name": "session_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chat_integrations_agent_slug_idx": {
+          "name": "chat_integrations_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "chat_integrations_status_idx": {
+          "name": "chat_integrations_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connected_accounts": {
+      "name": "connected_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_connection_id": {
+          "name": "provider_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "toolkit_slug": {
+          "name": "toolkit_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connected_accounts_provider_connection_id_unique": {
+          "name": "connected_accounts_provider_connection_id_unique",
+          "columns": [
+            "provider_connection_id"
+          ],
+          "isUnique": true
+        },
+        "connected_accounts_userId_idx": {
+          "name": "connected_accounts_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connected_accounts_user_id_user_id_fk": {
+          "name": "connected_accounts_user_id_user_id_fk",
+          "tableFrom": "connected_accounts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_id": {
+          "name": "remote_mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_mcp_name": {
+          "name": "remote_mcp_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_tool": {
+          "name": "matched_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_audit_log_agent_slug_created_at_idx": {
+          "name": "mcp_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "mcp_audit_log_remote_mcp_id_created_at_idx": {
+          "name": "mcp_audit_log_remote_mcp_id_created_at_idx",
+          "columns": [
+            "remote_mcp_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "mcp_audit_log_mcp_agent_idx": {
+          "name": "mcp_audit_log_mcp_agent_idx",
+          "columns": [
+            "remote_mcp_id",
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_tool_policies": {
+      "name": "mcp_tool_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_tool_policies_unique": {
+          "name": "mcp_tool_policies_unique",
+          "columns": [
+            "mcp_id",
+            "tool_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk": {
+          "name": "mcp_tool_policies_mcp_id_remote_mcp_servers_id_fk",
+          "tableFrom": "mcp_tool_policies",
+          "tableTo": "remote_mcp_servers",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_author": {
+      "name": "message_author",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "message_author_session_idx": {
+          "name": "message_author_session_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_author_user_id_user_id_fk": {
+          "name": "message_author_user_id_user_id_fk",
+          "tableFrom": "message_author",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mobile_device": {
+      "name": "mobile_device",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mobile_device_refresh_token_hash_unique": {
+          "name": "mobile_device_refresh_token_hash_unique",
+          "columns": [
+            "refresh_token_hash"
+          ],
+          "isUnique": true
+        },
+        "mobile_device_user_id_idx": {
+          "name": "mobile_device_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "mobile_device_expires_at_idx": {
+          "name": "mobile_device_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mobile_device_user_id_user_id_fk": {
+          "name": "mobile_device_user_id_user_id_fk",
+          "tableFrom": "mobile_device",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mobile_pairing_token": {
+      "name": "mobile_pairing_token",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mobile_pairing_token_expires_at_idx": {
+          "name": "mobile_pairing_token_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mobile_pairing_token_user_id_user_id_fk": {
+          "name": "mobile_pairing_token_user_id_user_id_fk",
+          "tableFrom": "mobile_pairing_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notifications_agent_slug_is_read_idx": {
+          "name": "notifications_agent_slug_is_read_idx",
+          "columns": [
+            "agent_slug",
+            "is_read"
+          ],
+          "isUnique": false
+        },
+        "notifications_session_id_idx": {
+          "name": "notifications_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_audit_log": {
+      "name": "proxy_audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toolkit": {
+          "name": "toolkit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "policy_decision": {
+          "name": "policy_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_scopes": {
+          "name": "matched_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_audit_log_agent_slug_created_at_idx": {
+          "name": "proxy_audit_log_agent_slug_created_at_idx",
+          "columns": [
+            "agent_slug",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "proxy_audit_log_account_id_created_at_idx": {
+          "name": "proxy_audit_log_account_id_created_at_idx",
+          "columns": [
+            "account_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "proxy_audit_log_account_agent_idx": {
+          "name": "proxy_audit_log_account_agent_idx",
+          "columns": [
+            "account_id",
+            "agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "proxy_tokens": {
+      "name": "proxy_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "proxy_tokens_agent_slug_unique": {
+          "name": "proxy_tokens_agent_slug_unique",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": true
+        },
+        "proxy_tokens_token_unique": {
+          "name": "proxy_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_subscriptions": {
+      "name": "push_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keys_p256dh": {
+          "name": "keys_p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keys_auth": {
+          "name": "keys_auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "columns": [
+            "endpoint"
+          ],
+          "isUnique": true
+        },
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_vapid_keys": {
+      "name": "push_vapid_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_mcp_servers": {
+      "name": "remote_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token_endpoint": {
+          "name": "oauth_token_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_resource": {
+          "name": "oauth_resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_discovered_at": {
+          "name": "tools_discovered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "remote_mcp_servers_user_id_user_id_fk": {
+          "name": "remote_mcp_servers_user_id_user_id_fk",
+          "tableFrom": "remote_mcp_servers",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_expression": {
+          "name": "schedule_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "next_execution_at": {
+          "name": "next_execution_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_executed_at": {
+          "name": "last_executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "execution_count": {
+          "name": "execution_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resume_session_id": {
+          "name": "resume_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_tasks_pending_wake_unique": {
+          "name": "scheduled_tasks_pending_wake_unique",
+          "columns": [
+            "resume_session_id"
+          ],
+          "isUnique": true,
+          "where": "status = 'pending' AND resume_session_id IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_unread_marks": {
+      "name": "session_unread_marks",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "marked_at": {
+          "name": "marked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_unread_marks_agent_slug_user_idx": {
+          "name": "session_unread_marks_agent_slug_user_idx",
+          "columns": [
+            "agent_slug",
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_unread_marks_agent_slug_session_id_user_id_pk": {
+          "columns": [
+            "agent_slug",
+            "session_id",
+            "user_id"
+          ],
+          "name": "session_unread_marks_agent_slug_session_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "token_exchange_jti": {
+      "name": "token_exchange_jti",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "token_exchange_jti_expires_at_idx": {
+          "name": "token_exchange_jti_expires_at_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_override": {
+          "name": "avatar_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_avatar_override_idx": {
+          "name": "user_avatar_override_idx",
+          "columns": [
+            "avatar_override"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_triggers": {
+      "name": "webhook_triggers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_slug": {
+          "name": "agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'composio'"
+        },
+        "composio_trigger_id": {
+          "name": "composio_trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_account_id": {
+          "name": "connected_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fire_count": {
+          "name": "fire_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_session_id": {
+          "name": "last_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_session_id": {
+          "name": "created_by_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "minted_by_member_id": {
+          "name": "minted_by_member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhook_triggers_agent_slug_idx": {
+          "name": "webhook_triggers_agent_slug_idx",
+          "columns": [
+            "agent_slug"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_status_idx": {
+          "name": "webhook_triggers_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "webhook_triggers_composio_idx": {
+          "name": "webhook_triggers_composio_idx",
+          "columns": [
+            "composio_trigger_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "x_agent_policies": {
+      "name": "x_agent_policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_agent_slug": {
+          "name": "caller_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_agent_slug": {
+          "name": "target_agent_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "x_agent_policies_unique": {
+          "name": "x_agent_policies_unique",
+          "columns": [
+            "caller_agent_slug",
+            "target_agent_slug",
+            "operation"
+          ],
+          "isUnique": true
+        },
+        "x_agent_policies_caller_idx": {
+          "name": "x_agent_policies_caller_idx",
+          "columns": [
+            "caller_agent_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/shared/lib/db/migrations/meta/_journal.json
+++ b/src/shared/lib/db/migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1789059097911,
       "tag": "0040_user_avatar_override",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "6",
+      "when": 1789080776897,
+      "tag": "0041_user_avatar_lookup_index",
+      "breakpoints": true
     }
   ]
 }

--- a/src/shared/lib/db/schema.ts
+++ b/src/shared/lib/db/schema.ts
@@ -28,7 +28,9 @@ export const user = sqliteTable('user', {
   banReason: text('ban_reason'),
   banExpires: integer('ban_expires', { mode: 'timestamp_ms' }),
   mustChangePassword: integer('must_change_password', { mode: 'boolean' }).default(false),
-})
+}, (table) => ({
+  avatarOverrideIdx: index('user_avatar_override_idx').on(table.avatarOverride),
+}))
 
 /**
  * Stable installed-mobile-device identity. Access sessions rotate underneath

--- a/src/shared/lib/services/agent-members-service.ts
+++ b/src/shared/lib/services/agent-members-service.ts
@@ -3,20 +3,19 @@ import { db } from '@shared/lib/db'
 import { agentAcl, user } from '@shared/lib/db/schema'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { agentMembersSchema } from '@shared/lib/agent-members-schema'
-import { getUserImage } from '@shared/lib/user-profile-schema'
+import { getUserSummaries } from './user-profile-service'
 import { publishCollaborationEvent } from './collaboration-events'
 
 export function listAgentMembers(agentSlug: string) {
-  const rows = db.select({
-    id: user.id, name: user.name, email: user.email, image: user.image,
-    avatarOverride: user.avatarOverride, role: agentAcl.role,
-  }).from(agentAcl).innerJoin(user, eq(agentAcl.userId, user.id))
+  const rows = db.select({ id: agentAcl.userId, role: agentAcl.role }).from(agentAcl)
     .where(eq(agentAcl.agentSlug, agentSlug))
     // Joining time + stable ID keep faces stationary when names or roles change.
-    .orderBy(asc(agentAcl.createdAt), asc(user.id)).all()
-  return agentMembersSchema.parse(rows.map(({ avatarOverride, ...row }) => ({
-    ...row, image: getUserImage({ ...row, avatarOverride }),
-  })))
+    .orderBy(asc(agentAcl.createdAt), asc(agentAcl.userId)).all()
+  const profiles = getUserSummaries(rows.map(row => row.id))
+  return agentMembersSchema.parse(rows.flatMap(row => {
+    const profile = profiles.get(row.id)
+    return profile ? [{ ...profile, role: row.role }] : []
+  }))
 }
 
 export function notifyAgentMembersChanged(agentSlug: string, removedUserId?: string): void {

--- a/src/shared/lib/services/agent-members-service.ts
+++ b/src/shared/lib/services/agent-members-service.ts
@@ -2,20 +2,29 @@ import { asc, eq, inArray } from 'drizzle-orm'
 import { db } from '@shared/lib/db'
 import { agentAcl, user } from '@shared/lib/db/schema'
 import { isAuthMode } from '@shared/lib/auth/mode'
-import { agentMembersSchema } from '@shared/lib/agent-members-schema'
+import { agentMembersByAgentSchema, type AgentMember } from '@shared/lib/agent-members-schema'
 import { getUserSummaries } from './user-profile-service'
 import { publishCollaborationEvent } from './collaboration-events'
 
-export function listAgentMembers(agentSlug: string) {
-  const rows = db.select({ id: agentAcl.userId, role: agentAcl.role }).from(agentAcl)
-    .where(eq(agentAcl.agentSlug, agentSlug))
+/** Callers must authorize every agent before reading its roster. */
+export function listAgentMembersByAgent(agentSlugs: readonly string[]) {
+  const slugs = [...new Set(agentSlugs)]
+  const members = new Map(slugs.map(slug => [slug, [] as AgentMember[]]))
+  if (!slugs.length) return {}
+  const rows = db.select({ agentSlug: agentAcl.agentSlug, id: agentAcl.userId, role: agentAcl.role }).from(agentAcl)
+    .where(inArray(agentAcl.agentSlug, slugs))
     // Joining time + stable ID keep faces stationary when names or roles change.
     .orderBy(asc(agentAcl.createdAt), asc(agentAcl.userId)).all()
   const profiles = getUserSummaries(rows.map(row => row.id))
-  return agentMembersSchema.parse(rows.flatMap(row => {
+  for (const row of rows) {
     const profile = profiles.get(row.id)
-    return profile ? [{ ...profile, role: row.role }] : []
-  }))
+    if (profile) members.get(row.agentSlug)!.push({ ...profile, role: row.role })
+  }
+  return agentMembersByAgentSchema.parse(Object.fromEntries(members))
+}
+
+export function listAgentMembers(agentSlug: string) {
+  return listAgentMembersByAgent([agentSlug])[agentSlug]
 }
 
 export function notifyAgentMembersChanged(agentSlug: string, removedUserId?: string): void {

--- a/src/shared/lib/services/agent-members-service.ts
+++ b/src/shared/lib/services/agent-members-service.ts
@@ -19,14 +19,22 @@ export function listAgentMembers(agentSlug: string) {
   })))
 }
 
-export function notifyAgentMembersChanged(agentSlug: string, revokedUserId?: string): void {
+export function notifyAgentMembersChanged(agentSlug: string, removedUserId?: string): void {
   if (!isAuthMode()) return
   try {
     const recipients = db.select({ id: agentAcl.userId }).from(agentAcl)
       .where(eq(agentAcl.agentSlug, agentSlug)).all().map((row) => row.id)
     publishCollaborationEvent(recipients, { type: 'agent_members_changed', agentSlug })
-    // The removed user no longer passes the usual agent audience filter.
-    if (revokedUserId) publishCollaborationEvent([revokedUserId], { type: 'agent_access_revoked', agentSlug })
+    // Removed members still need a direct hint. Deployment admins retain
+    // route access without an ACL entry, so only refresh their membership UI.
+    if (removedUserId) {
+      const removedUser = db.select({ role: user.role }).from(user)
+        .where(eq(user.id, removedUserId)).get()
+      publishCollaborationEvent([removedUserId], {
+        type: removedUser?.role === 'admin' ? 'agent_members_changed' : 'agent_access_revoked',
+        agentSlug,
+      })
+    }
   } catch (error) {
     // The mutation already committed. Reconnect/focus refetches recover hints.
     console.error('Failed to notify agent members:', error)

--- a/src/shared/lib/services/agent-members-service.ts
+++ b/src/shared/lib/services/agent-members-service.ts
@@ -48,16 +48,3 @@ export function notifyAgentMembersChanged(agentSlug: string, removedUserId?: str
     console.error('Failed to notify agent members:', error)
   }
 }
-
-export function notifyUserProfileChanged(userId: string): void {
-  if (!isAuthMode()) return
-  try {
-    const sharedAgents = db.select({ slug: agentAcl.agentSlug }).from(agentAcl)
-      .where(eq(agentAcl.userId, userId)).all().map((row) => row.slug)
-    const recipients = sharedAgents.length ? db.selectDistinct({ id: agentAcl.userId }).from(agentAcl)
-      .where(inArray(agentAcl.agentSlug, sharedAgents)).all().map((row) => row.id) : []
-    publishCollaborationEvent([userId, ...recipients], { type: 'user_profile_changed', userId })
-  } catch (error) {
-    console.error('Failed to notify profile change:', error)
-  }
-}

--- a/src/shared/lib/services/agent-members-service.ts
+++ b/src/shared/lib/services/agent-members-service.ts
@@ -1,0 +1,47 @@
+import { asc, eq, inArray } from 'drizzle-orm'
+import { db } from '@shared/lib/db'
+import { agentAcl, user } from '@shared/lib/db/schema'
+import { isAuthMode } from '@shared/lib/auth/mode'
+import { agentMembersSchema } from '@shared/lib/agent-members-schema'
+import { getUserImage } from '@shared/lib/user-profile-schema'
+import { publishCollaborationEvent } from './collaboration-events'
+
+export function listAgentMembers(agentSlug: string) {
+  const rows = db.select({
+    id: user.id, name: user.name, email: user.email, image: user.image,
+    avatarOverride: user.avatarOverride, role: agentAcl.role,
+  }).from(agentAcl).innerJoin(user, eq(agentAcl.userId, user.id))
+    .where(eq(agentAcl.agentSlug, agentSlug))
+    // Joining time + stable ID keep faces stationary when names or roles change.
+    .orderBy(asc(agentAcl.createdAt), asc(user.id)).all()
+  return agentMembersSchema.parse(rows.map(({ avatarOverride, ...row }) => ({
+    ...row, image: getUserImage({ ...row, avatarOverride }),
+  })))
+}
+
+export function notifyAgentMembersChanged(agentSlug: string, revokedUserId?: string): void {
+  if (!isAuthMode()) return
+  try {
+    const recipients = db.select({ id: agentAcl.userId }).from(agentAcl)
+      .where(eq(agentAcl.agentSlug, agentSlug)).all().map((row) => row.id)
+    publishCollaborationEvent(recipients, { type: 'agent_members_changed', agentSlug })
+    // The removed user no longer passes the usual agent audience filter.
+    if (revokedUserId) publishCollaborationEvent([revokedUserId], { type: 'agent_access_revoked', agentSlug })
+  } catch (error) {
+    // The mutation already committed. Reconnect/focus refetches recover hints.
+    console.error('Failed to notify agent members:', error)
+  }
+}
+
+export function notifyUserProfileChanged(userId: string): void {
+  if (!isAuthMode()) return
+  try {
+    const sharedAgents = db.select({ slug: agentAcl.agentSlug }).from(agentAcl)
+      .where(eq(agentAcl.userId, userId)).all().map((row) => row.slug)
+    const recipients = sharedAgents.length ? db.selectDistinct({ id: agentAcl.userId }).from(agentAcl)
+      .where(inArray(agentAcl.agentSlug, sharedAgents)).all().map((row) => row.id) : []
+    publishCollaborationEvent([userId, ...recipients], { type: 'user_profile_changed', userId })
+  } catch (error) {
+    console.error('Failed to notify profile change:', error)
+  }
+}

--- a/src/shared/lib/services/collaboration-events.ts
+++ b/src/shared/lib/services/collaboration-events.ts
@@ -1,0 +1,28 @@
+import type { CollaborationEvent } from '@shared/lib/agent-members-schema'
+
+type Listener = (event: CollaborationEvent) => void | Promise<void>
+const listeners = new Map<string, Set<Listener>>()
+
+/** One subscription per existing global SSE connection, keyed by verified user. */
+export function subscribeCollaborationEvents(userId: string, listener: Listener): () => void {
+  const clients = listeners.get(userId) ?? new Set<Listener>()
+  clients.add(listener)
+  listeners.set(userId, clients)
+  return () => {
+    clients.delete(listener)
+    if (!clients.size) listeners.delete(userId)
+  }
+}
+
+/** Recipients are resolved by the service at the mutation boundary. */
+export function publishCollaborationEvent(userIds: Iterable<string>, event: CollaborationEvent): void {
+  for (const userId of new Set(userIds)) {
+    for (const listener of listeners.get(userId) ?? []) {
+      try {
+        Promise.resolve(listener(event)).catch((error) => console.error('Collaboration stream write failed:', error))
+      } catch (error) {
+        console.error('Collaboration stream write failed:', error)
+      }
+    }
+  }
+}

--- a/src/shared/lib/services/profile-avatar-service.ts
+++ b/src/shared/lib/services/profile-avatar-service.ts
@@ -1,4 +1,3 @@
-import { notifyUserProfileChanged } from './agent-members-service'
 import { randomUUID } from 'node:crypto'
 import fs from 'node:fs/promises'
 import path from 'node:path'
@@ -84,6 +83,5 @@ export async function setAvatar(userId: string, input: Buffer | null): Promise<s
     throw error
   }
   await removeStoredAvatar(previous)
-  notifyUserProfileChanged(userId)
   return reference
 }

--- a/src/shared/lib/services/profile-avatar-service.ts
+++ b/src/shared/lib/services/profile-avatar-service.ts
@@ -1,3 +1,4 @@
+import { notifyUserProfileChanged } from './agent-members-service'
 import { randomUUID } from 'node:crypto'
 import fs from 'node:fs/promises'
 import path from 'node:path'
@@ -83,5 +84,6 @@ export async function setAvatar(userId: string, input: Buffer | null): Promise<s
     throw error
   }
   await removeStoredAvatar(previous)
+  notifyUserProfileChanged(userId)
   return reference
 }

--- a/src/shared/lib/services/user-profile-service.test.ts
+++ b/src/shared/lib/services/user-profile-service.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+let directory: string
+let database: typeof import('@shared/lib/db')
+let profiles: typeof import('./user-profile-service')
+const override = '/api/profile/images/00000000-0000-4000-8000-000000000001.png'
+
+beforeAll(async () => {
+  directory = fs.mkdtempSync(path.join(os.tmpdir(), 'user-profiles-'))
+  vi.stubEnv('SUPERAGENT_DATA_DIR', directory)
+  database = await import('@shared/lib/db')
+  profiles = await import('./user-profile-service')
+  const { user } = await import('@shared/lib/db/schema')
+  database.db.insert(user).values([
+    { id: 'ada', name: 'Ada Lovelace', email: 'ada@example.test', image: 'https://example.test/ada.png', avatarOverride: override, role: 'admin' },
+    { id: 'maya', name: 'Maya Chen', email: 'maya@example.test', image: 'https://example.test/maya.png' },
+    { id: 'percent', name: '100% Person', email: 'percent@example.test', image: 'javascript:invalid' },
+    { id: 'underscore', name: 'Under_score', email: 'underscore@example.test' },
+    { id: 'backslash', name: 'Back\\slash', email: 'backslash@example.test' },
+    ...Array.from({ length: 55 }, (_, index) => ({
+      id: `team-${index}`, name: `Team Person ${index}`, email: `team-${index}@example.test`,
+    })),
+  ]).run()
+})
+
+afterAll(() => {
+  database.sqlite.close()
+  vi.unstubAllEnvs()
+  fs.rmSync(directory, { recursive: true, force: true })
+})
+
+describe('user profile reads', () => {
+  it('resolves distinct requested users with effective images and no internal fields', () => {
+    const result = profiles.getUserSummaries(['ada', 'ada', 'missing', 'maya', 'percent'])
+    expect(result.size).toBe(3)
+    expect(result.get('ada')).toEqual({ id: 'ada', name: 'Ada Lovelace', email: 'ada@example.test', image: override })
+    expect(result.get('maya')?.image).toBe('https://example.test/maya.png')
+    expect(result.get('percent')?.image).toBeNull()
+    expect(profiles.getUserSummaries([]).size).toBe(0)
+    expect(profiles.userExists('ada')).toBe(true)
+    expect(profiles.userExists('missing')).toBe(false)
+  })
+
+  it('keeps live sender summaries limited to the existing event fields', () => {
+    const user = { id: 'ada', name: 'Ada Lovelace', email: 'ada@example.test', image: 'https://example.test/ada.png', avatarOverride: override, role: 'admin' }
+    expect(profiles.toUserSender(user)).toEqual({ id: 'ada', name: 'Ada Lovelace', image: override })
+  })
+
+  it.each([
+    ['  ADA  ', 'ada'],
+    ['MAYA@EXAMPLE', 'maya'],
+    ['%', 'percent'],
+    ['_', 'underscore'],
+    ['\\', 'backslash'],
+  ])('searches names and emails literally for %s', (query, expectedId) => {
+    expect(profiles.searchUserSummaries(query, []).map(profile => profile.id)).toEqual([expectedId])
+  })
+
+  it('excludes current members before applying the invitation result limit', () => {
+    const existing = profiles.searchUserSummaries('Team Person', [])
+    expect(existing).toHaveLength(50)
+    const remaining = profiles.searchUserSummaries('Team Person', existing.map(profile => profile.id))
+    expect(remaining).toHaveLength(5)
+    expect(remaining.every(profile => !existing.some(member => member.id === profile.id))).toBe(true)
+    expect(profiles.searchUserSummaries(undefined, [])).toHaveLength(50)
+  })
+})

--- a/src/shared/lib/services/user-profile-service.ts
+++ b/src/shared/lib/services/user-profile-service.ts
@@ -1,0 +1,48 @@
+import { and, eq, inArray, notInArray, or, sql, type AnyColumn } from 'drizzle-orm'
+import { db } from '@shared/lib/db'
+import { user } from '@shared/lib/db/schema'
+import { getUserImage, type UserImageFields } from '@shared/lib/user-profile-schema'
+
+const profileFields = {
+  id: user.id, name: user.name, email: user.email,
+  image: user.image, avatarOverride: user.avatarOverride,
+}
+
+type ProfileRow = Pick<typeof user.$inferSelect, keyof typeof profileFields>
+export type UserSenderSource = { id: string; name: string } & UserImageFields
+
+/** The existing live-message/typing summary intentionally excludes email. */
+export function toUserSender(profile: UserSenderSource) {
+  return { id: profile.id, name: profile.name, image: getUserImage(profile) }
+}
+
+function toUserProfile(profile: ProfileRow) {
+  return { ...toUserSender(profile), email: profile.email }
+}
+
+/** Internal read API: callers authorize IDs through their agent/session first. */
+export function getUserSummaries(userIds: readonly string[]) {
+  const ids = [...new Set(userIds)]
+  const profiles = ids.length
+    ? db.select(profileFields).from(user).where(inArray(user.id, ids)).all()
+    : []
+  return new Map(profiles.map(profile => [profile.id, toUserProfile(profile)]))
+}
+
+export function userExists(userId: string): boolean {
+  return !!db.select({ id: user.id }).from(user).where(eq(user.id, userId)).get()
+}
+
+/** Callers authorize directory access and supply users to exclude. */
+export function searchUserSummaries(query: string | undefined, excludeIds: readonly string[]) {
+  // SQLite LIKE is case-insensitive. Treat %, _ and backslash as literals.
+  const escaped = query?.trim().replace(/[\\%_]/g, '\\$&') ?? ''
+  const matchesQuery = (column: AnyColumn) =>
+    sql`${column} LIKE ${`%${escaped}%`} ESCAPE '\\'`
+  const profiles = db.select(profileFields).from(user).where(and(
+    // Exclude before limiting, so existing members don't consume result slots.
+    excludeIds.length ? notInArray(user.id, [...excludeIds]) : undefined,
+    escaped ? or(matchesQuery(user.name), matchesQuery(user.email)) : undefined,
+  )).limit(50).all()
+  return profiles.map(toUserProfile)
+}

--- a/src/shared/lib/user-profile-schema.ts
+++ b/src/shared/lib/user-profile-schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-const providerImageSchema = z.string().trim().max(4096).url().refine((url) => /^https?:\/\//i.test(url))
+export const providerImageSchema = z.string().trim().max(4096).url().refine((url) => /^https?:\/\//i.test(url))
 export const avatarFilenameSchema = z.string().regex(/^[0-9a-f-]{36}\.png$/)
 export const avatarOverrideSchema = z.string().regex(/^\/api\/profile\/images\/[0-9a-f-]{36}\.png$/)
 export const MAX_AVATAR_BYTES = 1024 * 1024


### PR DESCRIPTION
Shared agents now show member photos in the header and beside their sidebar names. The sidebar shows up to four circles: up to four members appear as avatars; larger teams use three avatars and a +N circle, starting at +2 for five members. Hover, keyboard focus, or click opens a roster with names, emails, and roles. Owners and deployment admins also see an Invite button beside the member count; it opens the existing invitation pane for that agent without navigating away from the current page. The Invite press keeps the roster mounted through the pointer/focus handoff, including when its avatar trigger blurs before click. Ordinary users and viewers retain a read-only roster. Private agents have no sidebar indicator and retain the original Share button in the header.

Headers show up to five avatars, full-roster overflow, and the sharing + for owners/admins in one overlapping row. Private/shared transitions keep an open sharing pane in place. Existing Invite, Publish, and Export panes remain available. Native sidebar links, modifier clicks, status hover titles, expansion, sorting, and file drops retain their behavior; member controls and portaled roster events are isolated from dragging. Loading rosters show a count, and failed requests offer retry.

This is PR 2 of the collaboration stack, based on #1027. GET /api/agents/:id/members resolves canonical agent IDs and requires AgentRead; it returns only member summaries. Access mutations and invite search retain AgentAdmin. Sidebar, header, and sharing pane share one cached roster per agent with stable joining-time ordering. Sidebar roster requests are limited to shared agents in authenticated mode.

Membership and profile changes send scoped invalidation hints through the existing global SSE connection. Recipients come from current ACL membership; removed ordinary users receive a targeted revocation event that clears cached agent data and exits an active agent page. Removed deployment admins receive a membership update: their sidebar entry disappears, while their existing route access and open agent page remain available. Reconnects refresh rosters and the current profile, including recovery from fatal stream closure. The first successful connection does not trigger another session or roster fetch. Profile uploads, restoration, and Better Auth profile/provider updates refresh other members' avatars. The hints use the existing process-local stream model and contain no roster details.

Validation: typecheck and repository lint (no errors; existing warnings); the full collaboration E2E and all four sidebar shortcut E2Es pass against isolated mock servers; Focused unit/integration tests covering sidebar rendering, invitation permissions, status indicators, session invalidation on initial connection versus reconnect, and ordinary-user versus deployment-admin removal. All 13 sidebar member tests pass, including the four-/five-member boundary; light and dark browser checks verify four avatars for four members and three avatars plus +3 for six members. The collaboration E2E asserts that the status icon receives pointer hit-testing and that a removed deployment admin stays on the agent page while their sidebar entry disappears. Authenticated Playwright covers native and modifier-click navigation, expansion, sorting/cancellation, file drops, hover handoff, click pinning, outside dismissal, keyboard activation, and a 390px touch drawer. Chromium and WebKit checks verify status hover and native normal/Control-click navigation. A regression check covers pressing Invite when focus leaves the avatar trigger before the click; the interaction also passes in Chromium and WebKit. Invitation checks cover non-admin owners versus ordinary users/viewers, keyboard activation and return focus, outside dismissal, mobile touch, and submitting a synthetic invitation into a temporary agent while viewing a different agent; its stack and open roster update immediately. Browser checks also cover live private/shared transitions and overflow changes while a roster stays open, viewer access and revocation, and the existing development comparison. The stack also includes agent-route authorization, SQLite ACL, and real-socket audience/cleanup coverage.

## Compatibility and follow-ups

- `agent-item-*` identifies the native name link. Tests that need the complete row should scope to its `[data-sidebar="menu-button"]` container; shortcut coverage uses that contract. Known repository consumers have been checked, but external tests that assumed children of a full-row anchor may need adjustment.
- Keep `GET /api/agents/:id/access` for compatibility. The renderer reads `/members`; authenticated E2E coverage still checks the legacy endpoint's 200/403 behavior.
- Profile-update fan-out remains a performance follow-up. Better Auth user writes notify connected co-members even when visible profile fields are unchanged, and recipients invalidate all roster/invite-candidate queries. Only active queries refetch, and each agent's roster is shared across UI surfaces. A follow-up should suppress no-op/non-profile co-member hints and limit refetches to affected rosters while retaining session refreshes for the changed user.

## Demo

Inspect the header and sidebar rosters, navigate between agents, then use Invite to search another agent's candidates while staying on Personal Notes. All users and photos are synthetic data in an isolated mock instance.

https://github.com/user-attachments/assets/d8bdedd8-ef06-47e7-87bb-561a73dda96f

## Screenshots

| Light | Dark |
| --- | --- |
| ![Shared agent (light)](https://github.com/user-attachments/assets/496bc7d6-354f-4374-bdd8-f4c24fa40d42) | ![Shared agent (dark)](https://github.com/user-attachments/assets/c190d08a-689a-4d94-8b0f-c9b8490cfa90) |
| ![Sidebar roster (light)](https://github.com/user-attachments/assets/cac90cf4-d9d1-4451-89e0-a309dc92259a) | ![Sidebar roster (dark)](https://github.com/user-attachments/assets/4d1c2ac1-0c58-4214-b707-5318fc7089b9) |
| ![Member tooltip (light)](https://github.com/user-attachments/assets/bdd0c93b-f43a-435c-b556-12af8719accb) | ![Member tooltip (dark)](https://github.com/user-attachments/assets/05416307-8902-4d6b-bc83-8e86e820b55d) |
| ![Sharing (light)](https://github.com/user-attachments/assets/4dc65aa4-0e20-436d-b6f5-9628079c9339) | ![Sharing (dark)](https://github.com/user-attachments/assets/883c943a-0791-4497-a58b-574996a437ce) |
| ![Viewer roster (light)](https://github.com/user-attachments/assets/13e7847c-cbb4-40fc-b6f3-d453c1e3fdc8) | ![Viewer roster (dark)](https://github.com/user-attachments/assets/893127f8-8e11-4a00-9812-c49db9dd810f) |
| ![Private agent (light)](https://github.com/user-attachments/assets/5a24b4d6-a864-4e7f-9c47-8b1d85b3f2b6) | ![Private agent (dark)](https://github.com/user-attachments/assets/5c8e0645-94ac-4285-8138-3d489f8e3af9) |
| ![Sidebar invitation (light)](https://github.com/user-attachments/assets/ccea18c0-9f89-49ed-bb08-3111c84186a4) | ![Sidebar invitation (dark)](https://github.com/user-attachments/assets/75327340-9267-496a-b6bd-aee1b8fcdb43) |



