### PR TITLE
feat(container): tell agents how much time has passed between messages (SUP-811)

### DIFF
--- a/agent-container/src/claude-code.ts
+++ b/agent-container/src/claude-code.ts
@@ -21,6 +21,7 @@ import { createBrowserTools } from './tools/browser';
 import { renameBrowserSession } from './browser-state';
 import { computerUseTools } from './tools/computer-use';
 import { fileHooks, resolveToolFilePath } from './file-hooks';
+import { elapsedTimeNote } from './elapsed-time-note';
 import { promptDate } from './prompt-date';
 
 /**
@@ -1202,6 +1203,19 @@ export class ClaudeCodeProcess extends EventEmitter {
         return { behavior: 'allow' as const, updatedInput: toolInput };
       },
       hooks: {
+        // The transcript the CLI hands the hook does not yet hold this prompt,
+        // so its newest entry is the end of the previous exchange.
+        UserPromptSubmit: [
+          {
+            hooks: [
+              async (input) => {
+                const note = await elapsedTimeNote(input.transcript_path);
+                if (!note) return {};
+                return { hookSpecificOutput: { hookEventName: 'UserPromptSubmit' as const, additionalContext: note } };
+              },
+            ],
+          },
+        ],
         PreToolUse: [
           {
             matcher: 'mcp__user-input__.*',

--- a/agent-container/src/dashboard-manager.ts
+++ b/agent-container/src/dashboard-manager.ts
@@ -1,4 +1,5 @@
 import { spawn, ChildProcess } from 'child_process'
+import { readFileTail } from './file-tail'
 import * as fs from 'fs'
 import * as path from 'path'
 import { captureDashboardScreenshot, type ScreenshotResult } from './dashboard-screenshot'
@@ -43,15 +44,8 @@ export async function truncateOversizedLog(
     const stat = await fs.promises.stat(logPath)
     if (stat.size <= maxBytes) return false
 
-    const fd = await fs.promises.open(logPath, 'r')
-    let tail: Buffer
-    try {
-      const buf = Buffer.alloc(Math.min(keepBytes, stat.size))
-      const { bytesRead } = await fd.read(buf, 0, buf.length, stat.size - buf.length)
-      tail = buf.subarray(0, bytesRead)
-    } finally {
-      await fd.close()
-    }
+    const tail = await readFileTail(logPath, keepBytes)
+    if (!tail) return false
 
     await fs.promises.writeFile(
       logPath,

--- a/agent-container/src/elapsed-time-note.test.ts
+++ b/agent-container/src/elapsed-time-note.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { buildElapsedNote, elapsedTimeNote, formatElapsed, lastTranscriptActivity } from './elapsed-time-note'
+
+const line = (entry: object) => JSON.stringify(entry)
+
+describe('lastTranscriptActivity', () => {
+  it.each([
+    ['assistant', '2026-09-10T11:00:00.000Z', 'user', '2026-09-10T10:30:00.000Z'],
+    ['user', '2026-09-10T11:00:00.000Z', 'assistant', '2026-09-10T10:30:00.000Z'],
+  ])('takes the newest stamp when a %s entry is newest, regardless of line order', (newestType, newest, olderType, older) => {
+    const tail = [
+      'ssistant","timestamp":"2026-09-10T10:00:00.000Z"}',
+      line({ type: newestType, timestamp: newest }),
+      line({ type: olderType, timestamp: older }),
+      line({ type: 'attachment', timestamp: '2026-09-10T12:00:00.000Z' }),
+      line({ type: 'last-prompt' }),
+      line({ type: 'queue-operation', timestamp: '2026-09-10T13:00:00.000Z' }),
+    ].join('\n')
+    expect(lastTranscriptActivity(tail)?.toISOString()).toBe(newest)
+  })
+
+  it('returns null when no message entry carries a timestamp', () => {
+    expect(lastTranscriptActivity([line({ type: 'attachment' }), 'null', 'not json', ''].join('\n'))).toBeNull()
+  })
+})
+
+describe('formatElapsed', () => {
+  it.each([
+    [23 * 60_000, '23m'],
+    [2 * 3_600_000, '2h'],
+    [(2 * 60 + 13) * 60_000, '2h 13m'],
+    [(24 + 22) * 3_600_000 + 59_000, '1 day 22h'],
+    [3 * 24 * 3_600_000, '3 days'],
+    [12 * 24 * 3_600_000 + 5 * 3_600_000, '12 days'],
+  ])('%i ms → %s', (ms, expected) => {
+    expect(formatElapsed(ms)).toBe(expected)
+  })
+})
+
+describe('buildElapsedNote', () => {
+  it('renders both moments in the zone and the elapsed figure', () => {
+    const note = buildElapsedNote(
+      new Date('2026-09-09T01:40:00Z'),
+      new Date('2026-09-10T23:52:00Z'),
+      'America/Los_Angeles',
+    )
+    expect(note).toBe(
+      'The previous message was Tuesday, 2026-09-08 18:40. It is now Thursday, 2026-09-10 16:52 (America/Los_Angeles), 1 day 22h later.',
+    )
+  })
+})
+
+describe('elapsedTimeNote', () => {
+  const now = new Date('2026-09-10T23:52:00Z')
+  let dir: string
+  beforeEach(async () => { dir = await mkdtemp(join(tmpdir(), 'elapsed-note-')) })
+  afterEach(async () => { await rm(dir, { recursive: true, force: true }) })
+  const transcriptWith = async (lastAt: string) => {
+    const file = join(dir, 'session.jsonl')
+    await writeFile(file, [line({ type: 'user', timestamp: '2026-09-01T00:00:00Z' }), line({ type: 'assistant', timestamp: lastAt })].join('\n') + '\n')
+    return file
+  }
+
+  it('is null for a transcript that does not exist yet', async () => {
+    expect(await elapsedTimeNote('/nonexistent/session.jsonl', now, 'UTC')).toBeNull()
+  })
+
+  it('is null under the threshold', async () => {
+    expect(await elapsedTimeNote(await transcriptWith('2026-09-10T23:38:00Z'), now, 'UTC')).toBeNull()
+  })
+
+  it('states the gap at or past the threshold', async () => {
+    expect(await elapsedTimeNote(await transcriptWith('2026-09-10T23:37:00Z'), now, 'UTC')).toBe(
+      'The previous message was Thursday, 2026-09-10 23:37. It is now Thursday, 2026-09-10 23:52 (UTC), 15m later.',
+    )
+  })
+})

--- a/agent-container/src/elapsed-time-note.ts
+++ b/agent-container/src/elapsed-time-note.ts
@@ -1,0 +1,71 @@
+import { readFileTail } from './file-tail';
+import { promptDate } from './prompt-date';
+import { transcriptEntrySchema } from './transcript-entry-schema';
+
+// Same gap the transcript draws a time flag for. Keep in sync with
+// SESSION_GAP_MINUTES in src/renderer/components/messages/session-time-flag.tsx.
+export const ELAPSED_NOTE_MIN_MS = 15 * 60_000;
+
+// Same window as bin/list-sessions.py; a single tool-result entry can run past 64KB.
+const TAIL_WINDOW_BYTES = 256 * 1024;
+
+/**
+ * Newest timestamp among user and assistant entries, as the max over the
+ * window rather than the last line: a resume re-appends history with the
+ * original stamps. Other entry types are ignored because queue-operation
+ * lines already carry the current prompt's enqueue time when the hook runs.
+ */
+export function lastTranscriptActivity(tail: string): Date | null {
+  let latest: number | null = null;
+  for (const line of tail.split('\n')) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const entry = transcriptEntrySchema.safeParse(parsed);
+    if (!entry.success) continue;
+    if (entry.data.type !== 'user' && entry.data.type !== 'assistant') continue;
+    const at = new Date(entry.data.timestamp).getTime();
+    if (!Number.isNaN(at) && (latest === null || at > latest)) latest = at;
+  }
+  return latest === null ? null : new Date(latest);
+}
+
+/** `23m`, `2h 13m`, `1 day 22h`, `12 days`. */
+export function formatElapsed(ms: number): string {
+  const totalMinutes = Math.floor(ms / 60_000);
+  const days = Math.floor(totalMinutes / (24 * 60));
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60);
+  const minutes = totalMinutes % 60;
+  if (days >= 7) return `${days} days`;
+  if (days >= 1) return `${days} ${days === 1 ? 'day' : 'days'}${hours ? ` ${hours}h` : ''}`;
+  if (hours >= 1) return `${hours}h${minutes ? ` ${minutes}m` : ''}`;
+  return `${totalMinutes}m`;
+}
+
+function describeMoment(at: Date, timeZone: string): string {
+  const { weekday, date, time } = promptDate(at, timeZone);
+  return `${weekday}, ${date} ${time}`;
+}
+
+export function buildElapsedNote(previous: Date, now: Date, timeZone: string): string {
+  return (
+    `The previous message was ${describeMoment(previous, timeZone)}. ` +
+    `It is now ${describeMoment(now, timeZone)} (${timeZone}), ${formatElapsed(now.getTime() - previous.getTime())} later.`
+  );
+}
+
+/** Null under the threshold, and for a new session: its file is not written until after the prompt hooks run. */
+export async function elapsedTimeNote(
+  transcriptPath: string,
+  now: Date = new Date(),
+  timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
+): Promise<string | null> {
+  const tail = await readFileTail(transcriptPath, TAIL_WINDOW_BYTES);
+  if (!tail) return null;
+  const previous = lastTranscriptActivity(tail.toString('utf-8'));
+  if (!previous || now.getTime() - previous.getTime() < ELAPSED_NOTE_MIN_MS) return null;
+  return buildElapsedNote(previous, now, timeZone);
+}

