### PR TITLE
fix: let shared-agent members replace expired connections

### DIFF
--- a/e2e/auth/specs/connection-replacement.demo.spec.ts
+++ b/e2e/auth/specs/connection-replacement.demo.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect, type Page, type BrowserContext } from '@playwright/test'
+import { createServer } from 'http'
+import * as fs from 'fs/promises'
+import path from 'path'
+import { AuthPage } from '../pages/auth.page'
+import { AppPage } from '../../pages/app.page'
+import { SessionPage } from '../../pages/session.page'
+import { mockRecorder } from '../../helpers/mock-recorder'
+
+/** Run: npx playwright test --config playwright.connection-replacement-demo.config.ts
+ * Real Auth Mode, app UI, proxy, SQLite mapping swap and session lifecycle.
+ * Only the agent/model and upstream Slack provider are simulated. */
+test.skip(process.env.E2E_CONNECTION_REPLACEMENT_DEMO !== 'true', 'Requires the dedicated Auth Mode demo config')
+
+test('a non-owner replaces expired Slack and the interrupted script resumes with its new ID', async ({ browser, baseURL }, testInfo) => {
+  const upstreamCalls: string[] = []
+  const upstream = createServer((req, res) => {
+    if (req.url !== '/api/conversations.list') { res.writeHead(404).end(); return }
+    upstreamCalls.push(String(req.headers['x-demo-connection-id']))
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ ok: true, channels: [{ name: 'general' }, { name: 'product' }, { name: 'engineering' }] }))
+  })
+  const upstreamUrl = URL.parse(process.env.E2E_DEMO_SLACK_URL!)
+  if (!upstreamUrl) throw new Error('Invalid mock Slack URL')
+  await new Promise<void>((resolve, reject) => {
+    upstream.once('error', reject)
+    upstream.listen(Number(upstreamUrl.port), '127.0.0.1', resolve)
+  })
+  const contexts: BrowserContext[] = []
+  const recorder = mockRecorder<{
+    type: string; agentSlug?: string; sessionId?: string; content?: string;
+    key?: string; value?: string; scope?: string; hadTurnInFlight?: boolean;
+  }>()
+  const marks: Record<string, number> = {}
+
+  async function signUp(name: string, email: string) {
+    const context = await browser.newContext({ baseURL })
+    contexts.push(context)
+    const page = await context.newPage()
+    const auth = new AuthPage(page)
+    await page.goto('/')
+    await auth.signUpOrSignIn(name, email, 'password123')
+    const app = new AppPage(page)
+    await app.waitForAppLoaded()
+    await app.dismissWizardIfVisible()
+    return page
+  }
+  async function account(page: Page, providerConnectionId: string, displayName: string, status: string) {
+    const res = await page.request.post('/api/connected-accounts', {
+      data: { providerConnectionId, toolkitSlug: 'slack', displayName, status },
+    })
+    expect(res.ok()).toBeTruthy()
+    const { account: created } = await res.json() as { account: { id: string } }
+    const policies = await page.request.put(`/api/policies/scope/${created.id}`, {
+      data: { policies: [{ scope: '*', decision: 'allow' }] },
+    })
+    expect(policies.ok()).toBeTruthy()
+    return created.id
+  }
+  async function pause(page: Page, ms: number) {
+    // eslint-disable-next-line local-rules/no-brittle-playwright-selectors -- video pacing after assertions, never synchronization
+    await page.waitForTimeout(ms)
+  }
+  try {
+    // The first signup becomes global admin. The two people in the demo must
+    // be ordinary users so this genuinely exercises the agent member ACL.
+    await signUp('Demo Admin', 'admin@demo.test')
+    const owner = await signUp('Odette Owner', 'owner@demo.test')
+    const member = await signUp('Mel Member', 'member@demo.test')
+    const agentRes = await owner.request.post('/api/agents', { data: { name: 'Shared Slack Agent' } })
+    expect(agentRes.ok()).toBeTruthy()
+    const { slug } = await agentRes.json() as { slug: string }
+    const search = await owner.request.get(`/api/agents/${slug}/access/search-users?q=member%40demo.test`)
+    const users = await search.json() as Array<{ id: string; email: string }>
+    const memberId = users.find((u) => u.email === 'member@demo.test')!.id
+    const grant = await owner.request.post(`/api/agents/${slug}/access`, { data: { userId: memberId, role: 'user' } })
+    expect(grant.status()).toBe(201)
+    const oldId = await account(owner, 'demo-slack-owner-expired', 'Odette — Shared workspace', 'expired')
+    const newId = await account(member, 'demo-slack-member-active', 'Mel — Demo workspace', 'active')
+    expect(newId).not.toBe(oldId)
+    const assignment = await owner.request.post(`/api/agents/${slug}/connected-accounts`, { data: { accountIds: [oldId] } })
+    expect(assignment.ok()).toBeTruthy()
+
+    // Only record the actual member walkthrough, not signup/setup.
+    const context = await browser.newContext({
+      baseURL, storageState: await member.context().storageState(),
+      viewport: { width: 1440, height: 900 },
+      recordVideo: { dir: testInfo.outputPath('recording'), size: { width: 1440, height: 900 } },
+    })
+    contexts.push(context)
+    const page = await context.newPage()
+    marks.recordingStart = Date.now()
+    await page.goto(`/agents/${slug}`)
+    const session = new SessionPage(page)
+    await expect(session.getMessageInput()).toBeVisible()
+    marks.start = Date.now()
+    await pause(page, 1200)
+    await session.getMessageInput().pressSequentially('List the Slack channels using the shared connection.', { delay: 38 })
+    await pause(page, 800)
+    const createdSession = page.waitForResponse((r) => r.url().endsWith(`/api/agents/${slug}/sessions`) && r.request().method() === 'POST')
+    await session.getSendButton().click()
+    const sessionRes = await createdSession
+    expect(sessionRes.ok()).toBeTruthy()
+    const { id: sessionId } = await sessionRes.json() as { id: string }
+
+    const expired = page.getByTestId('account-reauth-request')
+    await expect(expired).toBeVisible({ timeout: 30_000 })
+    await expect(expired).toContainText('This request needs Slack access that has expired.')
+    await expect(expired).toContainText('Replace it with an account you own')
+    await expect(page.getByTestId('account-reauth-reconnect-btn')).toHaveCount(0)
+    expect(upstreamCalls).toEqual([])
+    marks.expired = Date.now()
+    await page.screenshot({ path: testInfo.outputPath('expired.png') })
+    await pause(page, 3500)
+    await page.getByTestId('account-reauth-replace-btn').hover()
+    await pause(page, 1000)
+    await page.getByTestId('account-reauth-replace-btn').click()
+    const picker = page.getByTestId('connected-account-request')
+    await expect(picker).toBeVisible()
+    await expect(picker).toContainText('Mel — Demo workspace')
+    await expect(picker).not.toContainText('Odette — Shared workspace')
+    marks.picker = Date.now()
+    await page.screenshot({ path: testInfo.outputPath('picker.png') })
+    await pause(page, 4500)
+    const submit = picker.getByRole('button', { name: 'Replace connection', exact: true })
+    await expect(submit).toBeEnabled()
+    await submit.hover()
+    await pause(page, 1000)
+    const replacementResponse = page.waitForResponse((r) => r.url().endsWith('/replace-account') && r.request().method() === 'POST')
+    marks.replace = Date.now()
+    await submit.click()
+    const replacement = await replacementResponse
+    expect(replacement.ok()).toBeTruthy()
+    expect(await replacement.json()).toMatchObject({ success: true, liveRefresh: true, sessionNotification: true })
+    await expect(expired).toHaveCount(0)
+    await expect(picker).toHaveCount(0)
+    await expect(page.getByText('The script ran successfully against the mock Slack API.', { exact: false })).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByTestId('message-assistant').getByText(newId, { exact: true })).toBeVisible()
+    const notice = page.getByTestId('connection-replacement-notice')
+    await expect(notice).toContainText('Slack connection replaced')
+    await expect(notice).toContainText('Session interrupted. Agent notified')
+    await expect(page.getByTestId('interrupt-marker')).toHaveCount(0)
+    await expect(page.getByText('#engineering', { exact: true })).toBeVisible()
+    expect(upstreamCalls).toEqual(['demo-slack-member-active'])
+
+    const sent = await recorder.waitFor((r) => r.type === 'sendMessage' && r.sessionId === sessionId && !!r.content?.includes(`New account ID: ${newId}`))
+    expect(sent.content).toContain(`Previous account ID: ${oldId}`)
+    const events = recorder.read().filter((r) => r.agentSlug === slug)
+    const refreshIndex = events.findIndex((r) => r.type === 'connectionEnvironment' && !!r.value?.includes(newId))
+    const interruptIndex = events.findIndex((r) => r.type === 'interruptSession' && r.sessionId === sessionId)
+    const messageIndex = events.findIndex((r) => r.type === 'sendMessage' && r.content === sent.content)
+    expect(refreshIndex).toBeGreaterThanOrEqual(0)
+    expect(interruptIndex).toBeGreaterThan(refreshIndex)
+    expect(messageIndex).toBeGreaterThan(interruptIndex)
+    expect(events[interruptIndex]).toMatchObject({ scope: 'turn', hadTurnInFlight: true })
+    const projected = JSON.parse(events[refreshIndex].value!)
+    expect(JSON.stringify(projected)).toContain(newId)
+    expect(JSON.stringify(projected)).not.toContain(oldId)
+    const mappings = await page.request.get(`/api/agents/${slug}/connected-accounts`)
+    expect((await mappings.json()).accounts.map((a: { id: string }) => a.id)).toEqual([newId])
+    const originalAccounts = await owner.request.get('/api/connected-accounts')
+    expect((await originalAccounts.json()).accounts.some((a: { id: string }) => a.id === oldId)).toBe(true)
+    const scriptPath = path.join(process.env.SUPERAGENT_DATA_DIR!, 'agents', slug, 'workspace', 'scripts', 'list-slack-channels.mjs')
+    const script = await fs.readFile(scriptPath, 'utf8')
+    expect(script).toContain(newId)
+    expect(script).not.toContain(oldId)
+    marks.complete = Date.now()
+    await page.screenshot({ path: testInfo.outputPath('continued.png') })
+    await fs.writeFile(testInfo.outputPath('evidence.json'), JSON.stringify({
+      mock: 'Model/runtime and local Slack provider; real application UI, APIs, script execution and authorization',
+      agentSlug: slug, sessionId, memberRole: 'user', oldId, newId, systemMessage: sent.content,
+      runtimeSequence: events.filter((r) => ['connectionEnvironment', 'interruptSession', 'sendMessage'].includes(r.type)),
+      upstreamCalls, script,
+    }, null, 2))
+    await notice.getByText('Connection details', { exact: true }).click()
+    await expect(notice.getByText(oldId, { exact: true })).toBeVisible()
+    await expect(notice.getByText(newId, { exact: true })).toBeVisible()
+    await page.screenshot({ path: testInfo.outputPath('replacement-details.png') })
+    await pause(page, 4000)
+    await notice.getByText('Connection details', { exact: true }).click()
+    await pause(page, 3000)
+    marks.end = Date.now()
+    await fs.writeFile(testInfo.outputPath('marks.json'), JSON.stringify(marks, null, 2))
+    const video = page.video()!
+    await context.close()
+    await video.saveAs(testInfo.outputPath('demo.webm'))
+    // The same renderer must survive reloading persisted history.
+    await member.goto(`/agents/${slug}/sessions/${sessionId}`)
+    await expect(member.getByTestId('connection-replacement-notice')).toContainText('Slack connection replaced')
+    await expect(member.getByTestId('interrupt-marker')).toHaveCount(0)
+  } finally {
+    await Promise.all(contexts.map((context) => context.close()))
+    await new Promise<void>((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()))
+  }
+})

--- a/playwright.connection-replacement-demo.config.ts
+++ b/playwright.connection-replacement-demo.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test'
+import path from 'path'
+
+// Dedicated Auth Mode server and database; never uses a developer's data.
+const dataDir = path.resolve(process.env.SUPERAGENT_DATA_DIR ?? '.e2e-data/connection-replacement-demo')
+const port = process.env.E2E_PORT ?? '4317'
+const baseURL = `http://localhost:${port}`
+process.env.SUPERAGENT_DATA_DIR = dataDir
+process.env.E2E_CONNECTION_REPLACEMENT_DEMO = 'true'
+process.env.E2E_DEMO_SLACK_URL ??= 'http://127.0.0.1:4318'
+
+export default defineConfig({
+  testDir: './e2e/auth/specs',
+  testMatch: 'connection-replacement.demo.spec.ts',
+  outputDir: 'test-results/connection-replacement-demo',
+  workers: 1,
+  retries: 0,
+  timeout: 120_000,
+  reporter: [['list']],
+  use: { ...devices['Desktop Chrome'], baseURL },
+  webServer: {
+    command: 'node e2e/setup-e2e-data.js && npm run dev:web',
+    env: {
+      SUPERAGENT_DATA_DIR: dataDir,
+      VITE_CACHE_DIR: path.join(dataDir, '.vite'),
+      PORT: port,
+      AUTH_MODE: 'true',
+      E2E_MOCK: 'true',
+      E2E_CONNECTION_REPLACEMENT_DEMO: 'true',
+      E2E_DEMO_SLACK_URL: process.env.E2E_DEMO_SLACK_URL,
+      ANTHROPIC_API_KEY: 'sk-ant-e2e-mock',
+    },
+    url: `${baseURL}/api/settings`,
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+})

--- a/src/api/routes/account-reauth.test.ts
+++ b/src/api/routes/account-reauth.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Hono } from 'hono'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import { eq } from 'drizzle-orm'
+import * as schema from '@shared/lib/db/schema'
+
+let testDb: ReturnType<typeof drizzle>
+let sqlite: InstanceType<typeof Database>
+let currentUserId = 'member'
+let authMode = true
+const syncEnvironment = vi.fn()
+const activeSessions = vi.fn<() => string[]>()
+const interrupt = vi.fn()
+const send = vi.fn()
+
+vi.mock('@shared/lib/db', () => ({ get db() { return testDb } }))
+vi.mock('@shared/lib/auth/mode', () => ({ isAuthMode: () => authMode }))
+vi.mock('@shared/lib/auth/config', () => ({ getCurrentUserId: () => currentUserId }))
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    syncAgentSessionsAwaiting: vi.fn(), getActiveSessionIdsForAgent: () => activeSessions(),
+    isSessionActive: () => true, getTurnGeneration: () => 3, markSessionInterrupted: vi.fn(),
+    withSessionSend: async (_agent: string, _session: string, _client: unknown, deliver: () => Promise<void>) => deliver(),
+  },
+}))
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    getCachedInfo: () => ({ status: 'running' }),
+    getClient: () => ({ interruptSession: interrupt, sendMessage: send }),
+  },
+}))
+vi.mock('@shared/lib/container/connection-runtime-sync', () => ({
+  syncAgentConnectionEnvironment: (...args: unknown[]) => syncEnvironment(...args),
+}))
+vi.mock('@shared/lib/services/audit-log-service', () => ({ logAuditEvent: vi.fn() }))
+vi.mock('@shared/lib/platform-attribution', () => ({}))
+vi.mock('@shared/lib/utils/file-storage', () => ({ resolveAgentId: vi.fn() }))
+vi.mock('@shared/lib/proxy/token-store', () => ({ validateProxyToken: vi.fn() }))
+
+import accountReauth from './account-reauth'
+import { accountReauthManager } from '@shared/lib/proxy/account-reauth-manager'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+import { getReplacementAccountId } from '@shared/lib/proxy/account-replacement'
+
+type TestEnv = { Variables: { user: { id: string }; agentId: string } }
+let app: Hono<TestEnv>
+
+function account(id: string, userId: string, status: 'active' | 'expired' = 'active', toolkitSlug = 'slack') {
+  testDb.insert(schema.connectedAccounts).values({
+    id, userId, status, toolkitSlug, providerConnectionId: `provider-${id}`,
+    displayName: id, createdAt: new Date(), updatedAt: new Date(),
+  }).run()
+}
+
+function mapping(agentSlug: string, connectedAccountId: string) {
+  testDb.insert(schema.agentConnectedAccounts).values({
+    id: `${agentSlug}-${connectedAccountId}`, agentSlug, connectedAccountId, createdAt: new Date(),
+  }).run()
+}
+
+function mappedAccounts(agentSlug: string) {
+  return testDb.select().from(schema.agentConnectedAccounts)
+    .where(eq(schema.agentConnectedAccounts.agentSlug, agentSlug)).all()
+    .map((row) => row.connectedAccountId).sort()
+}
+
+function park(agentSlug = 'shared-agent') {
+  const settled = accountReauthManager.requestReauth({
+    agentSlug, accountId: 'old', toolkit: 'slack', accountStatus: 'expired',
+  }).catch((error: unknown) => error)
+  const [request] = userInputRequestManager.getAgentScopedRequests(agentSlug)
+  return { id: request.id, settled }
+}
+
+function replace(requestId: string, accountIds = ['mine'], agentSlug = 'shared-agent') {
+  return app.request(`/api/agents/${agentSlug}/reauth-request/${requestId}/replace-account`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ accountIds }),
+  })
+}
+
+beforeEach(() => {
+  sqlite = new Database(':memory:')
+  testDb = drizzle(sqlite, { schema })
+  migrate(testDb, { migrationsFolder: 'src/shared/lib/db/migrations' })
+  currentUserId = 'member'
+  authMode = true
+  syncEnvironment.mockReset().mockResolvedValue(true)
+  activeSessions.mockReset().mockReturnValue([])
+  interrupt.mockReset().mockResolvedValue({ interrupted: true, processKept: true })
+  send.mockReset().mockResolvedValue(undefined)
+  userInputRequestManager.reset()
+  for (const id of ['owner', 'member', 'viewer', 'stranger']) {
+    testDb.insert(schema.user).values({ id, name: id, email: `${id}@test.example` }).run()
+  }
+  for (const agentSlug of ['shared-agent', 'other-agent']) {
+    for (const role of ['owner', 'user', 'viewer'] as const) {
+      const userId = role === 'user' ? 'member' : role
+      testDb.insert(schema.agentAcl).values({
+        id: `${agentSlug}-${userId}`, userId, agentSlug, role, createdAt: new Date(),
+      }).run()
+    }
+  }
+  account('old', 'owner', 'expired')
+  account('mine', 'member')
+  account('theirs', 'owner')
+  mapping('shared-agent', 'old')
+  mapping('other-agent', 'old')
+
+  // Supply the authenticated context established by the parent agents router;
+  // exercise the real AgentUser middleware and ownership SQL in the child route.
+  app = new Hono<TestEnv>()
+  app.use('/api/agents/:id/*', async (c, next) => {
+    c.set('user', { id: currentUserId })
+    c.set('agentId', c.req.param('id'))
+    await next()
+  })
+  app.route('/api/agents', accountReauth)
+})
+
+afterEach(() => {
+  accountReauthManager.rejectAll()
+  userInputRequestManager.reset()
+  sqlite.close()
+})
+
+describe('account reauthentication replacement', () => {
+  it('interrupts the active session and sends the replacement ID through the system-message path', async () => {
+    activeSessions.mockReturnValue(['running-session'])
+    const request = park()
+    const response = await replace(request.id)
+    expect(await response.json()).toEqual({ success: true, liveRefresh: true, sessionNotification: true })
+    expect(interrupt).toHaveBeenCalledWith('running-session', { scope: 'turn' })
+    expect(send).toHaveBeenCalledWith('running-session',
+      expect.stringContaining('[SYSTEM] Connection to "Slack" was replaced.'),
+      expect.any(String), { shouldQuery: true })
+    expect(send.mock.calls[0][1]).toContain('ID: mine.')
+  })
+
+  it('lets a shared-agent member replace an owner connection only for that agent', async () => {
+    const oldRecord = testDb.select().from(schema.connectedAccounts).where(eq(schema.connectedAccounts.id, 'old')).get()
+    const request = park()
+    const other = park('other-agent')
+    const response = await replace(request.id)
+
+    expect(response.status).toBe(200)
+    expect(getReplacementAccountId(await request.settled)).toBe('mine')
+    expect(mappedAccounts('shared-agent')).toEqual(['mine'])
+    expect(mappedAccounts('other-agent')).toEqual(['old'])
+    expect(testDb.select().from(schema.connectedAccounts).where(eq(schema.connectedAccounts.id, 'old')).get()).toEqual(oldRecord)
+    expect(userInputRequestManager.getOpenRequest(other.id)).not.toBeNull()
+    expect(syncEnvironment).toHaveBeenCalledWith('shared-agent', 'connected-accounts')
+  })
+
+  it.each(['viewer', 'stranger'])('rejects a %s through the real agent ACL check', async (userId) => {
+    currentUserId = userId
+    const request = park()
+    expect((await replace(request.id)).status).toBe(403)
+    expect(mappedAccounts('shared-agent')).toEqual(['old'])
+    expect(userInputRequestManager.getOpenRequest(request.id)).not.toBeNull()
+  })
+
+  it('rejects a replacement owned by another user', async () => {
+    const request = park()
+    expect((await replace(request.id, ['theirs'])).status).toBe(404)
+    expect(mappedAccounts('shared-agent')).toEqual(['old'])
+    expect(userInputRequestManager.getOpenRequest(request.id)).not.toBeNull()
+  })
+
+  it.each([
+    { status: 'expired' as const, toolkit: 'slack', expected: 409 },
+    { status: 'active' as const, toolkit: 'gmail', expected: 400 },
+  ])('rejects an incompatible replacement: $status $toolkit', async ({ status, toolkit, expected }) => {
+    account('invalid', 'member', status, toolkit)
+    const request = park()
+    expect((await replace(request.id, ['invalid'])).status).toBe(expected)
+    expect(mappedAccounts('shared-agent')).toEqual(['old'])
+  })
+
+  it('rejects cross-agent and already-settled requests without changing mappings', async () => {
+    const request = park()
+    expect((await replace(request.id, ['mine'], 'other-agent')).status).toBe(404)
+    accountReauthManager.dismiss(request.id, 'shared-agent')
+    expect((await replace(request.id)).status).toBe(404)
+    expect(mappedAccounts('shared-agent')).toEqual(['old'])
+    expect(mappedAccounts('other-agent')).toEqual(['old'])
+  })
+
+  it('rejects missing original mappings and multiple replacements', async () => {
+    const request = park()
+    expect((await replace(request.id, ['mine', 'theirs'])).status).toBe(400)
+    testDb.delete(schema.agentConnectedAccounts)
+      .where(eq(schema.agentConnectedAccounts.agentSlug, 'shared-agent')).run()
+    expect((await replace(request.id)).status).toBe(409)
+    expect(mappedAccounts('shared-agent')).toEqual([])
+    expect(userInputRequestManager.getOpenRequest(request.id)).not.toBeNull()
+  })
+
+  it('accepts an already-assigned replacement without duplicating its mapping', async () => {
+    mapping('shared-agent', 'mine')
+    const request = park()
+    expect((await replace(request.id)).status).toBe(200)
+    expect(mappedAccounts('shared-agent')).toEqual(['mine'])
+  })
+
+  it('rolls back the replacement if removing the old mapping fails', async () => {
+    sqlite.exec(`CREATE TRIGGER fail_unlink BEFORE DELETE ON agent_connected_accounts
+      BEGIN SELECT RAISE(ABORT, 'test unlink failure'); END;`)
+    const request = park()
+    expect((await replace(request.id)).status).toBe(500)
+    expect(mappedAccounts('shared-agent')).toEqual(['old'])
+    expect(userInputRequestManager.getOpenRequest(request.id)).not.toBeNull()
+    expect(syncEnvironment).not.toHaveBeenCalled()
+  })
+
+  it('releases the pending call and reports a failed metadata refresh', async () => {
+    syncEnvironment.mockResolvedValue(false)
+    const request = park()
+    const response = await replace(request.id)
+    expect(await response.json()).toEqual({ success: true, liveRefresh: false, sessionNotification: false })
+    expect(getReplacementAccountId(await request.settled)).toBe('mine')
+    expect(mappedAccounts('shared-agent')).toEqual(['mine'])
+  })
+
+  it('preserves single-user mode behavior without an account owner restriction', async () => {
+    authMode = false
+    const request = park()
+    expect((await replace(request.id, ['theirs'])).status).toBe(200)
+    expect(mappedAccounts('shared-agent')).toEqual(['theirs'])
+  })
+})