--- a/agent-container/src/file-tail.ts
+++ b/agent-container/src/file-tail.ts
@@ -1,0 +1,24 @@
+import * as fs from 'fs';
+
+/** The last `maxBytes` of a file, or null when it cannot be read (a missing file included). */
+export async function readFileTail(filePath: string, maxBytes: number): Promise<Buffer | null> {
+  try {
+    const handle = await fs.promises.open(filePath, 'r');
+    try {
+      const { size } = await handle.stat();
+      const start = Math.max(0, size - maxBytes);
+      const buf = Buffer.alloc(size - start);
+      let offset = 0;
+      while (offset < buf.length) {
+        const { bytesRead } = await handle.read(buf, offset, buf.length - offset, start + offset);
+        if (bytesRead === 0) break;
+        offset += bytesRead;
+      }
+      return buf.subarray(0, offset);
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return null;
+  }
+}

--- a/agent-container/src/prompt-date.test.ts
+++ b/agent-container/src/prompt-date.test.ts
@@ -6,9 +6,9 @@ describe('promptDate', () => {
   const instant = new Date('2026-09-10T23:30:00Z')
 
   it.each([
-    ['UTC', { date: '2026-09-10', weekday: 'Thursday', utcOffset: 'UTC+00:00' }],
-    ['Asia/Kolkata', { date: '2026-09-11', weekday: 'Friday', utcOffset: 'UTC+05:30' }],
-  ])('renders the calendar day and offset in %s', (timeZone, expected) => {
+    ['UTC', { date: '2026-09-10', weekday: 'Thursday', utcOffset: 'UTC+00:00', time: '23:30' }],
+    ['Asia/Kolkata', { date: '2026-09-11', weekday: 'Friday', utcOffset: 'UTC+05:30', time: '05:00' }],
+  ])('renders the calendar day, clock and offset in %s', (timeZone, expected) => {
     expect(promptDate(instant, timeZone)).toEqual({ timeZone, ...expected })
   })
 })

--- a/agent-container/src/prompt-date.ts
+++ b/agent-container/src/prompt-date.ts
@@ -10,6 +10,8 @@ export interface PromptDate {
   timeZone: string;
   /** e.g. UTC-07:00 */
   utcOffset: string;
+  /** Local wall clock, HH:MM. */
+  time: string;
 }
 
 export function promptDate(
@@ -22,6 +24,9 @@ export function promptDate(
     month: '2-digit',
     day: '2-digit',
     weekday: 'long',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
     timeZoneName: 'longOffset',
   }).formatToParts(now);
   const part = (type: Intl.DateTimeFormatPartTypes) => parts.find((p) => p.type === type)?.value ?? '';
@@ -32,5 +37,6 @@ export function promptDate(
     weekday: part('weekday'),
     timeZone,
     utcOffset: offset === 'GMT' ? 'UTC+00:00' : offset.replace('GMT', 'UTC'),
+    time: `${part('hour')}:${part('minute')}`,
   };
 }