--- a/src/api/routes/account-reauth.ts
+++ b/src/api/routes/account-reauth.ts
@@ -1,0 +1,89 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { and, eq } from 'drizzle-orm'
+import { db } from '@shared/lib/db'
+import { agentConnectedAccounts, connectedAccounts } from '@shared/lib/db/schema'
+import { getCurrentUserId } from '@shared/lib/auth/config'
+import { ownerScope } from '@shared/lib/auth/ownership'
+import { accountReauthManager } from '@shared/lib/proxy/account-reauth-manager'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+import { messagePersister } from '@shared/lib/container/message-persister'
+import { finishConnectionReplacement } from '@shared/lib/container/connection-replacement'
+import { getProvider } from '@shared/lib/account-providers/service-catalog'
+import { logAuditEvent } from '@shared/lib/services/audit-log-service'
+import { AgentUser, getAgentId } from '../middleware/auth'
+
+const accountReauth = new Hono()
+const replacementSchema = z.object({ accountIds: z.array(z.string().min(1)).length(1) })
+
+// Mounted under agents, after authentication and agent resolution. Members can
+// supply their own connection, as in provide-connected-account/provide-remote-mcp.
+accountReauth.post('/:id/reauth-request/:requestId/replace-account', AgentUser(), async (c) => {
+  const slug = getAgentId(c)
+  const requestId = c.req.param('requestId')
+  const parsed = replacementSchema.safeParse(await c.req.json().catch(() => null))
+  if (!parsed.success) return c.json({ error: 'Select one replacement account' }, 400)
+
+  try {
+    // Keep validation and the mapping swap synchronous and atomic: a timeout,
+    // dismissal, or owner reconnect cannot settle the card between them.
+    const result = db.transaction((tx) => {
+      const request = userInputRequestManager.getOpenRequest(requestId)
+      if (request?.kind !== 'account_reauth_required' || request.scope.agentSlug !== slug) {
+        return { error: 'Reconnection request is no longer available', status: 404 as const }
+      }
+      const previousAccountId = request.payload.accountId
+      if (!previousAccountId || !request.payload.toolkit) {
+        return { error: 'Invalid reconnection request', status: 409 as const }
+      }
+      const accountId = parsed.data.accountIds[0]
+      const replacement = tx.select().from(connectedAccounts).where(and(
+        eq(connectedAccounts.id, accountId),
+        ownerScope(c, connectedAccounts.userId),
+      )).get()
+      if (!replacement) return { error: 'Account not found', status: 404 as const }
+      if (replacement.toolkitSlug !== request.payload.toolkit || accountId === previousAccountId) {
+        return { error: 'Choose a different account for the same service', status: 400 as const }
+      }
+      if (replacement.status !== 'active') {
+        return { error: 'Reconnect the replacement account before granting access', status: 409 as const }
+      }
+      const mapping = tx.select().from(agentConnectedAccounts).where(and(
+        eq(agentConnectedAccounts.agentSlug, slug),
+        eq(agentConnectedAccounts.connectedAccountId, previousAccountId),
+      )).get()
+      if (!mapping) return { error: 'The original account is no longer assigned to this agent', status: 409 as const }
+
+      tx.insert(agentConnectedAccounts).values({
+        id: crypto.randomUUID(),
+        agentSlug: slug,
+        connectedAccountId: accountId,
+        createdAt: new Date(),
+      }).onConflictDoNothing().run()
+      tx.delete(agentConnectedAccounts).where(eq(agentConnectedAccounts.id, mapping.id)).run()
+      return { accountId, previousAccountId, toolkit: request.payload.toolkit }
+    })
+    if ('error' in result) return c.json({ error: result.error }, result.status)
+
+    logAuditEvent({ userId: getCurrentUserId(c), object: 'account', objectId: result.previousAccountId, action: 'unassigned', details: { agentSlug: slug } })
+    logAuditEvent({ userId: getCurrentUserId(c), object: 'account', objectId: result.accountId, action: 'assigned', details: { agentSlug: slug } })
+    const recovery = await finishConnectionReplacement({
+      agentSlug: slug,
+      kind: 'connected-accounts',
+      name: getProvider(result.toolkit)?.displayName ?? result.toolkit,
+      previousId: result.previousAccountId,
+      replacementId: result.accountId,
+    }, () => {
+      if (!accountReauthManager.replaceAccount(requestId, slug, result.accountId)) {
+        userInputRequestManager.resolve(requestId, 'answered')
+        messagePersister.syncAgentSessionsAwaiting(slug)
+      }
+    })
+    return c.json({ success: true, ...recovery })
+  } catch (error) {
+    console.error('Failed to replace account connection:', error)
+    return c.json({ error: 'Failed to replace the connection' }, 500)
+  }
+})
+
+export default accountReauth

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -7,6 +7,8 @@ import { randomUUID } from 'crypto'
 import { z } from 'zod'
 import { zValidator } from '@hono/zod-validator'
 import { getPolyfillJs } from '../speech-recognition-polyfill'
+import accountReauth from './account-reauth'
+import mcpReauth from './mcp-reauth'
 import { getLlmPolyfillJs } from '../llm-polyfill'
 import {
   dashboardMountPath,
@@ -7457,6 +7459,9 @@ agents.get('/:id/pending-requests', AgentRead(), (c) => {
 // =============================================================================
 
 const MAX_DISMISS_REASON_LENGTH = 500
+
+agents.route('/', accountReauth)
+agents.route('/', mcpReauth)
 
 // POST /api/agents/:id/reauth-request/:requestId/dismiss - Give up on a parked
 // re-authentication card.

--- a/src/api/routes/mcp-proxy.reauth.integration.test.ts
+++ b/src/api/routes/mcp-proxy.reauth.integration.test.ts
@@ -119,6 +119,20 @@ describe('MCP re-auth park → reconnect → resume integration', () => {
     userInputRequestManager.reset()
   })
 
+  it('settles replaced MCP calls with the new ID without forwarding stale tools', async () => {
+    const response = app.request('http://localhost/api/mcp-proxy/agent-1/mcp-1', {
+      method: 'POST', headers: rpcHeaders(),
+      body: JSON.stringify({ jsonrpc: '2.0', id: 21, method: 'tools/call', params: { name: 'search', arguments: {} } }),
+    })
+    await vi.waitFor(() => expect(userInputRequestManager.getAgentScopedRequests('agent-1')).toHaveLength(1))
+    const [request] = userInputRequestManager.getAgentScopedRequests('agent-1')
+    expect(mcpReauthManager.replaceMcp(request.id, 'agent-1', 'new-mcp')).toBe(true)
+    const result = await response
+    expect(result.status).toBe(409)
+    expect(await result.json()).toMatchObject({ error: 'mcp_replaced', replacementMcpId: 'new-mcp' })
+    expect(mocks.safeFetch).not.toHaveBeenCalled()
+  })
+
   it('deduplicates the card and resumes concurrent calls on one real upstream session', async () => {
     const initialize = await app.request('http://localhost/api/mcp-proxy/agent-1/mcp-1', {
       method: 'POST',

--- a/src/api/routes/mcp-proxy.ts
+++ b/src/api/routes/mcp-proxy.ts
@@ -4,6 +4,7 @@ import { validateProxyToken } from '@shared/lib/proxy/token-store'
 import { resolveMcpPolicy } from '@shared/lib/proxy/policy-resolver'
 import { reviewManager } from '@shared/lib/proxy/review-manager'
 import { mcpReauthManager } from '@shared/lib/proxy/mcp-reauth-manager'
+import { getReplacementMcpId } from '@shared/lib/proxy/mcp-replacement'
 import { isReauthDismissed, reauthDismissalReason, withDismissalReason } from '@shared/lib/proxy/reauth-dismissal'
 import { db } from '@shared/lib/db'
 import {
@@ -385,6 +386,7 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
 
   type ReauthResult =
     | { ok: true }
+    | { ok: false; reason: 'replaced'; replacementMcpId: string }
     // See the account proxy for `dismissReason`.
     | { ok: false; reason: 'timeout' | 'dismissed' | 'missing' | 'inactive'; dismissReason?: string }
 
@@ -397,6 +399,8 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
         authType: mcp!.authType,
       }, c.req.raw.signal)
     } catch (error) {
+      const replacementMcpId = getReplacementMcpId(error)
+      if (replacementMcpId) return { ok: false, reason: 'replaced', replacementMcpId }
       // See the account proxy: a dismissal is a decision, not a stalled wait.
       if (isReauthDismissed(error)) {
         return { ok: false, reason: 'dismissed', dismissReason: reauthDismissalReason(error) }
@@ -414,6 +418,15 @@ mcpProxy.all('/:agentSlug/:mcpId/:rest{.*}?', async (c) => {
   const reauthFailureResponse = async (
     result: Exclude<ReauthResult, { ok: true }>,
   ) => {
+    if (result.reason === 'replaced') {
+      const message = `This MCP connection was replaced. Use the tools for MCP ID ${result.replacementMcpId} instead of ${mcpId}.`
+      await logMcpAuditEntry({
+        agentSlug, remoteMcpId: mcpId, remoteMcpName: mcp?.name ?? mcpId,
+        method, requestPath: mcpMethodInfo, statusCode: 409, errorMessage: message,
+        durationMs: Date.now() - startTime, matchedTool: toolName ?? undefined,
+      })
+      return c.json({ error: 'mcp_replaced', message, replacementMcpId: result.replacementMcpId }, 409)
+    }
     const failure = MCP_REAUTH_FAILURES[result.reason]
     const { statusCode, error } = failure
     const message = withDismissalReason(failure.message, result.dismissReason)

--- a/src/api/routes/mcp-reauth.test.ts
+++ b/src/api/routes/mcp-reauth.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Hono } from 'hono'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+import { eq } from 'drizzle-orm'
+import * as schema from '@shared/lib/db/schema'
+
+let testDb: ReturnType<typeof drizzle>
+let sqlite: InstanceType<typeof Database>
+let currentUserId = 'member'
+const syncEnvironment = vi.fn()
+const activeSessions = vi.fn<() => string[]>()
+const interrupt = vi.fn()
+const send = vi.fn()
+vi.mock('@shared/lib/db', () => ({ get db() { return testDb } }))
+vi.mock('@shared/lib/auth/mode', () => ({ isAuthMode: () => true }))
+vi.mock('@shared/lib/auth/config', () => ({ getCurrentUserId: () => currentUserId }))
+vi.mock('@shared/lib/container/message-persister', () => ({
+  messagePersister: {
+    syncAgentSessionsAwaiting: vi.fn(), getActiveSessionIdsForAgent: () => activeSessions(),
+    isSessionActive: () => true, getTurnGeneration: () => 3, markSessionInterrupted: vi.fn(),
+    withSessionSend: async (_agent: string, _session: string, _client: unknown, deliver: () => Promise<void>) => deliver(),
+  },
+}))
+vi.mock('@shared/lib/container/container-manager', () => ({
+  containerManager: {
+    getCachedInfo: () => ({ status: 'running' }),
+    getClient: () => ({ interruptSession: interrupt, sendMessage: send }),
+  },
+}))
+vi.mock('@shared/lib/container/connection-runtime-sync', () => ({
+  syncAgentConnectionEnvironment: (...args: unknown[]) => syncEnvironment(...args),
+}))
+vi.mock('@shared/lib/services/audit-log-service', () => ({ logAuditEvent: vi.fn() }))
+vi.mock('@shared/lib/platform-attribution', () => ({}))
+vi.mock('@shared/lib/utils/file-storage', () => ({ resolveAgentId: vi.fn() }))
+vi.mock('@shared/lib/proxy/token-store', () => ({ validateProxyToken: vi.fn() }))
+
+import mcpReauth from './mcp-reauth'
+import { mcpReauthManager } from '@shared/lib/proxy/mcp-reauth-manager'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+import { getReplacementMcpId } from '@shared/lib/proxy/mcp-replacement'
+
+type TestEnv = { Variables: { user: { id: string }; agentId: string } }
+let app: Hono<TestEnv>
+const oldUrl = 'https://custom-mcp.example/mcp?token=private-owner-token'
+const newUrl = 'https://custom-mcp.example/mcp?token=member-token'
+
+function mcp(id: string, userId: string, status: 'active' | 'auth_required' = 'active', url = newUrl) {
+  testDb.insert(schema.remoteMcpServers).values({
+    id, userId, status, url, name: 'Custom MCP', authType: 'oauth',
+    accessToken: `secret-${id}`, createdAt: new Date(), updatedAt: new Date(),
+  }).run()
+}
+function mapping(agentSlug: string, remoteMcpId: string) {
+  testDb.insert(schema.agentRemoteMcps).values({
+    id: `${agentSlug}-${remoteMcpId}`, agentSlug, remoteMcpId, createdAt: new Date(),
+  }).run()
+}
+function mapped(agentSlug: string) {
+  return testDb.select().from(schema.agentRemoteMcps).where(eq(schema.agentRemoteMcps.agentSlug, agentSlug)).all()
+    .map((row) => row.remoteMcpId).sort()
+}
+function park(agentSlug = 'shared-agent') {
+  const settled = mcpReauthManager.requestReauth({ agentSlug, mcpId: 'old', mcpName: 'Custom MCP', authType: 'oauth' })
+    .catch((error: unknown) => error)
+  const [request] = userInputRequestManager.getAgentScopedRequests(agentSlug)
+  return { id: request.id, settled }
+}
+function url(requestId: string, agentSlug = 'shared-agent') {
+  return `/api/agents/${agentSlug}/reauth-request/${requestId}/replace-mcp`
+}
+function replace(requestId: string, remoteMcpIds = ['mine'], agentSlug = 'shared-agent') {
+  return app.request(url(requestId, agentSlug), {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ remoteMcpIds }),
+  })
+}
+
+beforeEach(() => {
+  sqlite = new Database(':memory:')
+  testDb = drizzle(sqlite, { schema })
+  migrate(testDb, { migrationsFolder: 'src/shared/lib/db/migrations' })
+  currentUserId = 'member'
+  syncEnvironment.mockReset().mockResolvedValue(true)
+  activeSessions.mockReset().mockReturnValue([])
+  interrupt.mockReset().mockResolvedValue({ interrupted: true, processKept: true })
+  send.mockReset().mockResolvedValue(undefined)
+  userInputRequestManager.reset()
+  for (const id of ['owner', 'member', 'viewer', 'stranger']) {
+    testDb.insert(schema.user).values({ id, name: id, email: `${id}@test.example` }).run()
+  }
+  for (const agentSlug of ['shared-agent', 'other-agent']) {
+    for (const role of ['owner', 'user', 'viewer'] as const) {
+      const userId = role === 'user' ? 'member' : role
+      testDb.insert(schema.agentAcl).values({ id: `${agentSlug}-${userId}`, userId, agentSlug, role, createdAt: new Date() }).run()
+    }
+  }
+  mcp('old', 'owner', 'auth_required', oldUrl)
+  mcp('mine', 'member')
+  mcp('theirs', 'owner')
+  mapping('shared-agent', 'old')
+  mapping('other-agent', 'old')
+  app = new Hono<TestEnv>()
+  app.use('/api/agents/:id/*', async (c, next) => {
+    c.set('user', { id: currentUserId })
+    c.set('agentId', c.req.param('id'))
+    await next()
+  })
+  app.route('/api/agents', mcpReauth)
+})
+afterEach(() => {
+  mcpReauthManager.rejectAll()
+  userInputRequestManager.reset()
+  sqlite.close()
+})
+
+describe('MCP connection replacement', () => {
+  it('interrupts the active session and sends the replacement ID through the system-message path', async () => {
+    activeSessions.mockReturnValue(['running-session'])
+    const request = park()
+    const response = await replace(request.id)
+    expect(await response.json()).toEqual({ success: true, liveRefresh: true, sessionNotification: true })
+    expect(interrupt).toHaveBeenCalledWith('running-session', { scope: 'turn' })
+    expect(send).toHaveBeenCalledWith('running-session',
+      expect.stringContaining('[SYSTEM] Connection to "Custom MCP" was replaced.'),
+      expect.any(String), { shouldQuery: true })
+    expect(send.mock.calls[0][1]).toContain('ID: mine.')
+  })
+
+  it('replaces only the shared agent mapping and refreshes before releasing the parked calls', async () => {
+    const original = testDb.select().from(schema.remoteMcpServers).where(eq(schema.remoteMcpServers.id, 'old')).get()
+    const request = park()
+    const other = park('other-agent')
+    syncEnvironment.mockImplementation(async () => {
+      expect(mapped('shared-agent')).toEqual(['mine'])
+      expect(userInputRequestManager.getOpenRequest(request.id)).not.toBeNull()
+      return true
+    })
+    expect((await replace(request.id)).status).toBe(200)
+    expect(getReplacementMcpId(await request.settled)).toBe('mine')
+    expect(mapped('other-agent')).toEqual(['old'])
+    expect(testDb.select().from(schema.remoteMcpServers).where(eq(schema.remoteMcpServers.id, 'old')).get()).toEqual(original)
+    expect(userInputRequestManager.getOpenRequest(other.id)).not.toBeNull()
+    expect(syncEnvironment).toHaveBeenCalledWith('shared-agent', 'remote-mcps')
+  })
+
+  it('prefills with the member URL and never returns the original private URL', async () => {
+    const request = park()
+    const response = await app.request(url(request.id))
+    expect(await response.json()).toEqual({ url: newUrl })
+    testDb.delete(schema.remoteMcpServers).where(eq(schema.remoteMcpServers.id, 'mine')).run()
+    expect(await (await app.request(url(request.id))).json()).toEqual({ url: '' })
+  })
+
+  it.each(['viewer', 'stranger'])('rejects a %s through the real agent ACL', async (userId) => {
+    const request = park()
+    currentUserId = userId
+    expect((await app.request(url(request.id))).status).toBe(403)
+    expect((await replace(request.id)).status).toBe(403)
+    expect(mapped('shared-agent')).toEqual(['old'])
+  })
+
+  it('rejects another user’s replacement and cross-agent requests', async () => {
+    const request = park()
+    expect((await replace(request.id, ['theirs'])).status).toBe(404)
+    expect((await replace(request.id, ['mine'], 'other-agent')).status).toBe(404)
+    expect((await app.request(url(request.id, 'other-agent'))).status).toBe(404)
+    expect(mapped('shared-agent')).toEqual(['old'])
+  })
+
+  it.each([
+    { status: 'auth_required' as const, endpoint: newUrl, expected: 409 },
+    { status: 'active' as const, endpoint: 'https://different.example/mcp', expected: 400 },
+    { status: 'active' as const, endpoint: 'https://custom-mcp.example/other', expected: 400 },
+  ])('rejects an incompatible connection: $status $endpoint', async ({ status, endpoint, expected }) => {
+    mcp('invalid', 'member', status, endpoint)
+    const request = park()
+    expect((await replace(request.id, ['invalid'])).status).toBe(expected)
+    expect(mapped('shared-agent')).toEqual(['old'])
+    expect(userInputRequestManager.getOpenRequest(request.id)).not.toBeNull()
+  })
+
+  it('rejects stale cards and multiple replacements', async () => {
+    const request = park()
+    expect((await replace(request.id, ['mine', 'theirs'])).status).toBe(400)
+    mcpReauthManager.dismiss(request.id, 'shared-agent')
+    expect((await replace(request.id)).status).toBe(404)
+    expect(mapped('shared-agent')).toEqual(['old'])
+  })
+
+  it('accepts an already assigned replacement without duplicating the mapping', async () => {
+    mapping('shared-agent', 'mine')
+    const request = park()
+    expect((await replace(request.id)).status).toBe(200)
+    expect(mapped('shared-agent')).toEqual(['mine'])
+  })
+
+  it('rolls back the mapping swap if unlink fails', async () => {
+    sqlite.exec(`CREATE TRIGGER fail_unlink BEFORE DELETE ON agent_remote_mcps BEGIN SELECT RAISE(ABORT, 'test unlink failure'); END;`)
+    const request = park()
+    expect((await replace(request.id)).status).toBe(500)
+    expect(mapped('shared-agent')).toEqual(['old'])
+    expect(userInputRequestManager.getOpenRequest(request.id)).not.toBeNull()
+    expect(syncEnvironment).not.toHaveBeenCalled()
+  })
+})

--- a/src/api/routes/mcp-reauth.ts
+++ b/src/api/routes/mcp-reauth.ts
@@ -1,0 +1,84 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { and, eq } from 'drizzle-orm'
+import { db } from '@shared/lib/db'
+import { agentRemoteMcps, remoteMcpServers } from '@shared/lib/db/schema'
+import { getCurrentUserId } from '@shared/lib/auth/config'
+import { isOwnedByCaller, ownerScope } from '@shared/lib/auth/ownership'
+import { mcpReauthManager } from '@shared/lib/proxy/mcp-reauth-manager'
+import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
+import { messagePersister } from '@shared/lib/container/message-persister'
+import { finishConnectionReplacement } from '@shared/lib/container/connection-replacement'
+import { sameMcpEndpoint } from '@shared/lib/mcp/endpoint'
+import { COMMON_MCP_SERVERS } from '@shared/lib/mcp/common-servers'
+import { logAuditEvent } from '@shared/lib/services/audit-log-service'
+import { AgentUser, getAgentId } from '../middleware/auth'
+
+const mcpReauth = new Hono()
+const replacementSchema = z.object({ remoteMcpIds: z.array(z.string().min(1)).length(1) })
+
+function loadRequestedMcp(requestId: string, agentSlug: string) {
+  const request = userInputRequestManager.getOpenRequest(requestId)
+  if (request?.kind !== 'mcp_reauth_required' || request.scope.agentSlug !== agentSlug || !request.payload.mcpId) return null
+  return db.select({ mapping: agentRemoteMcps, mcp: remoteMcpServers })
+    .from(agentRemoteMcps).innerJoin(remoteMcpServers, eq(agentRemoteMcps.remoteMcpId, remoteMcpServers.id))
+    .where(and(eq(agentRemoteMcps.agentSlug, agentSlug), eq(remoteMcpServers.id, request.payload.mcpId)))
+    .get() ?? null
+}
+
+// Prefill from the caller's own connection or the public catalog. Never expose
+// another owner's custom URL, which may contain credentials in its query string.
+mcpReauth.get('/:id/reauth-request/:requestId/replace-mcp', AgentUser(), (c) => {
+  const current = loadRequestedMcp(c.req.param('requestId'), getAgentId(c))
+  if (!current) return c.json({ error: 'Reconnection request is no longer available' }, 404)
+  const ownMcps = db.select().from(remoteMcpServers).where(ownerScope(c, remoteMcpServers.userId)).all()
+  const ownMatch = ownMcps.find((mcp) => mcp.id !== current.mcp.id && sameMcpEndpoint(mcp.url, current.mcp.url))
+  const catalogMatch = COMMON_MCP_SERVERS.find((mcp) => sameMcpEndpoint(mcp.url, current.mcp.url))
+  const url = ownMatch?.url ?? catalogMatch?.url ?? (isOwnedByCaller(c, current.mcp) ? current.mcp.url : '')
+  return c.json({ url })
+})
+
+mcpReauth.post('/:id/reauth-request/:requestId/replace-mcp', AgentUser(), async (c) => {
+  const agentSlug = getAgentId(c)
+  const requestId = c.req.param('requestId')
+  const parsed = replacementSchema.safeParse(await c.req.json().catch(() => null))
+  if (!parsed.success) return c.json({ error: 'Select one replacement MCP connection' }, 400)
+
+  try {
+    const result = db.transaction((tx) => {
+      const current = loadRequestedMcp(requestId, agentSlug)
+      if (!current) return { error: 'Reconnection request is no longer available', status: 404 as const }
+      const replacementId = parsed.data.remoteMcpIds[0]
+      const replacement = tx.select().from(remoteMcpServers).where(and(
+        eq(remoteMcpServers.id, replacementId), ownerScope(c, remoteMcpServers.userId),
+      )).get()
+      if (!replacement) return { error: 'MCP connection not found', status: 404 as const }
+      if (replacementId === current.mcp.id || !sameMcpEndpoint(current.mcp.url, replacement.url)) {
+        return { error: 'Choose a different connection to the same MCP endpoint', status: 400 as const }
+      }
+      if (replacement.status !== 'active') return { error: 'Reconnect the replacement MCP before granting access', status: 409 as const }
+
+      tx.insert(agentRemoteMcps).values({
+        id: crypto.randomUUID(), agentSlug, remoteMcpId: replacementId, createdAt: new Date(),
+      }).onConflictDoNothing().run()
+      tx.delete(agentRemoteMcps).where(eq(agentRemoteMcps.id, current.mapping.id)).run()
+      return { previousId: current.mcp.id, replacementId, name: current.mcp.name }
+    })
+    if ('error' in result) return c.json({ error: result.error }, result.status)
+
+    logAuditEvent({ userId: getCurrentUserId(c), object: 'mcp', objectId: result.previousId, action: 'unassigned', details: { agentSlug } })
+    logAuditEvent({ userId: getCurrentUserId(c), object: 'mcp', objectId: result.replacementId, action: 'assigned', details: { agentSlug } })
+    const recovery = await finishConnectionReplacement({ agentSlug, kind: 'remote-mcps', ...result }, () => {
+      if (!mcpReauthManager.replaceMcp(requestId, agentSlug, result.replacementId)) {
+        userInputRequestManager.resolve(requestId, 'answered')
+        messagePersister.syncAgentSessionsAwaiting(agentSlug)
+      }
+    })
+    return c.json({ success: true, ...recovery })
+  } catch (error) {
+    console.error('Failed to replace MCP connection:', error)
+    return c.json({ error: 'Failed to replace the MCP connection' }, 500)
+  }
+})
+
+export default mcpReauth

--- a/src/api/routes/proxy.test.ts
+++ b/src/api/routes/proxy.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Hono } from 'hono'
+import { AccountReplacedError } from '@shared/lib/proxy/account-replacement'
 
 // Mock dependencies
 const mockValidateProxyToken = vi.fn()
@@ -788,6 +789,50 @@ describe('proxy route', () => {
         providerConnectionId: 'comp-reconnected',
       }))
     })
+
+    it.each(['local', 'remote', 'token'] as const)(
+      'returns replacement instructions from %s reauth and applies the new account policy on retry',
+      async (failure) => {
+        mockValidateProxyToken.mockResolvedValue('my-agent')
+        mockDbFrom.mockReturnValue({ innerJoin: mockInnerJoin })
+        mockInnerJoin.mockReturnValue({ where: mockWhere })
+        mockWhere.mockReturnValue({ limit: mockLimit })
+        mockLimit.mockResolvedValue([{ account: {
+          id: 'acc-123', toolkitSlug: 'slack', providerName: 'composio',
+          providerConnectionId: 'old-provider', userId: 'old-owner',
+          status: failure === 'local' ? 'expired' : 'active',
+        } }])
+        mockIsHostAllowed.mockReturnValue(true)
+        if (failure === 'remote') mockGetConnection.mockResolvedValueOnce({ status: 'EXPIRED' })
+        if (failure === 'token') mockMakeApiCall.mockRejectedValueOnce(new Error('Failed to fetch token'))
+        mockRequestReauth.mockRejectedValueOnce(new AccountReplacedError('replacement'))
+
+        const response = await makeRequest('/api/proxy/my-agent/acc-123/slack.com/api/conversations.list', {
+          headers: { Authorization: 'Bearer synth_valid' },
+        })
+        expect(response.status).toBe(409)
+        expect(await response.json()).toMatchObject({
+          error: 'account_replaced', replacementAccountId: 'replacement',
+          message: expect.stringContaining('Retry the request using account ID replacement'),
+        })
+        expect(mockMakeApiCall).toHaveBeenCalledTimes(failure === 'token' ? 1 : 0)
+
+        // The new credential must not inherit the old account's allow decision.
+        mockMakeApiCall.mockClear()
+        mockLimit.mockResolvedValue([{ account: {
+          id: 'replacement', toolkitSlug: 'slack', providerName: 'composio',
+          providerConnectionId: 'new-provider', userId: 'new-owner', status: 'active',
+        } }])
+        mockResolveApiPolicy.mockResolvedValueOnce({ decision: 'block', matchedScopes: ['test.scope'] })
+        const retry = await makeRequest('/api/proxy/my-agent/replacement/slack.com/api/conversations.list', {
+          headers: { Authorization: 'Bearer synth_valid' },
+        })
+        expect(retry.status).toBe(403)
+        expect(await retry.json()).toMatchObject({ error: 'blocked_by_policy' })
+        expect(mockResolveApiPolicy).toHaveBeenLastCalledWith('replacement', expect.anything(), 'new-owner', 'slack')
+        expect(mockMakeApiCall).not.toHaveBeenCalled()
+      },
+    )
 
     it('returns a clear timeout when local account re-authentication is abandoned', async () => {
       mockValidateProxyToken.mockResolvedValue('my-agent')

--- a/src/api/routes/proxy.ts
+++ b/src/api/routes/proxy.ts
@@ -6,6 +6,7 @@ import { matchScopes } from '@shared/lib/proxy/scope-matcher'
 import { resolveApiPolicy } from '@shared/lib/proxy/policy-resolver'
 import { reviewManager } from '@shared/lib/proxy/review-manager'
 import { accountReauthManager } from '@shared/lib/proxy/account-reauth-manager'
+import { getReplacementAccountId } from '@shared/lib/proxy/account-replacement'
 import { isReauthDismissed, reauthDismissalReason, withDismissalReason } from '@shared/lib/proxy/reauth-dismissal'
 import { getAccountProviderByName } from '@shared/lib/account-providers'
 import { attribution, runWithAttribution } from '@shared/lib/platform-attribution'
@@ -151,6 +152,7 @@ proxy.all('/:agentSlug/:accountId/:rest{.+}', async (c) => {
 
   type ReauthResult =
     | { ok: true }
+    | { ok: false; reason: 'replaced'; replacementAccountId: string }
     // `dismissReason` is what the dismisser typed, forwarded so the agent
     // learns WHY a person cut its call off, not merely that they did.
     | { ok: false; reason: 'timeout' | 'dismissed' | 'missing' | 'inactive'; dismissReason?: string }
@@ -164,6 +166,8 @@ proxy.all('/:agentSlug/:accountId/:rest{.+}', async (c) => {
         accountStatus: status,
       }, c.req.raw.signal)
     } catch (error) {
+      const replacementAccountId = getReplacementAccountId(error)
+      if (replacementAccountId) return { ok: false, reason: 'replaced', replacementAccountId }
       // A person pressing Dismiss and a five-minute timer both land here; only
       // the first should read as a decision the agent must respect.
       if (isReauthDismissed(error)) {
@@ -184,6 +188,15 @@ proxy.all('/:agentSlug/:accountId/:rest{.+}', async (c) => {
     status: 'expired' | 'revoked',
     auditError: (message: string, statusCode: number) => Promise<void>,
   ) => {
+    if (result.reason === 'replaced') {
+      await auditError('Account replaced for this agent by a user', 409)
+      return c.json({
+        error: 'account_replaced',
+        replacementAccountId: result.replacementAccountId,
+        message: `A user replaced this connection for this agent. Retry the request using account ID ${result.replacementAccountId} in the proxy URL instead of ${accountId}. The replacement account's access policies will be checked on the new request.`,
+      }, 409)
+    }
+
     if (result.reason === 'timeout') {
       await auditError(`Account re-authentication timed out (${status})`, 408)
       return c.json({

--- a/src/api/routes/remote-mcps.test.ts
+++ b/src/api/routes/remote-mcps.test.ts
@@ -1280,6 +1280,7 @@ describe('OAuth callback — postMessage origin', () => {
     expect(res.status).toBe(200)
     const html = await res.text()
     expect(html).toContain('window.location.origin')
+    expect(html).toContain('"state":"xyz"')
     expect(html).not.toContain("'*'")
   })
 
@@ -1330,6 +1331,7 @@ describe('OAuth callback — postMessage origin', () => {
     expect(res.status).toBe(200)
     const html = await res.text()
     expect(html).toContain('window.location.origin')
+    expect(html).toContain('"state":"xyz"')
     expect(html).not.toContain("'*'")
   })
 
@@ -1378,6 +1380,7 @@ describe('OAuth callback — postMessage origin', () => {
     expect(res.status).toBe(200)
     const html = await res.text()
     expect(html).toContain('window.location.origin')
+    expect(html).toContain('"state":"xyz"')
     expect(html).not.toContain("'*'")
     expect(mockFindAgentsAssignedRemoteMcp).toHaveBeenCalledWith('mcp-new')
     expect(mockSyncRemoteMcpAgents).toHaveBeenCalledWith(['agent-a'])
@@ -1458,6 +1461,7 @@ describe('OAuth callback — postMessage origin', () => {
     expect(html).toContain('window.location.replace')
     expect(html).toContain('superagent://mcp-oauth-callback?success=true')
     expect(html).toContain('mcpId=mcp-new')
+    expect(html).toContain('state=xyz')
     // NOT the web postMessage/BroadcastChannel bridge.
     expect(html).not.toContain("new BroadcastChannel('mcp-oauth-callback')")
   })

--- a/src/api/routes/remote-mcps.ts
+++ b/src/api/routes/remote-mcps.ts
@@ -61,6 +61,7 @@ function escapeHtml(str: string): string {
 
 type McpOAuthCallbackPayload = {
   type: 'mcp-oauth-callback'
+  state?: string
   success: boolean
   mcpId?: string
   error?: string
@@ -155,6 +156,7 @@ function renderMcpOAuthHandoffHtml(payload: McpOAuthCallbackPayload, desktopProt
   const protocol = resolveDesktopOAuthProtocol(desktopProtocol)
   const params = new URLSearchParams()
   params.set('success', payload.success ? 'true' : 'false')
+  if (payload.state) params.set('state', payload.state)
   if (payload.mcpId) params.set('mcpId', payload.mcpId)
   if (payload.error) params.set('error', payload.error)
   const deepLink = `${protocol}://mcp-oauth-callback?${params.toString()}`
@@ -422,14 +424,14 @@ remoteMcps.get('/oauth-callback', async (c) => {
     const issuerValidation = validateAndConsumeOAuthErrorResponse(state, iss)
     if (!issuerValidation.valid) {
       return c.html(mcpOAuthCallbackBody(
-        { type: 'mcp-oauth-callback', success: false, error: 'OAuth callback validation failed' },
+        { type: 'mcp-oauth-callback', state, success: false, error: 'OAuth callback validation failed' },
         'OAuth callback validation failed. You can close this window.',
         issuerValidation,
       ))
     }
 
     return c.html(mcpOAuthCallbackBody(
-      { type: 'mcp-oauth-callback', success: false, error },
+      { type: 'mcp-oauth-callback', state, success: false, error },
       `OAuth error: ${error}. You can close this window.`,
       issuerValidation,
     ))
@@ -448,7 +450,7 @@ remoteMcps.get('/oauth-callback', async (c) => {
 
   if (!result.success || !result.mcpId) {
     return c.html(mcpOAuthCallbackBody(
-      { type: 'mcp-oauth-callback', success: false, error: 'Token exchange failed' },
+      { type: 'mcp-oauth-callback', state, success: false, error: 'Token exchange failed' },
       'OAuth failed. You can close this window.',
       delivery,
     ))
@@ -492,6 +494,7 @@ remoteMcps.get('/oauth-callback', async (c) => {
     return c.html(mcpOAuthCallbackBody(
       {
         type: 'mcp-oauth-callback',
+        state,
         success: false,
         error: `Connected but failed to discover tools: ${errorMsg}`,
       },
@@ -506,7 +509,7 @@ remoteMcps.get('/oauth-callback', async (c) => {
 
   trackServerEvent('mcp_oauth_succeeded', { url: serverUrl, mcpId: result.mcpId })
   return c.html(mcpOAuthCallbackBody(
-    { type: 'mcp-oauth-callback', success: true, mcpId: result.mcpId },
+    { type: 'mcp-oauth-callback', state, success: true, mcpId: result.mcpId },
     'OAuth successful! You can close this window.',
     delivery,
   ))

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1212,7 +1212,7 @@ function handleDeepLinkUrl(url: string, fromQueue = false) {
           const text = await res.text()
           mainWindow?.webContents.send(
             'mcp-oauth-callback',
-            parseMcpOAuthCompletionResponse(text),
+            { ...parseMcpOAuthCompletionResponse(text), state: plan.state },
           )
         })
         .catch((err) => {
@@ -1220,6 +1220,7 @@ function handleDeepLinkUrl(url: string, fromQueue = false) {
           mainWindow?.webContents.send('mcp-oauth-callback', {
             success: false,
             error: err.message || 'Failed to complete OAuth',
+            state: plan.state,
           })
         })
     }

--- a/src/main/mcp-oauth-callback.test.ts
+++ b/src/main/mcp-oauth-callback.test.ts
@@ -9,6 +9,7 @@ describe('planMcpOAuthCallback', () => {
     )
     expect(plan).toEqual({
       action: 'complete',
+      state: 'xyz',
       completionUrl:
         'http://localhost:4823/cloud/pr0xy-k3y/api/remote-mcps/oauth-callback?code=abc&state=xyz',
     })
@@ -21,6 +22,7 @@ describe('planMcpOAuthCallback', () => {
     )
     expect(plan).toEqual({
       action: 'complete',
+      state: 'xyz',
       completionUrl:
         'http://localhost:4823/api/remote-mcps/oauth-callback?code=abc&state=xyz&iss=https%3A%2F%2Fauth.example.com',
     })
@@ -28,23 +30,23 @@ describe('planMcpOAuthCallback', () => {
 
   it('notifies directly when the hand-off page already carries a success result', () => {
     const plan = planMcpOAuthCallback(
-      'superagent://mcp-oauth-callback?success=true&mcpId=mcp-1',
+      'superagent://mcp-oauth-callback?success=true&mcpId=mcp-1&state=own-flow',
       'http://localhost:4823/cloud/pr0xy-k3y',
     )
     expect(plan).toEqual({
       action: 'notify',
-      result: { success: true, mcpId: 'mcp-1', error: null },
+      result: { success: true, mcpId: 'mcp-1', error: null, state: 'own-flow' },
     })
   })
 
   it('notifies a failure with the carried error when success=false', () => {
     const plan = planMcpOAuthCallback(
-      'superagent://mcp-oauth-callback?success=false&error=Token%20exchange%20failed',
+      'superagent://mcp-oauth-callback?success=false&error=Token%20exchange%20failed&state=failed-flow',
       'http://localhost:4823',
     )
     expect(plan).toEqual({
       action: 'notify',
-      result: { success: false, mcpId: null, error: 'Token exchange failed' },
+      result: { success: false, mcpId: null, error: 'Token exchange failed', state: 'failed-flow' },
     })
   })
 

--- a/src/main/mcp-oauth-callback.ts
+++ b/src/main/mcp-oauth-callback.ts
@@ -2,6 +2,7 @@ export interface McpOAuthCallbackResult {
   success: boolean
   mcpId: string | null
   error: string | null
+  state?: string
 }
 
 export type McpOAuthCallbackPlan =
@@ -10,7 +11,7 @@ export type McpOAuthCallbackPlan =
   | { action: 'notify'; result: McpOAuthCallbackResult }
   // Custom-scheme path: the app received the raw code/state, so the token
   // exchange still has to run — against the Superagent that initiated the flow.
-  | { action: 'complete'; completionUrl: string }
+  | { action: 'complete'; completionUrl: string; state?: string }
 
 /**
  * Decide how to handle an mcp-oauth-callback deep link. `apiBaseUrl` must be
@@ -29,6 +30,7 @@ export function planMcpOAuthCallback(
     return null
   }
   const params = callbackUrl.searchParams
+  const state = params.get('state')
 
   if (params.has('success')) {
     const success = params.get('success') === 'true'
@@ -36,6 +38,7 @@ export function planMcpOAuthCallback(
       action: 'notify',
       result: {
         success,
+        ...(state ? { state } : {}),
         mcpId: params.get('mcpId') || null,
         error: success ? null : (params.get('error') || 'OAuth failed'),
       },
@@ -44,6 +47,7 @@ export function planMcpOAuthCallback(
 
   return {
     action: 'complete',
+    ...(state ? { state } : {}),
     completionUrl: `${apiBaseUrl}/api/remote-mcps/oauth-callback${callbackUrl.search}`,
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -50,6 +50,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // MCP OAuth callback handling - receives result from main process after token exchange
   onMcpOAuthCallback: (callback: (params: {
+    state?: string
     success: boolean
     mcpId?: string | null
     error?: string | null
@@ -478,7 +479,7 @@ declare global {
       desktopProtocol?: string
       onOAuthCallback: (callback: (params: OAuthCallbackParams) => void) => () => void
       removeOAuthCallback: () => void
-      onMcpOAuthCallback: (callback: (params: { success: boolean; mcpId?: string | null; error?: string | null }) => void) => () => void
+      onMcpOAuthCallback: (callback: (params: { state?: string; success: boolean; mcpId?: string | null; error?: string | null }) => void) => () => void
       removeMcpOAuthCallback: () => void
       onPlatformAuthCallback: (callback: (params: { success: boolean; email?: string | null; error?: string | null }) => void) => () => void
       removePlatformAuthCallback: () => void

--- a/src/renderer/components/messages/account-reauth-request-item.test.tsx
+++ b/src/renderer/components/messages/account-reauth-request-item.test.tsx
@@ -6,6 +6,14 @@ import { AccountReauthRequestItem } from './account-reauth-request-item'
 const mockReconnect = vi.fn()
 const mockDismiss = vi.fn()
 let mockPendingAccountId: string | null = null
+vi.mock('./connected-account-request-item', () => ({
+  ConnectedAccountRequestItem: ({ toolkit, replacement }: { toolkit: string; replacement: { requestId: string; onCancel: () => void } }) => (
+    <div data-testid="replacement-picker" data-toolkit={toolkit} data-request-id={replacement.requestId}>
+      <button onClick={replacement.onCancel}>Cancel replacement</button>
+    </div>
+  ),
+}))
+
 let mockOwnedAccountIds = ['account-1', 'account-2', 'account-3']
 
 vi.mock('@renderer/lib/reauth-dismiss', () => ({
@@ -93,7 +101,7 @@ describe('AccountReauthRequestItem', () => {
     expect(screen.getByText('Waiting for reconnection')).toBeInTheDocument()
   })
 
-  it('offers a member who does not own the account a way out instead of reconnect', () => {
+  it('lets a non-owner replace the connection and cancel back to the recovery card', () => {
     mockOwnedAccountIds = []
     render(
       <AccountReauthRequestItem
@@ -106,11 +114,16 @@ describe('AccountReauthRequestItem', () => {
       />,
     )
 
-    // Reconnecting stays the owner's alone, but the card blocks every session
-    // of the agent — so this member must not be left with nothing to press.
     expect(screen.queryByTestId('account-reauth-reconnect-btn')).not.toBeInTheDocument()
     expect(screen.getByTestId('account-reauth-dismiss-btn')).toBeInTheDocument()
-    expect(screen.getByText(/Only the connection owner can reconnect/)).toBeInTheDocument()
+    expect(screen.getByText(/Replace it with an account you own/)).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('account-reauth-replace-btn'))
+    expect(screen.getByTestId('replacement-picker')).toHaveAttribute('data-toolkit', 'gmail')
+    expect(screen.getByTestId('replacement-picker')).toHaveAttribute('data-request-id', 'proxy-4')
+    fireEvent.click(screen.getByText('Cancel replacement'))
+    expect(screen.getByTestId('account-reauth-dismiss-btn')).toBeInTheDocument()
+    expect(mockReconnect).not.toHaveBeenCalled()
+    expect(mockDismiss).not.toHaveBeenCalled()
   })
 
   it('dismisses the parked request and closes the card', async () => {
@@ -174,5 +187,6 @@ describe('AccountReauthRequestItem', () => {
     )
 
     expect(screen.queryByTestId('account-reauth-dismiss-btn')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('account-reauth-replace-btn')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/components/messages/account-reauth-request-item.tsx
+++ b/src/renderer/components/messages/account-reauth-request-item.tsx
@@ -9,6 +9,7 @@ import { getProvider } from '@shared/lib/account-providers/service-catalog'
 import { DeclineButton } from './decline-button'
 import { RequestItemActions } from './request-item-actions'
 import { RequestItemShell } from './request-item-shell'
+import { ConnectedAccountRequestItem } from './connected-account-request-item'
 
 interface AccountReauthRequestItemProps {
   proxyRequestId: string
@@ -31,6 +32,7 @@ export function AccountReauthRequestItem({
   readOnly,
   onComplete,
 }: AccountReauthRequestItemProps) {
+  const [replacing, setReplacing] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [dismissing, setDismissing] = useState(false)
   const { reconnect, pendingAccountId } = useOAuthReconnect()
@@ -41,9 +43,7 @@ export function AccountReauthRequestItem({
   const statusLabel = accountStatus === 'expired' ? 'expired' : 'been revoked'
   const ownsAccount = connectedAccounts?.accounts.some((account) => account.id === accountId)
   const canReconnect = !readOnly && ownsAccount === true
-  // Reconnecting is the owner's alone, but the card blocks every session of the
-  // agent — so anyone looking at it needs a way out, or a shared credential
-  // nobody present can fix wedges the agent until the request times out.
+  // Members can supply their own replacement without modifying the owner's credentials.
   const canDismiss = !readOnly
 
   const handleReconnect = async () => {
@@ -69,11 +69,25 @@ export function AccountReauthRequestItem({
     }
   }
 
+  if (replacing && !readOnly) {
+    return (
+      <ConnectedAccountRequestItem
+        toolUseId={proxyRequestId}
+        toolkit={toolkit}
+        reason={`Replace ${providerName} connection`}
+        sessionId={sessionId}
+        agentSlug={agentSlug}
+        replacement={{ requestId: proxyRequestId, onCancel: () => setReplacing(false) }}
+        onComplete={onComplete}
+      />
+    )
+  }
+
   return (
     <RequestItemShell
       title={`This request needs ${providerName} access that has ${statusLabel}.`}
       subtitle={ownsAccount === false
-        ? 'Only the connection owner can reconnect it. Dismiss to let the agent move on without it.'
+        ? 'Replace it with an account you own to continue, or dismiss this request.'
         : 'Reconnect to continue. The original request will resume automatically.'}
       icon={<ServiceIcon slug={toolkit} fallback="oauth" className="h-4 w-4" />}
       theme="orange"
@@ -93,6 +107,16 @@ export function AccountReauthRequestItem({
             label="Dismiss"
             data-testid="account-reauth-dismiss-btn"
           />
+          <Button
+            type="button"
+            size="xs"
+            variant={canReconnect ? 'outline' : 'default'}
+            onClick={() => setReplacing(true)}
+            disabled={isReconnecting || dismissing}
+            data-testid="account-reauth-replace-btn"
+          >
+            Replace connection
+          </Button>
           {canReconnect && (
             <Button
               type="button"

--- a/src/renderer/components/messages/connected-account-request-item.test.tsx
+++ b/src/renderer/components/messages/connected-account-request-item.test.tsx
@@ -1,12 +1,15 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ConnectedAccountRequestItem } from './connected-account-request-item'
 import { renderWithProviders } from '@renderer/test/test-utils'
 import { useConnectedAccountsByToolkit, useDeleteConnectedAccount } from '@renderer/hooks/use-connected-accounts'
 
 const mockApiFetch = vi.fn()
+vi.mock('@renderer/lib/oauth-popup', () => ({
+  prepareOAuthPopup: () => ({ navigate: vi.fn().mockResolvedValue(undefined), close: vi.fn() }),
+}))
 vi.mock('@renderer/lib/api', () => ({
   apiFetch: (...args: unknown[]) => mockApiFetch(...args),
 }))
@@ -138,6 +141,97 @@ describe('ConnectedAccountRequestItem', () => {
       expect(screen.getByText('Access Granted')).toBeInTheDocument()
     })
     expect(defaultProps.onComplete).toHaveBeenCalled()
+  })
+
+  it('submits a replacement to the agent-scoped endpoint without a session', async () => {
+    const user = userEvent.setup()
+    mockApiFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
+    renderWithProviders(
+      <ConnectedAccountRequestItem {...defaultProps} sessionId={undefined}
+        replacement={{ requestId: 'reauth-1', onCancel: vi.fn() }} />,
+    )
+    await user.click(screen.getByRole('button', { name: 'Replace connection' }))
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      '/api/agents/my-agent/reauth-request/reauth-1/replace-account',
+      expect.objectContaining({ body: expect.stringContaining('"accountIds":["acc-1"]') }),
+    )
+    await waitFor(() => expect(defaultProps.onComplete).toHaveBeenCalledOnce())
+  })
+
+  it('keeps the replacement picker open when the server rejects the account', async () => {
+    const user = userEvent.setup()
+    mockApiFetch.mockResolvedValueOnce({ ok: false, json: async () => ({ error: 'Account not found' }) })
+    renderWithProviders(
+      <ConnectedAccountRequestItem {...defaultProps}
+        replacement={{ requestId: 'reauth-1', onCancel: vi.fn() }} />,
+    )
+    await user.click(screen.getByRole('button', { name: 'Replace connection' }))
+    expect(await screen.findByText(/Account not found/)).toBeInTheDocument()
+    expect(defaultProps.onComplete).not.toHaveBeenCalled()
+  })
+
+  it('selects only one account when replacing a connection', async () => {
+    const user = userEvent.setup()
+    const existing = vi.mocked(useConnectedAccountsByToolkit)('github')
+    vi.mocked(useConnectedAccountsByToolkit).mockReturnValue({
+      ...existing,
+      data: { accounts: [existing.data!.accounts[0], { ...existing.data!.accounts[0], id: 'acc-2' }] },
+    })
+    renderWithProviders(
+      <ConnectedAccountRequestItem {...defaultProps}
+        replacement={{ requestId: 'reauth-1', onCancel: vi.fn() }} />,
+    )
+    const [first, second] = screen.getAllByRole('checkbox')
+    await user.click(first)
+    await user.click(second)
+    expect(first).not.toBeChecked()
+    expect(second).toBeChecked()
+  })
+
+  it('connects a new owned account and uses it instead of the previous selection', async () => {
+    const user = userEvent.setup()
+    const existing = vi.mocked(useConnectedAccountsByToolkit)('github')
+    const newAccount = { ...existing.data!.accounts[0], id: 'new-account', displayName: 'New GitHub Account' }
+    const refetch = vi.fn(async () => {
+      vi.mocked(useConnectedAccountsByToolkit).mockReturnValue({
+        ...existing, data: { accounts: [...existing.data!.accounts, newAccount] }, refetch,
+      } as any)
+      return { data: { accounts: [...existing.data!.accounts, newAccount] } }
+    })
+    vi.mocked(useConnectedAccountsByToolkit).mockReturnValue({ ...existing, refetch } as any)
+    mockApiFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ redirectUrl: 'https://oauth.example' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
+    renderWithProviders(
+      <ConnectedAccountRequestItem {...defaultProps}
+        replacement={{ requestId: 'reauth-1', onCancel: vi.fn() }} />,
+    )
+    await user.click(screen.getByRole('button', { name: 'Add New Account' }))
+    expect(mockApiFetch).toHaveBeenNthCalledWith(1, '/api/connected-accounts/initiate',
+      expect.objectContaining({ body: JSON.stringify({ providerSlug: 'github', electron: false }) }))
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        origin: window.location.origin,
+        data: { type: 'oauth-callback', success: true, accountId: 'new-account' },
+      }))
+    })
+    await user.click(screen.getByRole('button', { name: 'Replace connection' }))
+    expect(mockApiFetch).toHaveBeenNthCalledWith(2,
+      '/api/agents/my-agent/reauth-request/reauth-1/replace-account',
+      expect.objectContaining({ body: expect.stringContaining('"accountIds":["new-account"]') }))
+  })
+
+  it('cancels replacement without declining the parked request', async () => {
+    const user = userEvent.setup()
+    const onCancel = vi.fn()
+    renderWithProviders(
+      <ConnectedAccountRequestItem {...defaultProps}
+        replacement={{ requestId: 'reauth-1', onCancel }} />,
+    )
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancel).toHaveBeenCalledOnce()
+    expect(mockApiFetch).not.toHaveBeenCalled()
+    expect(defaultProps.onComplete).not.toHaveBeenCalled()
   })
 
   it('declines access request', async () => {

--- a/src/renderer/components/messages/connected-account-request-item.tsx
+++ b/src/renderer/components/messages/connected-account-request-item.tsx
@@ -1,5 +1,7 @@
 import { apiFetch } from '@renderer/lib/api'
 import { prepareOAuthPopup } from '@renderer/lib/oauth-popup'
+import { warnIfLiveRefreshFailed } from '@renderer/lib/connection-live-refresh'
+import { useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
@@ -50,11 +52,15 @@ interface ConnectedAccountRequestItemProps {
   toolUseId: string
   toolkit: string
   reason?: string
-  sessionId: string
   agentSlug: string
   readOnly?: boolean
   onComplete: () => void
 }
+
+type ConnectedAccountRequestProps = ConnectedAccountRequestItemProps & (
+  | { sessionId: string; replacement?: never }
+  | { sessionId?: string; replacement: { requestId: string; onCancel: () => void } }
+)
 
 type RequestStatus = 'pending' | 'submitting' | 'provided' | 'declined' | 'connecting'
 
@@ -66,7 +72,9 @@ export function ConnectedAccountRequestItem({
   agentSlug,
   readOnly,
   onComplete,
-}: ConnectedAccountRequestItemProps) {
+  replacement,
+}: ConnectedAccountRequestProps) {
+  const queryClient = useQueryClient()
   const [selectedAccountIds, setSelectedAccountIds] = useState<Set<string>>(new Set())
   const [status, setStatus] = useState<RequestStatus>('pending')
   const [error, setError] = useState<string | null>(null)
@@ -117,14 +125,14 @@ export function ConnectedAccountRequestItem({
           let detectedNewAccountId = newAccountId
           if (newAccountId) {
             // We have the new account ID directly
-            setSelectedAccountIds((prev) => new Set(prev).add(newAccountId))
+            setSelectedAccountIds((prev) => new Set(replacement ? [] : prev).add(newAccountId))
           } else if (result.data?.accounts) {
             // Find the new account by comparing with accounts before OAuth
             const newAccount = result.data.accounts.find(
               (acc) => !accountIdsBeforeOAuth.current.has(acc.id)
             )
             if (newAccount) {
-              setSelectedAccountIds((prev) => new Set(prev).add(newAccount.id))
+              setSelectedAccountIds((prev) => new Set(replacement ? [] : prev).add(newAccount.id))
               detectedNewAccountId = newAccount.id
             }
           }
@@ -193,7 +201,7 @@ export function ConnectedAccountRequestItem({
 
     window.addEventListener('message', handleMessage)
     return () => window.removeEventListener('message', handleMessage)
-  }, [invalidateConnectedAccounts, refetch, toolkit])
+  }, [invalidateConnectedAccounts, refetch, toolkit, replacement])
 
   const toggleAccount = useCallback((accountId: string) => {
     const account = accounts.find((a) => a.id === accountId)
@@ -203,11 +211,12 @@ export function ConnectedAccountRequestItem({
       if (next.has(accountId)) {
         next.delete(accountId)
       } else {
+        if (replacement) next.clear()
         next.add(accountId)
       }
       return next
     })
-  }, [accounts])
+  }, [accounts, replacement])
 
   const handleConnectNew = async () => {
     setStatus('connecting')
@@ -251,7 +260,9 @@ export function ConnectedAccountRequestItem({
 
     try {
       const response = await apiFetch(
-        `/api/agents/${agentSlug}/sessions/${sessionId}/provide-connected-account`,
+        replacement
+          ? `/api/agents/${agentSlug}/reauth-request/${replacement.requestId}/replace-account`
+          : `/api/agents/${agentSlug}/sessions/${sessionId}/provide-connected-account`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -268,6 +279,12 @@ export function ConnectedAccountRequestItem({
         throw new Error(data.error || 'Failed to provide access')
       }
 
+      if (replacement) {
+        warnIfLiveRefreshFailed(await response.json().catch(() => ({})))
+        queryClient.invalidateQueries({ queryKey: ['agent-connected-accounts'] })
+        queryClient.invalidateQueries({ queryKey: ['account-agents'] })
+        queryClient.invalidateQueries({ queryKey: ['pending-user-requests'] })
+      }
       setStatus('provided')
       onComplete()
     } catch (err: unknown) {
@@ -277,6 +294,10 @@ export function ConnectedAccountRequestItem({
   }
 
   const handleDecline = async (reason?: string) => {
+    if (replacement) {
+      replacement.onCancel()
+      return
+    }
     setStatus('submitting')
     setError(null)
 
@@ -357,7 +378,9 @@ export function ConnectedAccountRequestItem({
   return (
     <RequestItemShell
       title={reason || `Connect to ${provider?.displayName || toolkit}`}
-      subtitle="Selected accounts will be linked to this agent for future use."
+      subtitle={replacement
+        ? 'Choose or connect an account you own. This replaces the connection for this agent. Active sessions will be interrupted and told to use the new account.'
+        : 'Selected accounts will be linked to this agent for future use.'}
       theme="blue"
       sessionId={sessionId}
       agentSlug={agentSlug}
@@ -467,13 +490,19 @@ export function ConnectedAccountRequestItem({
       {/* Action buttons when accounts exist */}
       {accounts.length > 0 && (
         <RequestItemActions>
-          <DeclineButton
-            onDecline={handleDecline}
-            disabled={status !== 'pending'}
-            label="Deny"
-            showIcon={false}
-            className="border-border text-foreground hover:bg-muted"
-          />
+          {replacement ? (
+            <Button size="xs" variant="outline" onClick={replacement.onCancel} disabled={status === 'submitting'}>
+              Cancel
+            </Button>
+          ) : (
+            <DeclineButton
+              onDecline={handleDecline}
+              disabled={status !== 'pending'}
+              label="Deny"
+              showIcon={false}
+              className="border-border text-foreground hover:bg-muted"
+            />
+          )}
 
           <Button
             onClick={handleProvide}
@@ -482,7 +511,7 @@ export function ConnectedAccountRequestItem({
             size="xs"
             className="min-w-24 bg-blue-600 text-white hover:bg-blue-700"
           >
-            Allow Access{selectedAccountIds.size > 0 ? ` (${selectedAccountIds.size})` : ''}
+            {replacement ? 'Replace connection' : `Allow Access${selectedAccountIds.size > 0 ? ` (${selectedAccountIds.size})` : ''}`}
           </Button>
         </RequestItemActions>
       )}
@@ -490,13 +519,19 @@ export function ConnectedAccountRequestItem({
       {/* Action buttons when no accounts */}
       {accounts.length === 0 && (
         <RequestItemActions>
-          <DeclineButton
-            onDecline={handleDecline}
-            disabled={status !== 'pending' && status !== 'connecting'}
-            label="Deny"
-            showIcon={false}
-            className="border-border text-foreground hover:bg-muted"
-          />
+          {replacement ? (
+            <Button size="xs" variant="outline" onClick={replacement.onCancel} disabled={status === 'submitting'}>
+              Cancel
+            </Button>
+          ) : (
+            <DeclineButton
+              onDecline={handleDecline}
+              disabled={status !== 'pending' && status !== 'connecting'}
+              label="Deny"
+              showIcon={false}
+              className="border-border text-foreground hover:bg-muted"
+            />
+          )}
         </RequestItemActions>
       )}
 

--- a/src/renderer/components/messages/mcp-reauth-request-item.test.tsx
+++ b/src/renderer/components/messages/mcp-reauth-request-item.test.tsx
@@ -4,6 +4,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { McpReauthRequestItem } from './mcp-reauth-request-item'
 
+vi.mock('./remote-mcp-request-item', () => ({
+  RemoteMcpRequestItem: ({ url, replacement }: { url: string; replacement: { requestId: string; onCancel: () => void } }) => (
+    <div data-testid="mcp-replacement-picker" data-url={url} data-request-id={replacement.requestId}>
+      <button onClick={replacement.onCancel}>Cancel replacement</button>
+    </div>
+  ),
+}))
+
 const mockInitiateOAuth = vi.fn()
 const mockApiFetch = vi.fn()
 const mockNavigate = vi.fn()
@@ -106,16 +114,24 @@ describe('McpReauthRequestItem', () => {
 
     expect(screen.queryByTestId('mcp-reauth-reconnect-btn')).not.toBeInTheDocument()
     expect(screen.queryByTestId('mcp-reauth-dismiss-btn')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mcp-reauth-replace-btn')).not.toBeInTheDocument()
     expect(screen.getByText('Waiting for reconnection')).toBeInTheDocument()
   })
 
-  it('offers a member who cannot manage the MCP a way out instead of reconnect', () => {
+  it('lets a non-owner open the replacement picker and cancel back to the recovery card', async () => {
     mockCanManage = false
     renderItem()
 
     expect(screen.queryByTestId('mcp-reauth-reconnect-btn')).not.toBeInTheDocument()
     expect(screen.getByTestId('mcp-reauth-dismiss-btn')).toBeInTheDocument()
-    expect(screen.getByText(/Only the connection owner or an administrator/)).toBeInTheDocument()
+    expect(screen.getByText(/Replace it with a connection you own/)).toBeInTheDocument()
+    mockApiFetch.mockResolvedValueOnce(new Response(JSON.stringify({ url: 'https://my-mcp.example/mcp' })))
+    fireEvent.click(screen.getByTestId('mcp-reauth-replace-btn'))
+    expect(await screen.findByTestId('mcp-replacement-picker')).toHaveAttribute('data-url', 'https://my-mcp.example/mcp')
+    expect(screen.getByTestId('mcp-replacement-picker')).toHaveAttribute('data-request-id', 'proxy-1')
+    fireEvent.click(screen.getByText('Cancel replacement'))
+    expect(screen.getByTestId('mcp-reauth-dismiss-btn')).toBeInTheDocument()
+    expect(mockInitiateOAuth).not.toHaveBeenCalled()
   })
 
   it('dismisses the parked request and closes the card', async () => {

--- a/src/renderer/components/messages/mcp-reauth-request-item.tsx
+++ b/src/renderer/components/messages/mcp-reauth-request-item.tsx
@@ -13,6 +13,7 @@ import { COMMON_MCP_SERVERS } from '@shared/lib/mcp/common-servers'
 import { DeclineButton } from './decline-button'
 import { RequestItemActions } from './request-item-actions'
 import { RequestItemShell } from './request-item-shell'
+import { RemoteMcpRequestItem } from './remote-mcp-request-item'
 
 interface McpReauthRequestItemProps {
   proxyRequestId: string
@@ -39,6 +40,8 @@ export function McpReauthRequestItem({
   const initiateOAuth = useInitiateMcpOAuth()
   const { data: canManage } = useCanManageRemoteMcp(mcpId)
   const [pending, setPending] = useState(false)
+  const [loadingReplacement, setLoadingReplacement] = useState(false)
+  const [replacementUrl, setReplacementUrl] = useState<string | null>(null)
   const [dismissing, setDismissing] = useState(false)
   const [bearerToken, setBearerToken] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -141,11 +144,42 @@ export function McpReauthRequestItem({
     }
   }
 
+  const replace = async () => {
+    setLoadingReplacement(true)
+    setError(null)
+    try {
+      const response = await apiFetch(`/api/agents/${agentSlug}/reauth-request/${proxyRequestId}/replace-mcp`)
+      if (!response.ok) throw new Error(await parseError(response, 'Failed to load replacement connections'))
+      const data = await response.json() as { url?: string }
+      setReplacementUrl(data.url ?? '')
+    } catch (replacementError) {
+      setError(replacementError instanceof Error ? replacementError.message : 'Failed to load replacement connections')
+    } finally {
+      setLoadingReplacement(false)
+    }
+  }
+
+  if (replacementUrl !== null && !readOnly) {
+    return (
+      <RemoteMcpRequestItem
+        toolUseId={proxyRequestId}
+        url={replacementUrl}
+        name={mcpName}
+        reason={`Replace ${mcpName} connection`}
+        authHint={authType === 'none' ? undefined : authType}
+        sessionId={sessionId}
+        agentSlug={agentSlug}
+        replacement={{ requestId: proxyRequestId, onCancel: () => setReplacementUrl(null) }}
+        onComplete={onComplete}
+      />
+    )
+  }
+
   return (
     <RequestItemShell
       title={`This request needs ${mcpName}, which requires re-authentication.`}
       subtitle={canManage === false
-        ? 'Only the connection owner or an administrator can reconnect it. Dismiss to let the agent move on without it.'
+        ? 'Replace it with a connection you own to continue, or dismiss this request.'
         : 'Reconnect to continue. The original MCP request will resume automatically.'}
       icon={<ServiceIcon slug={serviceSlug} fallback="mcp" className="h-4 w-4" />}
       theme="orange"
@@ -171,16 +205,27 @@ export function McpReauthRequestItem({
         <RequestItemActions>
           <DeclineButton
             onDecline={(reason) => { void dismiss(reason) }}
-            disabled={pending || dismissing}
+            disabled={pending || dismissing || loadingReplacement}
             label="Dismiss"
             data-testid="mcp-reauth-dismiss-btn"
           />
+          <Button
+            type="button"
+            size="xs"
+            variant={canReconnect ? 'outline' : 'default'}
+            onClick={() => void replace()}
+            loading={loadingReplacement}
+            disabled={pending || dismissing || loadingReplacement}
+            data-testid="mcp-reauth-replace-btn"
+          >
+            Replace connection
+          </Button>
           {canReconnect && (
             <Button
               type="button"
               size="xs"
               onClick={() => void reconnect()}
-              disabled={pending || dismissing || (authType === 'bearer' && !bearerToken.trim())}
+              disabled={pending || dismissing || loadingReplacement || (authType === 'bearer' && !bearerToken.trim())}
               data-testid="mcp-reauth-reconnect-btn"
             >
               {pending ? (

--- a/src/renderer/components/messages/message-item.tsx
+++ b/src/renderer/components/messages/message-item.tsx
@@ -459,7 +459,7 @@ function MessageItemComponent({ message, isStreaming, agentSlug, sessionId, isSe
     return null
   }
 
-  // Row kinds (the voice-mode boundary) own the whole row: no avatar column,
+  // System notice rows own the whole row: no avatar column,
   // no bubble width, drawn edge to edge like a compact boundary.
   if (CustomUserRender && userKind?.chrome === 'row' && hasText) {
     return <CustomUserRender text={text} message={message} renderMarkdown={renderMarkdown} />

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { screen, fireEvent, act, waitFor } from '@testing-library/react'
 import { useState } from 'react'
+import { buildConnectionReplacementMessage } from '@shared/lib/utils/connection-replacement-message'
 import { MessageList } from './message-list'
 // Resolves to the mocked module's class below — the one the component's
 // instanceof check sees.
@@ -215,6 +216,45 @@ describe('MessageList', () => {
     )
     expect(screen.getByText('Hi')).toBeInTheDocument()
     expect(screen.getByText('Hello!')).toBeInTheDocument()
+  })
+
+  it.each(['connected-accounts', 'remote-mcps'] as const)('replaces the adjacent interrupt badge with a %s notice when it arrives', (kind) => {
+    const interrupted = [
+      createUserMessage({ content: { text: 'Read the shared connection' } }),
+      createAssistantMessage({ content: { text: 'Reading…' } }),
+      createUserMessage({ content: { text: '[Request interrupted by user]' } }),
+    ]
+    mockMessagesData.data = interrupted
+    const { rerender } = renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+    expect(screen.getByTestId('interrupt-marker')).toBeInTheDocument()
+
+    mockMessagesData.data = [
+      ...interrupted,
+      createUserMessage({ content: { text: '[SYSTEM] Hidden runtime bookkeeping' } }),
+      createUserMessage({ content: { text: buildConnectionReplacementMessage({
+        kind, name: kind === 'connected-accounts' ? 'Slack' : 'Amplitude', previousId: 'old', replacementId: 'new',
+      }) } }),
+      createAssistantMessage({ content: { text: 'Continuing with the new connection' } }),
+    ]
+    rerender(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+    expect(screen.getByTestId('connection-replacement-notice')).toHaveTextContent('connection replaced')
+    expect(screen.queryByTestId('interrupt-marker')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Hidden runtime bookkeeping/)).not.toBeInTheDocument()
+    expect(screen.getByText('Continuing with the new connection')).toBeInTheDocument()
+  })
+
+  it('keeps a separate user stop when intervening conversation separates it from the replacement', () => {
+    mockMessagesData.data = [
+      createUserMessage({ content: { text: '[Request interrupted by user]' } }),
+      createUserMessage({ content: { text: 'Try again' } }),
+      createAssistantMessage({ content: { text: 'Reading Slack' } }),
+      createUserMessage({ content: { text: buildConnectionReplacementMessage({
+        kind: 'connected-accounts', name: 'Slack', previousId: 'old', replacementId: 'new',
+      }) } }),
+    ]
+    renderWithProviders(<MessageList sessionId="s-1" agentSlug="agent-1" />)
+    expect(screen.getByTestId('interrupt-marker')).toHaveTextContent('Stopped')
+    expect(screen.getByTestId('connection-replacement-notice')).toBeInTheDocument()
   })
 
   it('renders the interrupt marker as a bare chip in the user column', () => {

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -426,11 +426,19 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
     return () => clearTimeout(timerId)
   }, [pendingUserMessages, peerUserMessages, isActive, onPendingMessageAppeared, sessionId, draftsStore])
 
-  // Visible messages with system-injected entries filtered out (these must not
-  // consume window slots, and the windowing operates on what the user can see).
+  // Hidden system messages and redundant interrupt markers must not consume
+  // window slots: windowing operates on what the user can see.
   const visibleMessages = useMemo(() => {
     if (!messages) return []
-    return messages.filter((item) => !classifyUserMessage(item).hidden)
+    const visible = messages.filter((item) => !classifyUserMessage(item).hidden)
+    // The replacement notice explains its preceding interrupt. Keep the raw
+    // transcript intact for turn bookkeeping; only omit the redundant badge
+    // from display, before windowing. Other user stops remain visible.
+    return visible.filter((item, index) => !(
+      classifyUserMessage(item).kind === 'interrupt' &&
+      visible[index + 1] &&
+      classifyUserMessage(visible[index + 1]).kind === 'connection-replacement'
+    ))
   }, [messages])
 
   // Time flags are derived from all loaded history rather than the trailing DOM
@@ -454,7 +462,8 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       if (
         item.type !== 'user' ||
         item.queued ||
-        classifyUserMessage(item).kind === 'interrupt'
+        classifyUserMessage(item).kind === 'interrupt' ||
+        classifyUserMessage(item).kind === 'connection-replacement'
       ) continue
 
       const createdAt = new Date(item.createdAt)

--- a/src/renderer/components/messages/remote-mcp-request-item.test.tsx
+++ b/src/renderer/components/messages/remote-mcp-request-item.test.tsx
@@ -82,6 +82,7 @@ const defaultServer = {
 describe('RemoteMcpRequestItem', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseMcpOAuthListener.mockReset()
     mockInitiateOAuthMutateAsync.mockReset()
     mockServerListResponse([defaultServer])
   })
@@ -131,6 +132,154 @@ describe('RemoteMcpRequestItem', () => {
     expect(defaultProps.onComplete).toHaveBeenCalled()
   })
 
+  it('provides a replacement through the agent-scoped endpoint without a session', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<RemoteMcpRequestItem {...defaultProps} sessionId={undefined}
+      replacement={{ requestId: 'reauth-1', onCancel: vi.fn() }} />)
+    await user.click(await screen.findByRole('button', { name: 'Replace connection' }))
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/agents/my-agent/reauth-request/reauth-1/replace-mcp',
+      expect.objectContaining({ body: JSON.stringify({ toolUseId: 'tu-1', remoteMcpIds: ['mcp-1'] }) }))
+    await waitFor(() => expect(defaultProps.onComplete).toHaveBeenCalledOnce())
+  })
+
+  it('cancels replacement without declining the pending MCP request', async () => {
+    const user = userEvent.setup()
+    const onCancel = vi.fn()
+    renderWithProviders(<RemoteMcpRequestItem {...defaultProps}
+      replacement={{ requestId: 'reauth-1', onCancel }} />)
+    await screen.findByRole('button', { name: 'Replace connection' })
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancel).toHaveBeenCalledOnce()
+    expect(mockApiFetch.mock.calls.some(([, options]) => options?.method === 'POST')).toBe(false)
+    expect(defaultProps.onComplete).not.toHaveBeenCalled()
+  })
+
+  it('uses the exact new OAuth connection when replacing with a sibling at the same URL', async () => {
+    const user = userEvent.setup()
+    mockInitiateOAuthMutateAsync.mockResolvedValue({ state: 'flow-state', redirectUrl: 'https://oauth.example' })
+    renderWithProviders(<RemoteMcpRequestItem {...defaultProps} authHint="oauth"
+      replacement={{ requestId: 'reauth-1', onCancel: vi.fn() }} />)
+    await screen.findByRole('button', { name: 'Replace connection' })
+    await user.click(screen.getByRole('button', { name: /Connect Another|Add New/i }))
+    await waitFor(() => expect(mockUseMcpOAuthListener).toHaveBeenCalledWith(true, expect.any(Function), 'flow-state'))
+    mockServerListResponse([defaultServer, { ...defaultServer, id: 'new-mcp', name: 'New connection' }])
+    const callback = mockUseMcpOAuthListener.mock.calls.find(([active]) => active)?.[1]
+    act(() => callback({ success: true, mcpId: 'new-mcp' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Replace connection' })).toBeEnabled())
+    await user.click(screen.getByRole('button', { name: 'Replace connection' }))
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/agents/my-agent/reauth-request/reauth-1/replace-mcp',
+      expect.objectContaining({ body: JSON.stringify({ toolUseId: 'tu-1', remoteMcpIds: ['new-mcp'] }) }))
+  })
+
+  it('connects a custom replacement using an entered URL when safe prefill is unavailable', async () => {
+    mockServerListResponse([])
+    mockInitiateOAuthMutateAsync.mockResolvedValue({ state: 'flow-state', redirectUrl: 'https://oauth.example' })
+    const user = userEvent.setup()
+    renderWithProviders(<RemoteMcpRequestItem {...defaultProps} url="" authHint="oauth"
+      replacement={{ requestId: 'reauth-1', onCancel: vi.fn() }} />)
+    const input = await screen.findByRole('textbox', { name: 'MCP server URL' })
+    const connect = await screen.findByRole('button', { name: 'Connect' })
+    expect(connect).toBeDisabled()
+    await user.type(input, 'not-a-url')
+    expect(connect).toBeDisabled()
+    await user.clear(input)
+    await user.type(input, defaultProps.url)
+    await user.click(connect)
+    expect(mockInitiateOAuthMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ url: defaultProps.url }))
+    mockServerListResponse([{ ...defaultServer, id: 'custom-new' }])
+    const callback = mockUseMcpOAuthListener.mock.calls.find(([active]) => active)?.[1]
+    await act(async () => callback({ success: true, mcpId: 'custom-new' }))
+    await user.click(await screen.findByRole('button', { name: 'Replace connection' }))
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/agents/my-agent/reauth-request/reauth-1/replace-mcp',
+      expect.objectContaining({ body: JSON.stringify({ toolUseId: 'tu-1', remoteMcpIds: ['custom-new'] }) }))
+  })
+
+  it.each(['bearer', undefined] as const)('registers an entered replacement URL with %s authentication', async (authHint) => {
+    let created = false
+    mockApiFetch.mockImplementation((path: string, options?: { method?: string }) => {
+      if (path === '/api/remote-mcps' && options?.method === 'POST') {
+        created = true
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ server: defaultServer }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ servers: created ? [defaultServer] : [], policies: [] }) })
+    })
+    const user = userEvent.setup()
+    renderWithProviders(<RemoteMcpRequestItem {...defaultProps} url="" authHint={authHint}
+      replacement={{ requestId: 'reauth-1', onCancel: vi.fn() }} />)
+    await user.type(await screen.findByRole('textbox', { name: 'MCP server URL' }), defaultProps.url)
+    if (authHint) await user.type(screen.getByPlaceholderText('Bearer token'), 'member-token')
+    await user.click(screen.getByRole('button', { name: 'Connect' }))
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/remote-mcps', expect.objectContaining({
+      body: JSON.stringify({ name: defaultProps.name, url: defaultProps.url, authType: authHint ?? 'none', ...(authHint ? { accessToken: 'member-token' } : {}) }),
+    }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Replace connection' })).toBeEnabled())
+    await user.click(screen.getByRole('button', { name: 'Replace connection' }))
+    expect(defaultProps.onComplete).toHaveBeenCalledOnce()
+    expect(mockInitiateOAuthMutateAsync).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    'https://mcp.example.com/another-service',
+    'https://mcp.example.com:8443/sse',
+    'http://mcp.example.com/sse',
+    'https://another.example/sse',
+  ])('excludes incompatible replacement %s from auto-selection and the picker', async (url) => {
+    mockServerListResponse([
+      { ...defaultServer, status: 'auth_required', authType: 'oauth' },
+      { ...defaultServer, id: 'incompatible', name: 'Wrong endpoint', url },
+    ])
+    const user = userEvent.setup()
+    renderWithProviders(<RemoteMcpRequestItem {...defaultProps}
+      replacement={{ requestId: 'reauth-1', onCancel: vi.fn() }} />)
+    expect(await screen.findByRole('button', { name: 'Replace connection' })).toBeDisabled()
+    await user.click(screen.getByRole('button', { name: 'Select a different one' }))
+    expect(screen.queryByText('Wrong endpoint')).not.toBeInTheDocument()
+    expect(mockApiFetch.mock.calls.some(([, options]) => options?.method === 'POST')).toBe(false)
+  })
+
+  it('shows compatible replacement accounts across query and trailing-slash variants', async () => {
+    mockServerListResponse([
+      { ...defaultServer, name: 'First account', url: 'https://mcp.facebook.com/ads/?token=first' },
+      { ...defaultServer, id: 'second', name: 'Second account', url: 'https://mcp.facebook.com/ads' },
+    ])
+    renderWithProviders(<RemoteMcpRequestItem {...defaultProps} url="https://mcp.facebook.com/ads?token=member"
+      replacement={{ requestId: 'reauth-1', onCancel: vi.fn() }} />)
+    expect(await screen.findByText('First account')).toBeInTheDocument()
+    expect(screen.getByText('Second account')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Replace connection' })).toBeEnabled()
+  })
+
+  it.each([defaultProps.url, 'https://unrelated.example/mcp'])('ignores another OAuth flow at %s and still accepts its own callback', async (otherUrl) => {
+    const actual = await vi.importActual<typeof import('@renderer/hooks/use-mcp-oauth-listener')>('@renderer/hooks/use-mcp-oauth-listener')
+    mockUseMcpOAuthListener.mockImplementation(actual.useMcpOAuthListener)
+    mockInitiateOAuthMutateAsync.mockResolvedValue({ state: 'flow-state', redirectUrl: 'https://oauth.example' })
+    const user = userEvent.setup()
+    renderWithProviders(<RemoteMcpRequestItem {...defaultProps} authHint="oauth"
+      replacement={{ requestId: 'reauth-1', onCancel: vi.fn() }} />)
+    await screen.findByRole('button', { name: 'Replace connection' })
+    await user.click(screen.getByRole('button', { name: /Add New Account/ }))
+    await screen.findByText('Waiting for authorization...')
+    mockServerListResponse([defaultServer,
+      { ...defaultServer, id: 'other-flow-mcp', url: otherUrl },
+      { ...defaultServer, id: 'own-flow-mcp' },
+    ])
+    const callback = (data: Record<string, unknown>) => window.dispatchEvent(new MessageEvent('message', {
+      origin: window.location.origin, data: { type: 'mcp-oauth-callback', ...data },
+    }))
+    await act(async () => {
+      callback({ success: true, state: 'other-flow', mcpId: 'other-flow-mcp' })
+      callback({ success: false, state: 'other-flow', error: 'Other flow failed' })
+      callback({ success: true, mcpId: 'other-flow-mcp' })
+    })
+    expect(screen.getByText('Waiting for authorization...')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Replace connection' })).toBeDisabled()
+    await act(async () => callback({ success: true, state: 'flow-state', mcpId: 'own-flow-mcp' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Replace connection' })).toBeEnabled())
+    await user.click(screen.getByRole('button', { name: 'Replace connection' }))
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/agents/my-agent/reauth-request/reauth-1/replace-mcp',
+      expect.objectContaining({ body: JSON.stringify({ toolUseId: 'tu-1', remoteMcpIds: ['own-flow-mcp'] }) }))
+  })
+
   it('declines remote MCP request', async () => {
     const user = userEvent.setup()
 
@@ -178,7 +327,7 @@ describe('RemoteMcpRequestItem', () => {
   it('uses the shared OAuth callback listener while waiting for web OAuth', async () => {
     const user = userEvent.setup()
     mockServerListResponse([])
-    mockInitiateOAuthMutateAsync.mockResolvedValue({ redirectUrl: 'https://auth.example.com/oauth' })
+    mockInitiateOAuthMutateAsync.mockResolvedValue({ state: 'flow-state', redirectUrl: 'https://auth.example.com/oauth' })
 
     renderWithProviders(
       <RemoteMcpRequestItem
@@ -191,7 +340,7 @@ describe('RemoteMcpRequestItem', () => {
     await user.click(await screen.findByRole('button', { name: /Connect/i }))
 
     await waitFor(() => {
-      expect(mockUseMcpOAuthListener).toHaveBeenCalledWith(true, expect.any(Function))
+      expect(mockUseMcpOAuthListener).toHaveBeenCalledWith(true, expect.any(Function), 'flow-state')
     })
 
     const activeCall = mockUseMcpOAuthListener.mock.calls.find(([active]) => active === true)
@@ -301,7 +450,7 @@ describe('RemoteMcpRequestItem', () => {
 
     it('starts re-auth OAuth for the existing server on Reconnect', async () => {
       const user = userEvent.setup()
-      mockInitiateOAuthMutateAsync.mockResolvedValue({ redirectUrl: 'https://auth.example.com/oauth' })
+      mockInitiateOAuthMutateAsync.mockResolvedValue({ state: 'flow-state', redirectUrl: 'https://auth.example.com/oauth' })
 
       renderWithProviders(<RemoteMcpRequestItem {...defaultProps} />)
 
@@ -324,14 +473,14 @@ describe('RemoteMcpRequestItem', () => {
 
     it('enables Allow Access after re-auth completes and the server is active', async () => {
       const user = userEvent.setup()
-      mockInitiateOAuthMutateAsync.mockResolvedValue({ redirectUrl: 'https://auth.example.com/oauth' })
+      mockInitiateOAuthMutateAsync.mockResolvedValue({ state: 'flow-state', redirectUrl: 'https://auth.example.com/oauth' })
 
       renderWithProviders(<RemoteMcpRequestItem {...defaultProps} />)
 
       await user.click(await screen.findByRole('button', { name: /Reconnect/i }))
 
       await waitFor(() => {
-        expect(mockUseMcpOAuthListener).toHaveBeenCalledWith(true, expect.any(Function))
+        expect(mockUseMcpOAuthListener).toHaveBeenCalledWith(true, expect.any(Function), 'flow-state')
       })
 
       // Server comes back active after OAuth
@@ -354,7 +503,7 @@ describe('RemoteMcpRequestItem', () => {
       const serverA = { ...defaultServer, id: 'mcp-a', name: 'Account A' }
       const serverB = { ...staleServer, id: 'mcp-b', name: 'Account B' }
       mockServerListResponse([serverA, serverB])
-      mockInitiateOAuthMutateAsync.mockResolvedValue({ redirectUrl: 'https://auth.example.com/oauth' })
+      mockInitiateOAuthMutateAsync.mockResolvedValue({ state: 'flow-state', redirectUrl: 'https://auth.example.com/oauth' })
 
       renderWithProviders(<RemoteMcpRequestItem {...defaultProps} />)
 
@@ -481,7 +630,7 @@ describe('RemoteMcpRequestItem', () => {
 
     it('prefills the client ID the agent supplied and sends it on connect', async () => {
       mockServerListResponse([])
-      mockInitiateOAuthMutateAsync.mockResolvedValue({ redirectUrl: 'https://auth.example.com/authorize' })
+      mockInitiateOAuthMutateAsync.mockResolvedValue({ state: 'flow-state', redirectUrl: 'https://auth.example.com/authorize' })
       await act(async () => {
         renderWithProviders(
           <RemoteMcpRequestItem
@@ -508,7 +657,7 @@ describe('RemoteMcpRequestItem', () => {
 
     it('leaves the user free to correct what the agent supplied', async () => {
       mockServerListResponse([])
-      mockInitiateOAuthMutateAsync.mockResolvedValue({ redirectUrl: 'https://auth.example.com/authorize' })
+      mockInitiateOAuthMutateAsync.mockResolvedValue({ state: 'flow-state', redirectUrl: 'https://auth.example.com/authorize' })
       await act(async () => {
         renderWithProviders(
           <RemoteMcpRequestItem

--- a/src/renderer/components/messages/remote-mcp-request-item.tsx
+++ b/src/renderer/components/messages/remote-mcp-request-item.tsx
@@ -1,5 +1,6 @@
 import { apiFetch } from '@renderer/lib/api'
 import { prepareOAuthPopup } from '@renderer/lib/oauth-popup'
+import { warnIfLiveRefreshFailed } from '@renderer/lib/connection-live-refresh'
 
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import {
@@ -7,6 +8,7 @@ import {
   Plus,
 } from 'lucide-react'
 import { ServiceIcon } from '@renderer/components/ui/service-icon'
+import { sameMcpEndpoint } from '@shared/lib/mcp/endpoint'
 import { COMMON_MCP_SERVERS } from '@shared/lib/mcp/common-servers'
 import { Button } from '@renderer/components/ui/button'
 import { Input } from '@renderer/components/ui/input'
@@ -34,11 +36,15 @@ interface RemoteMcpRequestItemProps {
   /** Prefill for the Advanced section, supplied by the agent. */
   clientId?: string
   clientName?: string
-  sessionId: string
   agentSlug: string
   readOnly?: boolean
   onComplete: () => void
 }
+
+type RemoteMcpRequestProps = RemoteMcpRequestItemProps & (
+  | { sessionId: string; replacement?: never }
+  | { sessionId?: string; replacement: { requestId: string; onCancel: () => void } }
+)
 
 type RequestStatus = 'pending' | 'submitting' | 'provided' | 'declined' | 'registering' | 'oauth_pending'
 
@@ -54,7 +60,8 @@ export function RemoteMcpRequestItem({
   agentSlug,
   readOnly,
   onComplete,
-}: RemoteMcpRequestItemProps) {
+  replacement,
+}: RemoteMcpRequestProps) {
   const queryClient = useQueryClient()
   const initiateOAuth = useInitiateMcpOAuth()
   const { track } = useAnalyticsTracking()
@@ -83,6 +90,16 @@ export function RemoteMcpRequestItem({
   const [menuOpenMcpId, setMenuOpenMcpId] = useState<string | null>(null)
   const [policyEditorMcp, setPolicyEditorMcp] = useState<{ id: string; name: string; tools: Array<{ name: string; description?: string }> } | null>(null)
   const targetUrl = newUrl.trim() || url
+  const isReplacing = !!replacement
+  const needsReplacementUrl = isReplacing && !url
+  const validTargetUrl = useMemo(() => {
+    try {
+      const parsed = new URL(targetUrl)
+      return parsed.protocol === 'https:' || parsed.protocol === 'http:'
+    } catch {
+      return false
+    }
+  }, [targetUrl])
 
   // Fetch existing remote MCP servers
   const { data, isLoading, refetch } = useQuery<{ servers: RemoteMcpServer[] }>({
@@ -94,15 +111,22 @@ export function RemoteMcpRequestItem({
     },
   })
 
-  const servers = useMemo(() => Array.isArray(data?.servers) ? data.servers : [], [data])
+  // Replacement must keep the original endpoint. Filter every selection path,
+  // including the picker and submitted IDs, using the API's compatibility rule.
+  const servers = useMemo(() => {
+    const ownedServers = Array.isArray(data?.servers) ? data.servers : []
+    return isReplacing
+      ? ownedServers.filter((server) => sameMcpEndpoint(server.url, url || targetUrl))
+      : ownedServers
+  }, [data, isReplacing, url, targetUrl])
   const matchingServer = useMemo(
     () => servers.find((server) => server.url === targetUrl) || null,
     [servers, targetUrl]
   )
   const targetServiceKey = useMemo(() => getMcpServiceKey(targetUrl), [targetUrl])
   const targetServiceServers = useMemo(
-    () => servers.filter((server) => getMcpServiceKey(server.url) === targetServiceKey),
-    [servers, targetServiceKey]
+    () => isReplacing ? servers : servers.filter((server) => getMcpServiceKey(server.url) === targetServiceKey),
+    [servers, targetServiceKey, isReplacing]
   )
   const primarySelectedMcpId = selectedMcpIds.values().next().value as string | undefined
   const activeMcpId = primarySelectedMcpId || matchingServer?.id || targetServiceServers[0]?.id || null
@@ -118,8 +142,8 @@ export function RemoteMcpRequestItem({
     [selectedServer, targetServiceKey]
   )
   const displayedServiceServers = useMemo(
-    () => servers.filter((server) => getMcpServiceKey(server.url) === selectedServiceKey),
-    [selectedServiceKey, servers]
+    () => isReplacing ? servers : servers.filter((server) => getMcpServiceKey(server.url) === selectedServiceKey),
+    [selectedServiceKey, servers, isReplacing]
   )
   const connectCardSlug = COMMON_MCP_SERVERS.find((server) => server.url === targetUrl)?.slug || mcpSlug
   // Provider-side setup the user has to do before this server can connect at all.
@@ -189,21 +213,25 @@ export function RemoteMcpRequestItem({
   // servers can share the same URL (multiple accounts), so a URL match after
   // OAuth could select a sibling instead of the server that was reconnected.
   const reconnectMcpIdRef = useRef<string | null>(null)
+  const oauthTargetUrlRef = useRef(targetUrl)
+  const [oauthState, setOAuthState] = useState<string>()
 
   // Handle OAuth completion from Electron IPC, postMessage, BroadcastChannel, or storage fallback.
-  const handleOAuthComplete = useCallback((success: boolean, errorMessage?: string) => {
+  const handleOAuthComplete = useCallback((success: boolean, errorMessage?: string, completedMcpId?: string) => {
     if (success) {
       setError(null)
       // Refetch servers to find the reconnected or newly created one
       refetch().then(({ data: refreshedData }) => {
         const refreshedServers = Array.isArray(refreshedData?.servers) ? refreshedData.servers : []
-        const reconnectedId = reconnectMcpIdRef.current
+        const reconnectedId = reconnectMcpIdRef.current ?? completedMcpId
         reconnectMcpIdRef.current = null
         const completedServer = reconnectedId
           ? refreshedServers.find((s) => s.id === reconnectedId && s.status === 'active')
           : refreshedServers.find((s) => s.url === targetUrl && s.status === 'active')
-        if (completedServer) {
-          setSelectedMcpIds((prev) => new Set(prev).add(completedServer.id))
+        if (completedServer && sameMcpEndpoint(completedServer.url, oauthTargetUrlRef.current)) {
+          setSelectedMcpIds((prev) => new Set(replacement ? [] : prev).add(completedServer.id))
+        } else {
+          setError('The connected MCP does not match the requested endpoint or is unavailable. Please try again.')
         }
         setStatus('pending')
       }).catch(() => {
@@ -213,26 +241,30 @@ export function RemoteMcpRequestItem({
       setError(errorMessage || 'OAuth authorization failed')
       setStatus('pending')
     }
-  }, [refetch, targetUrl])
+  }, [refetch, targetUrl, replacement])
 
-  useMcpOAuthListener(status === 'oauth_pending', ({ success, error: oauthError }) => {
-    handleOAuthComplete(success, oauthError)
-  })
+  useMcpOAuthListener(status === 'oauth_pending', ({ success, error: oauthError, mcpId }) => {
+    handleOAuthComplete(success, oauthError, mcpId)
+  }, oauthState)
 
   const startOAuthFlow = async (
     popup: ReturnType<typeof prepareOAuthPopup>,
     // Pass { mcpId } to re-authenticate an existing server instead of registering a new one.
-    params?: { mcpId: string }
+    params?: { mcpId: string; name?: never; url?: never } | { mcpId?: never; name: string; url: string }
   ) => {
     reconnectMcpIdRef.current = params?.mcpId ?? null
+    const connectionUrl = params?.url ?? targetUrl
+    oauthTargetUrlRef.current = params?.mcpId
+      ? servers.find((server) => server.id === params.mcpId)?.url ?? connectionUrl
+      : connectionUrl
     try {
       const isElectron = !!window.electronAPI
       const result = await initiateOAuth.mutateAsync(
-        params
+        params?.mcpId
           ? { mcpId: params.mcpId, electron: isElectron }
           : {
-              name: newName.trim() || url,
-              url: targetUrl,
+              name: (params?.name ?? newName).trim() || connectionUrl,
+              url: connectionUrl,
               electron: isElectron,
               clientId: advClientId.trim() || undefined,
               clientSecret: advClientSecret.trim() || undefined,
@@ -240,12 +272,13 @@ export function RemoteMcpRequestItem({
             }
       )
 
-      if (result.redirectUrl) {
-        await popup.navigate(result.redirectUrl)
+      if (result.redirectUrl && result.state) {
+        setOAuthState(result.state)
         setStatus('oauth_pending')
+        await popup.navigate(result.redirectUrl)
       } else {
         popup.close()
-        setError('OAuth initiation did not return a redirect URL')
+        setError('OAuth initiation did not return a redirect URL and state')
         setStatus('pending')
       }
     } catch (oauthErr: unknown) {
@@ -288,7 +321,7 @@ export function RemoteMcpRequestItem({
       }
       queryClient.invalidateQueries({ queryKey: ['remote-mcps'] })
       await refetch()
-      setSelectedMcpIds((prev) => new Set(prev).add(mcpId))
+      setSelectedMcpIds((prev) => new Set(replacement ? [] : prev).add(mcpId))
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Reconnect failed')
     } finally {
@@ -322,7 +355,7 @@ export function RemoteMcpRequestItem({
       }
       queryClient.invalidateQueries({ queryKey: ['remote-mcps'] })
       await refetch()
-      setSelectedMcpIds((prev) => new Set(prev).add(mcpId))
+      setSelectedMcpIds((prev) => new Set(replacement ? [] : prev).add(mcpId))
       setReauthMcpId(null)
       setReauthToken('')
     } catch (err: unknown) {
@@ -333,6 +366,7 @@ export function RemoteMcpRequestItem({
   }
 
   const handleRegisterNew = async () => {
+    if (!validTargetUrl) return
     setStatus('registering')
     setError(null)
     track('mcp_added', { url: targetUrl, authType: authHint || (bearerToken ? 'bearer' : 'none'), location: 'session' })
@@ -415,7 +449,7 @@ export function RemoteMcpRequestItem({
     const popup = prepareOAuthPopup()
 
     if (authHint === 'oauth') {
-      await startOAuthFlow(popup)
+      await startOAuthFlow(popup, { name: nameToUse, url: resolvedTargetUrl })
       return
     }
 
@@ -435,7 +469,7 @@ export function RemoteMcpRequestItem({
 
       if (!response.ok) {
         if (responseData.needsOAuth) {
-          await startOAuthFlow(popup)
+          await startOAuthFlow(popup, { name: nameToUse, url: resolvedTargetUrl })
           return
         }
         if (responseData.needsAuth) {
@@ -474,7 +508,9 @@ export function RemoteMcpRequestItem({
 
     try {
       const response = await apiFetch(
-        `/api/agents/${agentSlug}/sessions/${sessionId}/provide-remote-mcp`,
+        replacement
+          ? `/api/agents/${agentSlug}/reauth-request/${replacement.requestId}/replace-mcp`
+          : `/api/agents/${agentSlug}/sessions/${sessionId}/provide-remote-mcp`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -490,6 +526,11 @@ export function RemoteMcpRequestItem({
         throw new Error(data.error || 'Failed to provide MCP access')
       }
 
+      if (replacement) {
+        warnIfLiveRefreshFailed(await response.json().catch(() => ({})))
+        queryClient.invalidateQueries({ queryKey: ['mcp-agents'] })
+        queryClient.invalidateQueries({ queryKey: ['pending-user-requests'] })
+      }
       setStatus('provided')
       // Bare prefix: agentSlug here is the session's display-slug route form, but the
       // agent-home Connections card keys on the canonical id — a targeted key misses it.
@@ -622,7 +663,9 @@ export function RemoteMcpRequestItem({
   return (
     <RequestItemShell
       title={reason || `Connect MCP server: ${name || url}`}
-      subtitle="The MCP server will be connected to this agent."
+      subtitle={replacement
+        ? 'Choose or connect an MCP you own. This replaces the connection for this agent. Active sessions will be interrupted and told to use the new connection.'
+        : 'The MCP server will be connected to this agent.'}
       theme="blue"
       sessionId={sessionId}
       agentSlug={agentSlug}
@@ -633,6 +676,22 @@ export function RemoteMcpRequestItem({
       data-testid={isCompleted ? 'remote-mcp-request-completed' : 'remote-mcp-request'}
       data-status={isCompleted ? status : undefined}
     >
+      {needsReplacementUrl && (
+        <Input
+          type="url"
+          aria-label="MCP server URL"
+          placeholder="Enter your MCP server URL"
+          value={newUrl}
+          onChange={(event) => {
+            setNewUrl(event.target.value)
+            setSelectedMcpIds(new Set())
+            hasAutoSelected.current = false
+            setError(null)
+          }}
+          disabled={status !== 'pending'}
+          className="mt-3"
+        />
+      )}
       <div className="mt-3">
         {status === 'oauth_pending' ? (
           <div className="flex items-center gap-3 rounded-[12px] border border-border bg-white px-4 py-3 dark:bg-background">
@@ -666,6 +725,7 @@ export function RemoteMcpRequestItem({
                         if (next.has(server.id)) {
                           next.delete(server.id)
                         } else {
+                          if (replacement) next.clear()
                           next.add(server.id)
                         }
                         return next
@@ -732,7 +792,7 @@ export function RemoteMcpRequestItem({
               size="xs"
               onClick={handleRegisterNew}
               loading={status === 'registering'}
-              disabled={status !== 'pending'}
+              disabled={!validTargetUrl || status !== 'pending'}
               className="shrink-0 bg-foreground text-background hover:bg-foreground/90"
             >
               <Plus className="h-3.5 w-3.5" />
@@ -815,13 +875,19 @@ export function RemoteMcpRequestItem({
       {/* Action buttons */}
       {!selectedServer && !matchingServer && status !== 'oauth_pending' ? (
         <RequestItemActions>
-          <DeclineButton
-            onDecline={handleDecline}
-            disabled={status !== 'pending' && status !== 'registering'}
-            label="Deny"
-            showIcon={false}
-            className="border-border text-foreground hover:bg-muted"
-          />
+          {replacement ? (
+            <Button size="xs" variant="outline" onClick={replacement.onCancel} disabled={status === 'submitting'}>
+              Cancel
+            </Button>
+          ) : (
+            <DeclineButton
+              onDecline={handleDecline}
+              disabled={status !== 'pending' && status !== 'registering'}
+              label="Deny"
+              showIcon={false}
+              className="border-border text-foreground hover:bg-muted"
+            />
+          )}
         </RequestItemActions>
       ) : null}
 
@@ -843,13 +909,19 @@ export function RemoteMcpRequestItem({
               ) : null}
             </div>
             <RequestItemActions inline>
-              <DeclineButton
-                onDecline={handleDecline}
-                disabled={status !== 'pending' && status !== 'oauth_pending'}
-                label="Deny"
-                showIcon={false}
-                className="border-border text-foreground hover:bg-muted"
-              />
+              {replacement ? (
+                <Button size="xs" variant="outline" onClick={replacement.onCancel} disabled={status === 'submitting'}>
+                  Cancel
+                </Button>
+              ) : (
+                <DeclineButton
+                  onDecline={handleDecline}
+                  disabled={status !== 'pending' && status !== 'oauth_pending'}
+                  label="Deny"
+                  showIcon={false}
+                  className="border-border text-foreground hover:bg-muted"
+                />
+              )}
 
               <Button
                 onClick={handleProvide}
@@ -858,7 +930,7 @@ export function RemoteMcpRequestItem({
                 size="xs"
                 className="bg-blue-600 hover:bg-blue-700 text-white"
               >
-                Allow Access{selectedMcpIdsForProvide.length > 1 ? ` (${selectedMcpIdsForProvide.length})` : ''}
+                {replacement ? 'Replace connection' : `Allow Access${selectedMcpIdsForProvide.length > 1 ? ` (${selectedMcpIdsForProvide.length})` : ''}`}
               </Button>
             </RequestItemActions>
           </div>

--- a/src/renderer/components/messages/user-message-kinds/connection-replacement.test.tsx
+++ b/src/renderer/components/messages/user-message-kinds/connection-replacement.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { buildConnectionReplacementMessage } from '@shared/lib/utils/connection-replacement-message'
+import { createUserMessage } from '@renderer/test/factories'
+import { ConnectionReplacementNotice } from './connection-replacement'
+
+it.each([
+  ['connected-accounts', 'Slack', 'account'],
+  ['remote-mcps', 'Amplitude', 'MCP'],
+] as const)('renders a %s replacement as a system notice with optional IDs', (kind, name, reference) => {
+  const text = buildConnectionReplacementMessage({ kind, name, previousId: 'old-id', replacementId: 'new-id' })
+  const renderMarkdown = vi.fn()
+  render(<ConnectionReplacementNotice text={text} message={createUserMessage()} renderMarkdown={renderMarkdown} />)
+  const notice = screen.getByTestId('connection-replacement-notice')
+  expect(notice).toHaveTextContent(`${name} connection replaced`)
+  expect(notice).toHaveTextContent('Session interrupted. Agent notified')
+  expect(notice.querySelector('details')).not.toHaveAttribute('open')
+  expect(notice).toHaveTextContent(`Previous ${reference} ID`)
+  expect(notice).toHaveTextContent(`New ${reference} ID`)
+  expect(notice).toHaveTextContent('new-id')
+  expect(notice).not.toHaveTextContent('[SYSTEM]')
+  expect(renderMarkdown).not.toHaveBeenCalled()
+})
+
+describe('unrecognized input', () => {
+  it('does not render a partial or unrelated notice', () => {
+    render(<ConnectionReplacementNotice text="[SYSTEM] Other message" message={createUserMessage()} renderMarkdown={vi.fn()} />)
+    expect(screen.queryByTestId('connection-replacement-notice')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/messages/user-message-kinds/connection-replacement.tsx
+++ b/src/renderer/components/messages/user-message-kinds/connection-replacement.tsx
@@ -1,0 +1,50 @@
+import { ArrowRightLeft, ChevronRight } from 'lucide-react'
+import { parseConnectionReplacementMessage } from '@shared/lib/utils/connection-replacement-message'
+import type { UserMessageKindSpec, UserMessageRenderProps } from './types'
+
+export function ConnectionReplacementNotice({ text, message }: UserMessageRenderProps) {
+  const replacement = parseConnectionReplacementMessage(text)
+  if (!replacement) return null
+  const reference = replacement.kind === 'connected-accounts' ? 'account' : 'MCP'
+  return (
+    <div
+      className="my-6 rounded-xl border border-border bg-muted/30 px-4 py-3 text-sm"
+      data-testid="connection-replacement-notice"
+      data-turn-anchor-id={message.id}
+    >
+      <div className="flex items-start gap-3">
+        <ArrowRightLeft className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+        <div className="min-w-0 flex-1">
+          <p className="font-medium text-foreground break-words">{replacement.name} connection replaced</p>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            Session interrupted. Agent notified to update its scripts and continue with the new connection.
+          </p>
+          <details className="group mt-2">
+            <summary className="inline-flex cursor-pointer list-none items-center gap-1 text-xs text-muted-foreground hover:text-foreground [&::-webkit-details-marker]:hidden">
+              <ChevronRight className="h-3 w-3 transition-transform group-open:rotate-90" aria-hidden />
+              Connection details
+            </summary>
+            <dl className="mt-2 space-y-2 text-xs">
+              <div>
+                <dt className="text-muted-foreground">Previous {reference} ID</dt>
+                <dd className="mt-0.5"><code className="break-all text-foreground">{replacement.previousId}</code></dd>
+              </div>
+              <div>
+                <dt className="text-muted-foreground">New {reference} ID</dt>
+                <dd className="mt-0.5"><code className="break-all text-foreground">{replacement.replacementId}</code></dd>
+              </div>
+            </dl>
+          </details>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const connectionReplacementNotice: UserMessageKindSpec = {
+  kind: 'connection-replacement',
+  match: (text) => parseConnectionReplacementMessage(text) !== null,
+  hidden: false,
+  Render: ConnectionReplacementNotice,
+  chrome: 'row',
+}

--- a/src/renderer/components/messages/user-message-kinds/index.test.ts
+++ b/src/renderer/components/messages/user-message-kinds/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { classifyUserMessage, classifyUserText, plainMessage, USER_MESSAGE_KINDS } from './index'
+import { buildConnectionReplacementMessage } from '@shared/lib/utils/connection-replacement-message'
 import { SlashCommandBubble } from './slash-command'
 
 const kindOf = (text: string) => classifyUserText(text).kind
@@ -67,15 +68,26 @@ describe('classifyUserText', () => {
     expect(classifyUserText('[SYSTEM] The user switched to something else.').kind).toBe('system')
   })
 
+  it.each(['connected-accounts', 'remote-mcps'] as const)('shows %s replacement notices before the hidden system catch-all', (kind) => {
+    const text = buildConnectionReplacementMessage({ kind, name: 'Service', previousId: 'old', replacementId: 'new' })
+    const spec = classifyUserText(text)
+    expect(spec.kind).toBe('connection-replacement')
+    expect(spec.hidden).toBe(false)
+    expect(spec.chrome).toBe('row')
+    expect(classifyUserText('[SYSTEM] Connection to an unrelated service').hidden).toBe(true)
+  })
+
   it('lists hidden kinds before the other visible ones so the visibility filter is order-safe', () => {
-    // The voice-mode notice is the one visible kind that must precede the
-    // hidden system prefix it specialises; after it, hidden comes first.
-    const rest = USER_MESSAGE_KINDS.filter((spec) => spec.kind !== 'voice-mode')
+    // Dedicated system notices must precede the hidden system prefix.
+    const notices = ['voice-mode', 'connection-replacement']
+    const rest = USER_MESSAGE_KINDS.filter((spec) => !notices.includes(spec.kind))
     const firstVisible = rest.findIndex((spec) => !spec.hidden)
     expect(rest.slice(firstVisible).every((spec) => !spec.hidden)).toBe(true)
-    expect(USER_MESSAGE_KINDS.findIndex((spec) => spec.kind === 'voice-mode')).toBeLessThan(
-      USER_MESSAGE_KINDS.findIndex((spec) => spec.kind === 'system'),
-    )
+    for (const kind of notices) {
+      expect(USER_MESSAGE_KINDS.findIndex((spec) => spec.kind === kind)).toBeLessThan(
+        USER_MESSAGE_KINDS.findIndex((spec) => spec.kind === 'system'),
+      )
+    }
   })
 })
 

--- a/src/renderer/components/messages/user-message-kinds/index.ts
+++ b/src/renderer/components/messages/user-message-kinds/index.ts
@@ -1,3 +1,4 @@
+import { connectionReplacementNotice } from './connection-replacement'
 import { compactCommand } from './compact'
 import { interruptMarker } from './interrupt'
 import { slashCommand } from './slash-command'
@@ -16,12 +17,12 @@ export const plainMessage: UserMessageKindSpec = {
 
 /**
  * Registry of user-message kinds, first match wins. Order is deliberate:
- * the voice-mode notice first (a system message with its own visible
- * marker), then the hidden system prefix, then exact prefixes, then the
- * broad "/" catch-all. Adding a kind is one spec file plus one entry here.
+ * visible system notices first, then the hidden system prefix, then exact
+ * prefixes, then the broad "/" catch-all. Adding a kind is one spec file plus one entry here.
  */
 export const USER_MESSAGE_KINDS: readonly UserMessageKindSpec[] = [
   voiceModeNotice,
+  connectionReplacementNotice,
   systemMessage,
   interruptMarker,
   compactCommand,

--- a/src/renderer/components/messages/user-message-kinds/types.ts
+++ b/src/renderer/components/messages/user-message-kinds/types.ts
@@ -1,7 +1,7 @@
 import type { ComponentType, ReactNode } from 'react'
 import type { ApiMessage } from '@shared/lib/types/api'
 
-export type UserMessageKind = 'system' | 'voice-mode' | 'interrupt' | 'compact' | 'slash' | 'plain'
+export type UserMessageKind = 'system' | 'connection-replacement' | 'voice-mode' | 'interrupt' | 'compact' | 'slash' | 'plain'
 
 export interface UserMessageRenderProps {
   /** Bubble text after the structured blocks (sender, files, folders) are peeled. */

--- a/src/renderer/hooks/use-mcp-oauth-listener.test.ts
+++ b/src/renderer/hooks/use-mcp-oauth-listener.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { renderHook } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 import { useMcpOAuthListener } from './use-mcp-oauth-listener'
 
 // Ensure no electronAPI so we test the postMessage path
@@ -68,6 +68,18 @@ describe('useMcpOAuthListener', () => {
     expect(onComplete).toHaveBeenCalledWith({ success: true, error: undefined })
   })
 
+  it('preserves the completed connection ID for replacement selection', () => {
+    const onComplete = vi.fn()
+    renderHook(() => useMcpOAuthListener(true, onComplete))
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        origin: window.location.origin,
+        data: { type: 'mcp-oauth-callback', success: true, mcpId: 'new-mcp' },
+      }))
+    })
+    expect(onComplete).toHaveBeenCalledWith({ success: true, error: undefined, mcpId: 'new-mcp' })
+  })
+
   it('calls onComplete for BroadcastChannel mcp-oauth-callback messages', () => {
     const onComplete = vi.fn()
     renderHook(() => useMcpOAuthListener(true, onComplete))
@@ -101,6 +113,45 @@ describe('useMcpOAuthListener', () => {
     fireStorageMessage(payload)
 
     expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['postMessage', 'broadcast', 'storage', 'electron'] as const)('correlates %s callbacks before consuming the listener', (transport) => {
+    let electronCallback: ((params: Record<string, unknown>) => void) | undefined
+    const unsubscribe = vi.fn()
+    if (transport === 'electron') {
+      Object.defineProperty(window, 'electronAPI', { configurable: true, value: {
+        onMcpOAuthCallback: (callback: typeof electronCallback) => { electronCallback = callback; return unsubscribe },
+      } })
+    }
+    try {
+      const onComplete = vi.fn()
+      const { unmount } = renderHook(() => useMcpOAuthListener(true, onComplete, 'own-flow'))
+      const dispatch = (data: Record<string, unknown>) => {
+        const payload = { type: 'mcp-oauth-callback', ...data }
+        if (transport === 'postMessage') firePostMessage(payload, window.location.origin)
+        if (transport === 'broadcast') broadcastChannels[0].dispatch(payload)
+        if (transport === 'storage') fireStorageMessage(payload)
+        if (transport === 'electron') electronCallback?.(payload)
+      }
+      dispatch({ success: true, state: 'other-flow', mcpId: 'wrong-mcp' })
+      dispatch({ success: false, state: 'other-flow', error: 'Other flow failed' })
+      dispatch({ success: true, mcpId: 'missing-state' })
+      expect(onComplete).not.toHaveBeenCalled()
+      dispatch({ success: true, state: 'own-flow', mcpId: 'correct-mcp' })
+      dispatch({ success: true, state: 'own-flow', mcpId: 'correct-mcp' })
+      expect(onComplete).toHaveBeenCalledExactlyOnceWith({ success: true, error: undefined, state: 'own-flow', mcpId: 'correct-mcp' })
+      unmount()
+      if (transport === 'electron') expect(unsubscribe).toHaveBeenCalledOnce()
+    } finally {
+      Object.defineProperty(window, 'electronAPI', { configurable: true, value: undefined, writable: true })
+    }
+  })
+
+  it('delivers a failure for its own OAuth state', () => {
+    const onComplete = vi.fn()
+    renderHook(() => useMcpOAuthListener(true, onComplete, 'own-flow'))
+    fireStorageMessage({ type: 'mcp-oauth-callback', success: false, state: 'own-flow', error: 'Access denied' })
+    expect(onComplete).toHaveBeenCalledWith({ success: false, state: 'own-flow', error: 'Access denied' })
   })
 
   it('ignores mcp-oauth-callback messages from a different origin', () => {

--- a/src/renderer/hooks/use-mcp-oauth-listener.ts
+++ b/src/renderer/hooks/use-mcp-oauth-listener.ts
@@ -1,10 +1,12 @@
 import { useEffect, useRef } from 'react'
 
-type McpOAuthResult = { success: boolean; error?: string }
+type McpOAuthResult = { success: boolean; error?: string; mcpId?: string; state?: string }
 type McpOAuthCallbackMessage = {
   type?: unknown
   success?: unknown
   error?: unknown
+  mcpId?: unknown
+  state?: unknown
 }
 
 const MCP_OAUTH_CALLBACK_CHANNEL = 'mcp-oauth-callback'
@@ -19,6 +21,8 @@ function parseMcpOAuthResult(data: unknown): McpOAuthResult | null {
   return {
     success: !!message.success,
     error: typeof message.error === 'string' ? message.error : undefined,
+    ...(typeof message.state === 'string' && message.state ? { state: message.state } : {}),
+    ...(typeof message.mcpId === 'string' && message.mcpId ? { mcpId: message.mcpId } : {}),
   }
 }
 
@@ -28,7 +32,7 @@ function parseMcpOAuthResult(data: unknown): McpOAuthResult | null {
  * and sever `window.opener`, so web mode listens on postMessage, BroadcastChannel,
  * and localStorage's cross-window storage event.
  */
-export function useMcpOAuthListener(active: boolean, onComplete: (result: McpOAuthResult) => void): void {
+export function useMcpOAuthListener(active: boolean, onComplete: (result: McpOAuthResult) => void, expectedState?: string): void {
   const callbackRef = useRef(onComplete)
   callbackRef.current = onComplete
 
@@ -39,6 +43,9 @@ export function useMcpOAuthListener(active: boolean, onComplete: (result: McpOAu
     const completeOnce = (data: unknown) => {
       const result = parseMcpOAuthResult(data)
       if (!result || completed) return
+      // Other tabs use the same transports. Ignore their callbacks without
+      // consuming this listener, including failures and callbacks without state.
+      if (expectedState !== undefined && result.state !== expectedState) return
 
       completed = true
       callbackRef.current(result)
@@ -76,6 +83,8 @@ export function useMcpOAuthListener(active: boolean, onComplete: (result: McpOAu
           type: 'mcp-oauth-callback',
           success: params.success,
           error: params.error ?? undefined,
+          mcpId: params.mcpId,
+          state: params.state,
         })
       })
     }
@@ -86,5 +95,5 @@ export function useMcpOAuthListener(active: boolean, onComplete: (result: McpOAu
       broadcastChannel?.close()
       unsubscribe?.()
     }
-  }, [active])
+  }, [active, expectedState])
 }

--- a/src/renderer/lib/connection-live-refresh.ts
+++ b/src/renderer/lib/connection-live-refresh.ts
@@ -10,5 +10,10 @@ export function warnIfLiveRefreshFailed(result: unknown): void {
     toast.warning(
       'One or more running agents need a restart to apply the latest connection state.',
     )
+  } else if (
+    typeof result === 'object' && result !== null &&
+    'sessionNotification' in result && result.sessionNotification === false
+  ) {
+    toast.warning('The connection was replaced, but a session could not be notified. Send it a message to continue with the new connection.')
   }
 }

--- a/src/shared/lib/container/connection-replacement.test.ts
+++ b/src/shared/lib/container/connection-replacement.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  sync: vi.fn(), active: vi.fn(), isActive: vi.fn(), interrupt: vi.fn(), markInterrupted: vi.fn(),
+  send: vi.fn(), withSend: vi.fn(), status: 'running', order: [] as string[],
+}))
+vi.mock('./connection-runtime-sync', () => ({
+  syncAgentConnectionEnvironment: mocks.sync,
+}))
+vi.mock('./container-manager', () => ({
+  containerManager: {
+    getCachedInfo: () => ({ status: mocks.status }),
+    getClient: () => ({ interruptSession: mocks.interrupt, sendMessage: mocks.send }),
+  },
+}))
+vi.mock('./message-persister', () => ({
+  messagePersister: {
+    getActiveSessionIdsForAgent: mocks.active,
+    isSessionActive: mocks.isActive,
+    getTurnGeneration: () => 7,
+    markSessionInterrupted: mocks.markInterrupted,
+    withSessionSend: mocks.withSend,
+  },
+}))
+
+import { finishConnectionReplacement, type ConnectionReplacement } from './connection-replacement'
+
+const change: ConnectionReplacement = {
+  agentSlug: 'shared-agent', kind: 'connected-accounts', name: 'Slack', previousId: 'old', replacementId: 'new',
+}
+const release = vi.fn()
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  mocks.order = []
+  mocks.status = 'running'
+  mocks.active.mockReturnValue(['session-1', 'session-2'])
+  mocks.isActive.mockReturnValue(true)
+  mocks.sync.mockImplementation(async () => { mocks.order.push('refresh'); return true })
+  mocks.interrupt.mockImplementation(async (id: string) => {
+    mocks.order.push(`interrupt:${id}`)
+    return { interrupted: true, processKept: true }
+  })
+  mocks.markInterrupted.mockImplementation(async (_agent: string, id: string) => { mocks.order.push(`mark:${id}`) })
+  mocks.send.mockImplementation(async (id: string) => { mocks.order.push(`send:${id}`) })
+  mocks.withSend.mockImplementation(async (_agent: string, _id: string, _client: unknown, send: () => Promise<void>) => send())
+  release.mockImplementation(() => { mocks.order.push('release') })
+})
+
+describe('connection replacement notification', () => {
+  it.each(['connected-accounts', 'remote-mcps'] as const)('refreshes and interrupts before notifying active sessions for %s', async (kind) => {
+    expect(await finishConnectionReplacement({ ...change, kind }, release))
+      .toEqual({ liveRefresh: true, sessionNotification: true })
+    expect(mocks.active).toHaveBeenCalledWith('shared-agent')
+    expect(mocks.sync).toHaveBeenCalledWith('shared-agent', kind)
+    for (const sessionId of ['session-1', 'session-2']) {
+      expect(mocks.interrupt).toHaveBeenCalledWith(sessionId, { scope: 'turn' })
+      expect(mocks.markInterrupted).toHaveBeenCalledWith('shared-agent', sessionId, {
+        processKept: true, turnGenerationBefore: 7,
+      })
+      expect(mocks.order.indexOf(`interrupt:${sessionId}`)).toBeGreaterThan(mocks.order.indexOf('refresh'))
+      expect(mocks.order.indexOf('release')).toBeGreaterThan(mocks.order.indexOf(`mark:${sessionId}`))
+      expect(mocks.order.indexOf(`send:${sessionId}`)).toBeGreaterThan(mocks.order.indexOf('release'))
+      expect(mocks.send).toHaveBeenCalledWith(sessionId,
+        expect.stringMatching(/^\[SYSTEM\] Connection to "Slack" was replaced\./),
+        expect.any(String), { shouldQuery: true })
+    }
+    const message = mocks.send.mock.calls[0][1] as string
+    expect(message).toContain(kind === 'connected-accounts' ? 'Previous account ID: old. New account ID: new.' : 'Previous MCP ID: old. New MCP ID: new.')
+    expect(message).toContain('Update scripts')
+    expect(mocks.withSend).toHaveBeenCalledTimes(2)
+    expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('keeps idle sessions asleep', async () => {
+    mocks.active.mockReturnValue([])
+    expect(await finishConnectionReplacement(change, release)).toEqual({ liveRefresh: true, sessionNotification: true })
+    expect(mocks.send).not.toHaveBeenCalled()
+    expect(mocks.interrupt).not.toHaveBeenCalled()
+    expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('does not restart a stopped container or a session stopped during refresh', async () => {
+    mocks.status = 'stopped'
+    await finishConnectionReplacement(change, release)
+    mocks.status = 'running'
+    mocks.isActive.mockReturnValue(false)
+    await finishConnectionReplacement(change, release)
+    expect(mocks.send).not.toHaveBeenCalled()
+    expect(mocks.interrupt).not.toHaveBeenCalled()
+  })
+
+  it('reports a failed refresh and releases the request without claiming tools are ready', async () => {
+    mocks.sync.mockResolvedValue(false)
+    expect(await finishConnectionReplacement(change, release)).toEqual({ liveRefresh: false, sessionNotification: false })
+    expect(mocks.send).not.toHaveBeenCalled()
+    expect(mocks.interrupt).not.toHaveBeenCalled()
+    expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('releases the parked call if runtime preparation throws unexpectedly', async () => {
+    mocks.sync.mockRejectedValue(new Error('runtime unavailable'))
+    expect(await finishConnectionReplacement(change, release)).toEqual({ liveRefresh: false, sessionNotification: false })
+    expect(release).toHaveBeenCalledOnce()
+    expect(mocks.send).not.toHaveBeenCalled()
+  })
+
+  it.each(['rejected', 'unacknowledged', 'send'] as const)('reports %s failures while notifying the other session', async (failure) => {
+    if (failure === 'rejected') mocks.interrupt.mockRejectedValueOnce(new Error('interrupt failed'))
+    if (failure === 'unacknowledged') mocks.interrupt.mockResolvedValueOnce({ interrupted: false, processKept: false })
+    if (failure === 'send') mocks.send.mockRejectedValueOnce(new Error('send failed'))
+    expect(await finishConnectionReplacement(change, release)).toEqual({ liveRefresh: true, sessionNotification: false })
+    expect(mocks.send).toHaveBeenCalledWith('session-2', expect.any(String), expect.any(String), { shouldQuery: true })
+    expect(release).toHaveBeenCalledOnce()
+  })
+})

--- a/src/shared/lib/container/connection-replacement.ts
+++ b/src/shared/lib/container/connection-replacement.ts
@@ -1,0 +1,78 @@
+import { randomUUID } from 'crypto'
+import { containerManager } from './container-manager'
+import { messagePersister } from './message-persister'
+import { syncAgentConnectionEnvironment, type ConnectionRuntimeKind } from './connection-runtime-sync'
+import type { ContainerClient } from './types'
+import { buildConnectionReplacementMessage } from '@shared/lib/utils/connection-replacement-message'
+
+export interface ConnectionReplacement {
+  agentSlug: string
+  kind: ConnectionRuntimeKind
+  name: string
+  previousId: string
+  replacementId: string
+}
+
+/** Refresh the runtime, interrupt its active turns, then deliver the new identity.
+ * Releasing parked calls after the interrupts prevents a stale tool result from
+ * driving a continuation before the system message. Idle sessions pick up the
+ * new projection on their next normal message; replacement does not wake them. */
+export async function finishConnectionReplacement(
+  change: ConnectionReplacement,
+  releaseRequests: () => void,
+): Promise<{ liveRefresh: boolean; sessionNotification: boolean }> {
+  const { agentSlug } = change
+  let liveRefresh = false
+  let sessionNotification = true
+  const ready: Array<{ sessionId: string; client: ContainerClient }> = []
+  try {
+    const sessionIds = messagePersister.getActiveSessionIdsForAgent(agentSlug)
+    liveRefresh = await syncAgentConnectionEnvironment(agentSlug, change.kind)
+    if (!liveRefresh) return { liveRefresh: false, sessionNotification: false }
+    if (sessionIds.length === 0 || containerManager.getCachedInfo(agentSlug).status !== 'running') {
+      return { liveRefresh: true, sessionNotification: true }
+    }
+
+    const client = containerManager.getClient(agentSlug)
+    const interrupted = await Promise.allSettled(sessionIds.map(async (sessionId) => {
+      // A user may have stopped a session while the projection was being updated.
+      if (!messagePersister.isSessionActive(agentSlug, sessionId)) return null
+      const turnGenerationBefore = messagePersister.getTurnGeneration(agentSlug, sessionId)
+      const result = await client.interruptSession(sessionId, { scope: 'turn' })
+      if (!result.interrupted) throw new Error(`Failed to interrupt session ${sessionId}`)
+      await messagePersister.markSessionInterrupted(agentSlug, sessionId, {
+        processKept: result.processKept,
+        turnGenerationBefore,
+      })
+      return sessionId
+    }))
+    for (const result of interrupted) {
+      if (result.status === 'rejected') {
+        sessionNotification = false
+        console.warn('[ConnectionReplacement] Failed to interrupt a session:', result.reason)
+      } else if (result.value) {
+        ready.push({ sessionId: result.value, client })
+      }
+    }
+  } catch (error) {
+    console.warn('[ConnectionReplacement] Failed to prepare session notifications:', error)
+    return { liveRefresh, sessionNotification: false }
+  } finally {
+    // The mapping has already changed. Never leave a parked call waiting for
+    // the removed connection, even if runtime preparation fails unexpectedly.
+    releaseRequests()
+  }
+
+  const deliveries = await Promise.allSettled(ready.map(({ sessionId, client }) =>
+    messagePersister.withSessionSend(agentSlug, sessionId, client, () =>
+      client.sendMessage(sessionId, buildConnectionReplacementMessage(change), randomUUID(), { shouldQuery: true }),
+    ),
+  ))
+  for (const result of deliveries) {
+    if (result.status === 'rejected') {
+      sessionNotification = false
+      console.warn('[ConnectionReplacement] Failed to notify a session:', result.reason)
+    }
+  }
+  return { liveRefresh, sessionNotification }
+}

--- a/src/shared/lib/container/mock-connection-replacement-scenario.ts
+++ b/src/shared/lib/container/mock-connection-replacement-scenario.ts
@@ -1,0 +1,114 @@
+/** Opt-in recording fixture. Only loaded by the E2E mock runtime with the
+ * dedicated demo flag. The model and credential provider are simulated; the
+ * script, host proxy, authorization, replacement route and interrupt are real. */
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import * as fs from 'fs/promises'
+import path from 'path'
+import { eq } from 'drizzle-orm'
+import { db } from '../db'
+import { agentConnectedAccounts } from '../db/schema'
+import { getOrCreateProxyToken } from '../proxy/token-store'
+import { getAgentWorkspaceDir } from '../utils/file-storage'
+import { ComposioAccountProvider } from '../account-providers/composio-account-provider'
+import { registerAccountProvider } from '../account-providers/provider-factory'
+import { MockContainerClient, SimpleTextResponseScenario, type MockScenario } from './mock-container-client'
+
+const runFile = promisify(execFile)
+
+class DemoAccountProvider extends ComposioAccountProvider {
+  override async getConnection(connectionId: string) {
+    return { id: connectionId, status: connectionId.endsWith('-expired') ? 'EXPIRED' as const : 'ACTIVE' as const }
+  }
+
+  override async makeApiCall(params: Parameters<ComposioAccountProvider['makeApiCall']>[0]): Promise<Response> {
+    if (!params.providerConnectionId.startsWith('demo-slack-') || params.toolkitSlug !== 'slack') {
+      throw new Error('The recording provider only accepts its seeded demo accounts')
+    }
+    const upstream = URL.parse(process.env.E2E_DEMO_SLACK_URL!)
+    if (!upstream || upstream.hostname !== '127.0.0.1') throw new Error('Demo upstream must be loopback')
+    upstream.pathname = '/api/conversations.list'
+    return fetch(upstream, {
+      headers: { 'X-Demo-Connection-Id': params.providerConnectionId },
+    })
+  }
+}
+
+class ConnectionReplacementScenario implements MockScenario {
+  execute(sessionId: string, client: MockContainerClient, message: string): void {
+    void this.run(sessionId, client, message).catch((error: unknown) => {
+      new SimpleTextResponseScenario(`Demo failed: ${String(error)}`).execute(sessionId, client, message)
+    })
+  }
+
+  private async run(sessionId: string, client: MockContainerClient, message: string): Promise<void> {
+    const agentSlug = client.getAgentId()
+    const scriptPath = path.join(getAgentWorkspaceDir(agentSlug), 'scripts', 'list-slack-channels.mjs')
+    const replacementId = message.match(/New account ID: ([\w-]+)\./)?.[1]
+    let accountId: string
+    if (replacementId) {
+      const previousId = message.match(/Previous account ID: ([\w-]+)\./)?.[1]
+      const script = await fs.readFile(scriptPath, 'utf8')
+      if (!previousId || !script.includes(previousId)) throw new Error('Script does not contain the old ID')
+      // The simulated agent consumes the REAL system message and actually edits
+      // and executes its script. It does not read the new mapping from the DB.
+      await fs.writeFile(scriptPath, script.replaceAll(previousId, replacementId))
+      accountId = replacementId
+    } else {
+      registerAccountProvider(new DemoAccountProvider())
+      const mapping = db.select().from(agentConnectedAccounts)
+        .where(eq(agentConnectedAccounts.agentSlug, agentSlug)).get()
+      if (!mapping) throw new Error('No shared account assigned')
+      accountId = mapping.connectedAccountId
+      await fs.mkdir(path.dirname(scriptPath), { recursive: true })
+      await fs.writeFile(scriptPath, [
+        `const accountId = ${JSON.stringify(accountId)}`,
+        `const url = new URL('/api/proxy/${agentSlug}/' + accountId + '/slack.com/api/conversations.list', process.env.DEMO_HOST_URL)`,
+        `const response = await fetch(url, { headers: { Authorization: 'Bearer ' + process.env.DEMO_PROXY_TOKEN } })`,
+        `console.log(JSON.stringify({ status: response.status, body: await response.json() }))`,
+      ].join('\n'))
+      client.writeJsonlEntry(sessionId, {
+        type: 'user', message: { content: message }, timestamp: new Date().toISOString(),
+      })
+      const content = [{ type: 'text', text: 'I’m running `scripts/list-slack-channels.mjs` with the shared Slack connection.' }]
+      client.writeJsonlEntry(sessionId, {
+        type: 'assistant', message: { content }, timestamp: new Date().toISOString(),
+      })
+      client.emitStreamMessage(sessionId, {
+        type: 'assistant', content: { type: 'assistant', message: { content } },
+      })
+    }
+    const { stdout } = await runFile(process.execPath, [scriptPath], {
+      env: {
+        ...process.env,
+        DEMO_HOST_URL: `http://127.0.0.1:${process.env.PORT}`,
+        DEMO_PROXY_TOKEN: await getOrCreateProxyToken(agentSlug),
+      },
+      timeout: 90_000,
+    })
+    // eslint-disable-next-line local-rules/no-unhandled-throwing-builtins -- execute() catches parsing and execution failures and emits the demo failure
+    const result = JSON.parse(stdout) as { status: number; body: { channels?: Array<{ name: string }>; error?: string } }
+    if (!replacementId) {
+      // Replacement interrupts this turn before releasing the parked 409.
+      // Its epoch-pinned client suppresses stale emissions after that interrupt.
+      if (result.status !== 409 || result.body.error !== 'account_replaced') {
+        throw new Error(`Expected replaced response, got ${stdout}`)
+      }
+      return
+    }
+    if (result.status !== 200 || !result.body.channels?.length) throw new Error(`Slack request failed: ${stdout}`)
+    const response = [
+      'The replacement system message reached this session. I updated `scripts/list-slack-channels.mjs` to use the new account ID:',
+      `\n\n\`${accountId}\``,
+      '\n\nThe script ran successfully against the mock Slack API. Channels:',
+      ...result.body.channels.map((channel) => `\n- #${channel.name}`),
+    ].join('')
+    new SimpleTextResponseScenario(response).execute(sessionId, client, message)
+  }
+}
+
+export function registerConnectionReplacementDemo(): void {
+  const scenario = new ConnectionReplacementScenario()
+  MockContainerClient.registerScenario('list the slack channels using the shared connection', scenario)
+  MockContainerClient.registerScenario('[SYSTEM] Connection to "Slack" was replaced.', scenario)
+}

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -2555,6 +2555,16 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
 
   async fetch(fetchPath: string, init?: RequestInit): Promise<Response> {
     // Mock fetch - return appropriate empty responses based on path
+    if (fetchPath === '/env' && init?.method === 'POST') {
+      try {
+        const body = JSON.parse(String(init.body)) as { key: string; value: string }
+        if (body.key === 'CONNECTED_ACCOUNTS' || body.key === 'REMOTE_MCPS') {
+          this.writeMockRecord({ type: 'connectionEnvironment', agentSlug: this.config.agentId, key: body.key, value: body.value })
+        }
+      } catch {
+        // A malformed body has no connection snapshot to record.
+      }
+    }
 
     // Workspace entry mutations are executed inside the real agent container.
     // The E2E mock has no container namespace, so mirror the operation against
@@ -3298,6 +3308,10 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
     if (!session) return { interrupted: false, processKept: false }
 
     const hadTurnInFlight = this.busySessions.has(sessionId)
+    this.writeMockRecord({
+      type: 'interruptSession', agentSlug: this.config.agentId, sessionId,
+      scope: options?.scope ?? 'turn', hadTurnInFlight,
+    })
     // 'turn' keeps the process and its background tasks (the real CLI honors
     // perTaskStopAffordance); 'all' replaces it, so every task dies with it.
     const processKept = (options?.scope ?? 'turn') === 'turn'
@@ -3406,4 +3420,11 @@ export class MockContainerClient extends EventEmitter implements ContainerClient
 
   // Events (inherited from EventEmitter)
   // on, off are already available from EventEmitter
+}
+
+// Recording-only scenario; ordinary E2E runs keep the default registry.
+if (process.env.E2E_MOCK === 'true' && process.env.E2E_CONNECTION_REPLACEMENT_DEMO === 'true') {
+  void import('./mock-connection-replacement-scenario').then(({ registerConnectionReplacementDemo }) => {
+    registerConnectionReplacementDemo()
+  })
 }

--- a/src/shared/lib/mcp/endpoint.ts
+++ b/src/shared/lib/mcp/endpoint.ts
@@ -1,0 +1,10 @@
+/** Compare connection endpoints without account-specific query credentials. */
+export function sameMcpEndpoint(first: string, second: string): boolean {
+  try {
+    const a = new URL(first)
+    const b = new URL(second)
+    return a.origin === b.origin && a.pathname.replace(/\/+$/, '') === b.pathname.replace(/\/+$/, '')
+  } catch {
+    return false
+  }
+}

--- a/src/shared/lib/proxy/account-reauth-manager.test.ts
+++ b/src/shared/lib/proxy/account-reauth-manager.test.ts
@@ -14,6 +14,7 @@ import {
 } from './account-reauth-manager'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import { isReauthDismissed } from './reauth-dismissal'
+import { getReplacementAccountId } from './account-replacement'
 
 const DETAILS = {
   agentSlug: 'agent-1',
@@ -148,6 +149,24 @@ describe('AccountReauthManager', () => {
 
     manager.completeAccount('account-1')
     await expect(promise).resolves.toBeUndefined()
+  })
+
+  it('releases all calls for a replacement while leaving other agents pending', async () => {
+    const first = manager.requestReauth(DETAILS).catch(getReplacementAccountId)
+    const second = manager.requestReauth(DETAILS).catch(getReplacementAccountId)
+    const otherAgent = manager.requestReauth({ ...DETAILS, agentSlug: 'agent-2' })
+    const [request] = userInputRequestManager.getAgentScopedRequests('agent-1')
+
+    expect(manager.replaceAccount(request.id, 'agent-2', 'replacement')).toBe(false)
+    expect(manager.replaceAccount(request.id, 'agent-1', 'replacement')).toBe(true)
+    expect(await Promise.all([first, second])).toEqual(['replacement', 'replacement'])
+    expect(userInputRequestManager.getAgentScopedRequests('agent-1')).toHaveLength(0)
+    expect(userInputRequestManager.getAgentScopedRequests('agent-2')).toHaveLength(1)
+    expect(userInputRequestManager.getRecentResolution(request.id)?.outcome).toBe('answered')
+    expect(manager.replaceAccount(request.id, 'agent-1', 'another')).toBe(false)
+
+    manager.completeAccount(DETAILS.accountId)
+    await expect(otherAgent).resolves.toBeUndefined()
   })
 
   it('reports an unknown request id as not dismissed', () => {

--- a/src/shared/lib/proxy/account-reauth-manager.ts
+++ b/src/shared/lib/proxy/account-reauth-manager.ts
@@ -3,6 +3,7 @@ import { messagePersister } from '@shared/lib/container/message-persister'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import type { PendingUserInputRequest } from '@shared/lib/user-input/request-schema'
 import { ReauthDismissedError, reauthDismissedMessage } from './reauth-dismissal'
+import { AccountReplacedError } from './account-replacement'
 
 export const ACCOUNT_REAUTH_TIMEOUT_MS = 5 * 60 * 1000
 
@@ -226,6 +227,17 @@ export class AccountReauthManager {
         reauthDismissedMessage('Account re-authentication', reason),
         reason,
       ),
+    })
+    return true
+  }
+
+  /** Release only this agent's calls; other agents still use the old account. */
+  replaceAccount(entryId: string, agentSlug: string, replacementAccountId: string): boolean {
+    const group = this.groups.get(entryId)
+    if (!group || group.agentSlug !== agentSlug) return false
+    this.settleGroup(group, 'answered', {
+      type: 'reject',
+      error: new AccountReplacedError(replacementAccountId),
     })
     return true
   }

--- a/src/shared/lib/proxy/account-replacement.ts
+++ b/src/shared/lib/proxy/account-replacement.ts
@@ -1,0 +1,17 @@
+/** A replacement changes identity, so the agent must retry through the new
+ * account's policy gate instead of replaying an already-approved request. */
+export class AccountReplacedError extends Error {
+  readonly replacementAccountId: string
+
+  constructor(accountId: string) {
+    super('The connection was replaced for this agent')
+    this.name = 'AccountReplacedError'
+    this.replacementAccountId = accountId
+  }
+}
+
+export function getReplacementAccountId(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) return undefined
+  const id = (error as { replacementAccountId?: unknown }).replacementAccountId
+  return typeof id === 'string' && id ? id : undefined
+}

--- a/src/shared/lib/proxy/mcp-reauth-manager.test.ts
+++ b/src/shared/lib/proxy/mcp-reauth-manager.test.ts
@@ -11,6 +11,7 @@ vi.mock('@shared/lib/container/message-persister', () => ({
 import { MCP_REAUTH_TIMEOUT_MS, McpReauthManager } from './mcp-reauth-manager'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import { isReauthDismissed } from './reauth-dismissal'
+import { getReplacementMcpId } from './mcp-replacement'
 
 const DETAILS = {
   agentSlug: 'agent-1',
@@ -125,6 +126,21 @@ describe('McpReauthManager', () => {
     expect((error as Error).message).toContain('not my server')
     expect(userInputRequestManager.getAgentScopedRequests('agent-1')).toHaveLength(0)
     expect(userInputRequestManager.stats.recentResolutions.at(-1)?.outcome).toBe('cancelled')
+  })
+
+  it('releases replaced calls for this agent while preserving another agent’s wait', async () => {
+    const first = manager.requestReauth(DETAILS).catch(getReplacementMcpId)
+    const second = manager.requestReauth(DETAILS).catch(getReplacementMcpId)
+    const other = manager.requestReauth({ ...DETAILS, agentSlug: 'agent-2' })
+    const [request] = userInputRequestManager.getAgentScopedRequests('agent-1')
+    expect(manager.replaceMcp(request.id, 'agent-2', 'new-mcp')).toBe(false)
+    expect(manager.replaceMcp(request.id, 'agent-1', 'new-mcp')).toBe(true)
+    expect(await Promise.all([first, second])).toEqual(['new-mcp', 'new-mcp'])
+    expect(userInputRequestManager.getAgentScopedRequests('agent-1')).toHaveLength(0)
+    expect(userInputRequestManager.getAgentScopedRequests('agent-2')).toHaveLength(1)
+    expect(userInputRequestManager.getRecentResolution(request.id)?.outcome).toBe('answered')
+    manager.completeMcp('mcp-1')
+    await expect(other).resolves.toBeUndefined()
   })
 
   it('refuses a dismissal aimed at another agent', async () => {

--- a/src/shared/lib/proxy/mcp-reauth-manager.ts
+++ b/src/shared/lib/proxy/mcp-reauth-manager.ts
@@ -3,6 +3,7 @@ import { messagePersister } from '@shared/lib/container/message-persister'
 import { userInputRequestManager } from '@shared/lib/user-input/request-manager'
 import type { PendingUserInputRequest } from '@shared/lib/user-input/request-schema'
 import { ReauthDismissedError, reauthDismissedMessage } from './reauth-dismissal'
+import { McpReplacedError } from './mcp-replacement'
 
 export const MCP_REAUTH_TIMEOUT_MS = 5 * 60 * 1000
 
@@ -209,6 +210,17 @@ export class McpReauthManager {
         reauthDismissedMessage('MCP re-authentication', reason),
         reason,
       ),
+    })
+    return true
+  }
+
+  /** Settle this agent's waiters without resuming them against stale tools. */
+  replaceMcp(entryId: string, agentSlug: string, replacementMcpId: string): boolean {
+    const group = this.groups.get(entryId)
+    if (!group || group.agentSlug !== agentSlug) return false
+    this.settleGroup(group, 'answered', {
+      type: 'reject',
+      error: new McpReplacedError(replacementMcpId),
     })
     return true
   }

--- a/src/shared/lib/proxy/mcp-replacement.ts
+++ b/src/shared/lib/proxy/mcp-replacement.ts
@@ -1,0 +1,15 @@
+export class McpReplacedError extends Error {
+  readonly replacementMcpId: string
+
+  constructor(mcpId: string) {
+    super('The MCP connection was replaced for this agent')
+    this.name = 'McpReplacedError'
+    this.replacementMcpId = mcpId
+  }
+}
+
+export function getReplacementMcpId(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) return undefined
+  const id = (error as { replacementMcpId?: unknown }).replacementMcpId
+  return typeof id === 'string' && id ? id : undefined
+}

--- a/src/shared/lib/utils/connection-replacement-message.test.ts
+++ b/src/shared/lib/utils/connection-replacement-message.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { buildConnectionReplacementMessage, parseConnectionReplacementMessage } from './connection-replacement-message'
+
+const previousMessage = '[SYSTEM] Connection to "Slack" was replaced. Previous account ID: old-account. New account ID: new-account. Update scripts, cached account IDs, and proxy URLs that reference the previous account ID.'
+
+describe('connection replacement messages', () => {
+  it('recognizes previously persisted account notifications', () => {
+    expect(parseConnectionReplacementMessage(previousMessage)).toEqual({
+      kind: 'connected-accounts', name: 'Slack', previousId: 'old-account', replacementId: 'new-account',
+    })
+  })
+
+  it.each(['connected-accounts', 'remote-mcps'] as const)('preserves quoted and Unicode names and IDs for %s', (kind) => {
+    const change = { kind, name: 'Team "Analytics" — 東京\\MCP', previousId: 'old-id', replacementId: 'new-id' }
+    expect(parseConnectionReplacementMessage(buildConnectionReplacementMessage(change))).toEqual(change)
+  })
+
+  it.each([
+    previousMessage.replace('[SYSTEM] ', ''),
+    '[SYSTEM] Unrelated connection setup notice',
+    previousMessage.replace('New account ID:', 'New MCP ID:'),
+    previousMessage.replace('new-account', ''),
+    previousMessage.replace('"Slack"', '"Invalid\\q"'),
+    '[SYSTEM] Connection to "Slack" was replaced.',
+  ])('does not misclassify unrelated or malformed text: %s', (text) => {
+    expect(parseConnectionReplacementMessage(text)).toBeNull()
+  })
+})

--- a/src/shared/lib/utils/connection-replacement-message.ts
+++ b/src/shared/lib/utils/connection-replacement-message.ts
@@ -1,0 +1,39 @@
+import { SYSTEM_MESSAGE_PREFIX } from './system-message'
+
+export interface ConnectionReplacementNotice {
+  kind: 'connected-accounts' | 'remote-mcps'
+  name: string
+  previousId: string
+  replacementId: string
+}
+
+const PREFIX = `${SYSTEM_MESSAGE_PREFIX}Connection to `
+
+/** Shared with the transcript renderer, including messages already on disk. */
+export function buildConnectionReplacementMessage(change: ConnectionReplacementNotice): string {
+  const reference = change.kind === 'connected-accounts' ? 'account' : 'MCP'
+  const instructions = change.kind === 'connected-accounts'
+    ? 'Update scripts, cached account IDs, and proxy URLs that reference the previous account ID.'
+    : 'Use the replacement MCP tools now available. Update scripts, cached MCP IDs, and tool references that use the previous connection.'
+  return `${PREFIX}${JSON.stringify(change.name)} was replaced. Previous ${reference} ID: ${change.previousId}. New ${reference} ID: ${change.replacementId}. ${instructions} Continue the user’s task with the new connection and its access permissions. Before retrying an interrupted write, check whether it already completed.`
+}
+
+export function parseConnectionReplacementMessage(text: string): ConnectionReplacementNotice | null {
+  if (!text.startsWith(PREFIX)) return null
+  // Names are JSON strings (including escaped quotes); both ID labels must
+  // name the same connection type. Unrelated system messages remain hidden.
+  const match = /^("(?:[^"\\]|\\.)*") was replaced\. Previous (account|MCP) ID: (\S+)\. New \2 ID: (\S+)\.(?:\s|$)/.exec(text.slice(PREFIX.length))
+  if (!match) return null
+  try {
+    const name: unknown = JSON.parse(match[1])
+    if (typeof name !== 'string' || !name.trim()) return null
+    return {
+      kind: match[2] === 'account' ? 'connected-accounts' : 'remote-mcps',
+      name,
+      previousId: match[3],
+      replacementId: match[4],
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/shared/lib/utils/system-message.ts
+++ b/src/shared/lib/utils/system-message.ts
@@ -2,7 +2,8 @@
  * Prefix for system-injected user messages: entries the app or the container
  * writes into the transcript as `user` turns (chat-integration notices,
  * scheduler wake-ups, MCP registration nudges) that the person never typed.
- * The UI hides them and notification summaries skip them.
+ * The UI hides them by default (some have dedicated renderers), and
+ * notification summaries skip them.
  *
  * The container keeps its own copy of this constant because it is a separate
  * package. Keep in sync with SYSTEM_MESSAGE_PREFIX in agent-container/src/claude-code.ts.


### PR DESCRIPTION
Expired connections owned by someone else can strand a shared agent in Auth Mode. Agent members can now replace API accounts and MCP connections with connections they own, using replacement modes in the existing connection dialogs.

The agent mapping changes atomically and preserves the original connection for other agents. Active sessions refresh their connection environment, interrupt the current turn, and receive a system message with the old and new IDs so scripts and tool references can be updated. A dedicated transcript notice explains the replacement and shows connection details instead of a redundant “Stopped” badge.

- Enforce agent access, replacement ownership, active status, and matching service/endpoint; retries use the replacement connection’s permissions.
- Support custom MCP URL entry when a safe prefill is unavailable, share endpoint matching between the picker and API, and correlate OAuth completion by state across web and Electron.
- Add an isolated Auth Mode demo with real application APIs, authorization, mapping swaps, and script execution against a mock Slack provider.

## Validation

- Application review suite: 615 passed, 19 skipped across 25 files.
- MCP/OAuth regression suite after fixes: 148 passed across 8 files.
- Runtime connection and interruption tests: 39 passed.
- Auth Mode Slack E2E, including persisted transcript reload: passed on rerun after an initial timeout.
- Typechecking and lint for the review fixes passed; `git diff --check` passed.

## Demo

A non-owner replaces expired shared Slack access, the session displays the connection-replacement notice, and the script resumes using the new account ID. The agent/model and upstream Slack provider are simulated; the application UI, authorization, proxy, mapping swap, and script execution are real.

https://github.com/user-attachments/assets/9107acb7-9038-402e-aba7-7621375b0143