--- a/agent-container/src/transcript-entry-schema.ts
+++ b/agent-container/src/transcript-entry-schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+/** The two fields of a transcript line the elapsed-time note reads. */
+export const transcriptEntrySchema = z.object({
+  type: z.string(),
+  timestamp: z.string(),
+});


### PR DESCRIPTION
Agents had no sense of time passing between messages: a reply after lunch or the next morning read as if it came seconds after the previous turn. This adds a `UserPromptSubmit` hook in the container that, when the transcript has been quiet for 15 minutes or more, hands the model a hidden one-line note with the previous message's time, the current time in the owner's zone, and the gap. The hook sits with the existing tool hooks, so the app, chat integrations, agent-to-agent calls and scheduled wakes are all covered in one place, and the note is stored as a transcript attachment the UI never renders.

Closes https://linear.app/datawizz/issue/SUP-811/tell-agents-how-much-time-has-passed-between-messages

Builds on #1030, now merged. Footprint: about 120 production lines in 6 files, 85 test lines in 2.

How it decides:

- Claude Code runs the hook before it processes each prompt and hands over the transcript path. At that moment the file does not yet hold the current prompt, so its newest `user` or `assistant` timestamp is the end of the previous exchange. A brand-new session has no file yet and gets no note.
- The timestamp is the max over the last 256KB, not the last line, because a resume re-appends history with the original stamps (same rule as `bin/list-sessions.py`). Other entry types are ignored: `queue-operation` lines already carry the current prompt's enqueue time when the hook runs, which would read as a zero gap.
- Under 15 minutes, nothing. The threshold is the same one the transcript uses to draw a time flag, duplicated with a keep-in-sync comment like `SYSTEM_MESSAGE_PREFIX`.
- The note is facts only: `The previous message was Thursday, 2026-09-10 13:26. It is now Friday, 2026-09-11 15:26 (America/Los_Angeles), 1 day 2h later.` Both moments are absolute with the weekday spelled out so the model never does date arithmetic. The elapsed figure is pre-computed and coarse.
- `promptDate` from #1030 gains a `time` field so both prompts format moments the same way. The tail read lives in `file-tail.ts`, and `truncateOversizedLog` in `dashboard-manager.ts` now uses it too.
- Rejected: a `[SYSTEM]`-prefixed hidden user turn (the model distrusts user text claiming to be system, and the prefix is never defined to it), a timestamp on every turn (token cost, and models start fabricating timestamps from the pattern), and a tool the model calls for the time (relies on it remembering, which is the failure this fixes).

Verified live through the SDK against the bundled CLI: no note on a new session or a quick reply, the note after a 2h 13m gap, and the note with the weekday advanced on a real resume 26 hours later. The model reported the gap and weekday correctly each time.
