### PR TITLE
Separate user profile reads from agent routes

### DIFF
--- a/src/api/routes/agents.test.ts
+++ b/src/api/routes/agents.test.ts
@@ -288,6 +288,13 @@ vi.mock('drizzle-orm', () => ({
   or: (...args: unknown[]) => args,
 }))
 
+vi.mock('@shared/lib/services/user-profile-service', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@shared/lib/services/user-profile-service')>(),
+  getUserSummaries: vi.fn(),
+  userExists: vi.fn(),
+}))
+import { getUserSummaries, userExists } from '@shared/lib/services/user-profile-service'
+
 // Auth
 const mockIsAuthMode = vi.fn().mockReturnValue(false)
 const mockInsertAuthor = vi.fn().mockResolvedValue(true)
@@ -649,6 +656,8 @@ function createApp() {
 }
 
 beforeEach(() => {
+  vi.mocked(getUserSummaries).mockReturnValue(new Map())
+  vi.mocked(userExists).mockReturnValue(true)
   mockAuthorizedAgentRole = 'owner'
   vi.mocked(sessionIsKnown).mockResolvedValue(true)
 })
@@ -2111,10 +2120,7 @@ describe('ACL — POST /:id/access (invite user)', () => {
   })
 
   it('returns 404 when target user does not exist', async () => {
-    // db.select().from(userTable).where().limit(1) → no user found
-    mockDbSelectFrom.mockReturnValueOnce({
-      where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) })),
-    })
+    vi.mocked(userExists).mockReturnValue(false)
 
     const res = await postJson(app, INVITE_URL, { userId: 'nonexistent', role: 'user' })
     expect(res.status).toBe(404)
@@ -2123,11 +2129,7 @@ describe('ACL — POST /:id/access (invite user)', () => {
   })
 
   it('returns 409 when user already has access', async () => {
-    // First query: user exists
-    mockDbSelectFrom.mockReturnValueOnce({
-      where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([{ id: 'user-1' }])) })),
-    })
-    // Second query: ACL entry already exists
+    // ACL entry already exists
     mockDbSelectFrom.mockReturnValueOnce({
       where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([{ id: 'acl-1' }])) })),
     })
@@ -2139,11 +2141,7 @@ describe('ACL — POST /:id/access (invite user)', () => {
   })
 
   it('returns 201 on successful invite', async () => {
-    // First query: user exists
-    mockDbSelectFrom.mockReturnValueOnce({
-      where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([{ id: 'user-1' }])) })),
-    })
-    // Second query: no existing ACL
+    // No existing ACL
     mockDbSelectFrom.mockReturnValueOnce({
       where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) })),
     })
@@ -2157,9 +2155,6 @@ describe('ACL — POST /:id/access (invite user)', () => {
   })
 
   it.each(['owner', 'user', 'viewer'])('accepts valid role: %s', async (role) => {
-    mockDbSelectFrom.mockReturnValueOnce({
-      where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([{ id: 'user-1' }])) })),
-    })
     mockDbSelectFrom.mockReturnValueOnce({
       where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([])) })),
     })
@@ -3987,36 +3982,40 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
     expect(mockDbSelectFrom).not.toHaveBeenCalled()
   })
 
-  it('annotates user messages with sender info in auth mode', async () => {
-    mockIsAuthMode.mockReturnValue(true)
-    mockTransformMessages.mockReturnValue([
-      { id: 'msg-1', type: 'user', content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
-      { id: 'msg-2', type: 'assistant', content: { text: 'hello' }, toolCalls: [], createdAt: new Date() },
-    ])
+  it.each(['', '?limit=2', '?after=previous'])(
+    'annotates user messages with sender info in auth mode (%s)', async (query) => {
+      mockIsAuthMode.mockReturnValue(true)
+      const messages = [
+        { id: 'msg-1', type: 'user' as const, content: { text: 'hi' }, toolCalls: [], createdAt: new Date() },
+        { id: 'msg-2', type: 'assistant' as const, content: { text: 'hello' }, toolCalls: [], createdAt: new Date() },
+      ]
+      mockTransformMessages.mockReturnValue(messages)
+      vi.mocked(getSessionMessagesPage).mockResolvedValue({ messages, nextCursor: null })
+      vi.mocked(getSessionMessagesDelta).mockResolvedValue({ messages, anchor: null })
 
-    // Mock the DB select chain for author lookup: db.select().from().innerJoin().where()
-    mockDbSelectFrom.mockReturnValue({
-      innerJoin: () => ({
-        where: () => Promise.resolve([
-          { messageId: 'msg-1', userId: 'user-1', userName: 'Alice', userEmail: 'alice@example.com', image: 'https://example.com/alice.png' },
-        ]),
-      }),
-    })
+      mockDbSelectFrom.mockReturnValue({
+        where: () => Promise.resolve([{ messageId: 'msg-1', userId: 'user-1' }]),
+      })
+      vi.mocked(getUserSummaries).mockReturnValue(new Map([['user-1', {
+        id: 'user-1', name: 'Alice', email: 'alice@example.com', image: 'https://example.com/alice.png',
+      }]]))
 
-    const res = await getReq(app, URL)
-    expect(res.status).toBe(200)
+      const res = await getReq(app, `${URL}${query}`)
+      expect(res.status).toBe(200)
 
-    const body = await res.json()
-    // User message should have sender
-    expect(body[0].sender).toEqual({
-      id: 'user-1',
-      name: 'Alice',
-      email: 'alice@example.com',
-      image: 'https://example.com/alice.png',
-    })
-    // Assistant message should not have sender
-    expect(body[1].sender).toBeUndefined()
-  })
+      const response = await res.json()
+      const body = query ? response.messages : response
+      // User message should have sender
+      expect(body[0].sender).toEqual({
+        id: 'user-1',
+        name: 'Alice',
+        email: 'alice@example.com',
+        image: 'https://example.com/alice.png',
+      })
+      // Assistant message should not have sender
+      expect(body[1].sender).toBeUndefined()
+    },
+  )
 
   it('handles sessions with no author records gracefully', async () => {
     mockIsAuthMode.mockReturnValue(true)
@@ -4025,11 +4024,7 @@ describe('message author attribution — GET /:id/sessions/:sessionId/messages',
     ])
 
     // DB returns no author records (messages from before feature was added)
-    mockDbSelectFrom.mockReturnValue({
-      innerJoin: () => ({
-        where: () => Promise.resolve([]),
-      }),
-    })
+    mockDbSelectFrom.mockReturnValue({ where: () => Promise.resolve([]) })
 
     const res = await getReq(app, URL)
     expect(res.status).toBe(200)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1,6 +1,6 @@
 import agentMembers from './agent-members'
 import { notifyAgentMembersChanged } from '@shared/lib/services/agent-members-service'
-import { getUserImage, type UserImageFields } from '@shared/lib/user-profile-schema'
+import { getUserSummaries, searchUserSummaries, toUserSender, userExists, type UserSenderSource } from '@shared/lib/services/user-profile-service'
 import { Hono, type Context } from 'hono'
 import { bodyLimit } from 'hono/body-limit'
 import { streamSSE } from 'hono/streaming'
@@ -118,8 +118,8 @@ import {
   listPendingWakesByAgent,
 } from '@shared/lib/services/scheduled-task-service'
 import { db } from '@shared/lib/db'
-import { connectedAccounts, agentConnectedAccounts, proxyAuditLog, remoteMcpServers, agentRemoteMcps, mcpAuditLog, agentAcl, user as userTable, messageAuthor, apiScopePolicies, mcpToolPolicies } from '@shared/lib/db/schema'
-import { eq, and, inArray, notInArray, desc, count, or, sql, type AnyColumn } from 'drizzle-orm'
+import { connectedAccounts, agentConnectedAccounts, proxyAuditLog, remoteMcpServers, agentRemoteMcps, mcpAuditLog, agentAcl, messageAuthor, apiScopePolicies, mcpToolPolicies } from '@shared/lib/db/schema'
+import { eq, and, inArray, desc, count } from 'drizzle-orm'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { getCurrentUserId } from '@shared/lib/auth/config'
 import { getViewerUserId, ownerScope } from '@shared/lib/auth/ownership'
@@ -1583,15 +1583,14 @@ agents.get('/:id/access', AgentAdmin(), async (c) => {
         userId: agentAcl.userId,
         role: agentAcl.role,
         createdAt: agentAcl.createdAt,
-        userName: userTable.name,
-        userEmail: userTable.email,
-        image: userTable.image,
-        avatarOverride: userTable.avatarOverride,
       })
       .from(agentAcl)
-      .innerJoin(userTable, eq(agentAcl.userId, userTable.id))
       .where(eq(agentAcl.agentSlug, slug))
-    return c.json(rows.map(({ avatarOverride, ...row }) => ({ ...row, image: getUserImage({ ...row, avatarOverride }) })))
+    const profiles = getUserSummaries(rows.map(row => row.userId))
+    return c.json(rows.flatMap(row => {
+      const profile = profiles.get(row.userId)
+      return profile ? [{ ...row, userName: profile.name, userEmail: profile.email, image: profile.image }] : []
+    }))
   } catch (error) {
     console.error('Failed to fetch agent access:', error)
     return c.json({ error: 'Failed to fetch agent access' }, 500)
@@ -1612,12 +1611,7 @@ agents.post('/:id/access', AgentAdmin(), async (c) => {
     }
 
     // Check user exists
-    const [targetUser] = await db
-      .select({ id: userTable.id })
-      .from(userTable)
-      .where(eq(userTable.id, userId))
-      .limit(1)
-    if (!targetUser) {
+    if (!userExists(userId)) {
       return c.json({ error: 'User not found' }, 404)
     }
 
@@ -1811,26 +1805,7 @@ agents.get('/:id/access/search-users', AgentAdmin(), async (c) => {
 
     const excludeIds = existingUserIds.map((r) => r.userId)
 
-    // Search users by name or email (SQLite LIKE is case-insensitive by default)
-    // Escape LIKE wildcards to prevent pattern injection (e.g. searching "%"
-    // matching all users); the ESCAPE clause is required for the backslashes
-    // to act as escapes rather than literals.
-    const escaped = query ? query.replace(/[\\%_]/g, '\\$&') : ''
-    const matchesQuery = (column: AnyColumn) =>
-      sql`${column} LIKE ${`%${escaped}%`} ESCAPE '\\'`
-    const users = await db
-      .select({ id: userTable.id, name: userTable.name, email: userTable.email, image: userTable.image, avatarOverride: userTable.avatarOverride })
-      .from(userTable)
-      .where(
-        and(
-          // Exclude access holders in the WHERE so they don't eat limit slots
-          excludeIds.length ? notInArray(userTable.id, excludeIds) : undefined,
-          escaped ? or(matchesQuery(userTable.name), matchesQuery(userTable.email)) : undefined
-        )
-      )
-      .limit(50)
-
-    return c.json(users.map(({ avatarOverride, ...person }) => ({ ...person, image: getUserImage({ ...person, avatarOverride }) })))
+    return c.json(searchUserSummaries(query, excludeIds))
   } catch (error) {
     console.error('Failed to search users:', error)
     return c.json({ error: 'Failed to search users' }, 500)
@@ -2293,26 +2268,17 @@ async function annotateAndRecoverMessages(
     .select({
       messageId: messageAuthor.id,
       userId: messageAuthor.userId,
-      userName: userTable.name,
-      userEmail: userTable.email,
-      image: userTable.image,
-      avatarOverride: userTable.avatarOverride,
     })
     .from(messageAuthor)
-    .innerJoin(userTable, eq(messageAuthor.userId, userTable.id))
     .where(and(eq(messageAuthor.sessionId, sessionId), inArray(messageAuthor.id, userMessageIds)))
 
-  const authorMap = new Map(authors.map((a) => [a.messageId, a]))
+  const profiles = getUserSummaries(authors.map(author => author.userId))
+  const authorMap = new Map(authors.map(author => [author.messageId, profiles.get(author.userId)]))
   for (const msg of transformed) {
     if (msg.type !== 'user') continue
     const author = authorMap.get(msg.id)
     if (author) {
-      msg.sender = {
-        id: author.userId,
-        name: author.userName,
-        email: author.userEmail,
-        image: getUserImage(author),
-      }
+      msg.sender = author
     }
   }
 }
@@ -2478,27 +2444,18 @@ agents.get('/:id/sessions/:sessionId/messages', AgentRead(), async (c) => {
           .select({
             messageId: messageAuthor.id,
             userId: messageAuthor.userId,
-            userName: userTable.name,
-            userEmail: userTable.email,
-            image: userTable.image,
-            avatarOverride: userTable.avatarOverride,
           })
           .from(messageAuthor)
-          .innerJoin(userTable, eq(messageAuthor.userId, userTable.id))
           .where(eq(messageAuthor.sessionId, sessionId))
 
-        const authorMap = new Map(authors.map((a) => [a.messageId, a]))
+        const profiles = getUserSummaries(authors.map(author => author.userId))
+        const authorMap = new Map(authors.map(author => [author.messageId, profiles.get(author.userId)]))
 
         for (const msg of transformed) {
           if (msg.type !== 'user') continue
           const author = authorMap.get(msg.id)
           if (author) {
-            msg.sender = {
-              id: author.userId,
-              name: author.userName,
-              email: author.userEmail,
-              image: getUserImage(author),
-            }
+            msg.sender = author
           }
         }
       }
@@ -2762,11 +2719,10 @@ async function persistAndBroadcastUserMessage(
     agentSlug: args.agentSlug,
     userId,
   })
-  const user = c.get('user' as never) as { id: string; name: string } & UserImageFields
   messagePersister.broadcastSessionEvent(args.agentSlug, args.sessionId, {
     type: 'user_message',
     content: args.content,
-    sender: { id: user.id, name: user.name, image: getUserImage(user) },
+    sender: toUserSender(c.get('user' as never) as UserSenderSource),
     uuid: args.messageUuid,
     queued: args.queued,
   })
@@ -2977,7 +2933,6 @@ agents.post('/:id/sessions/:sessionId/typing', AgentUser(), async (c) => {
   if (!isAuthMode()) return c.json({ ok: true })
 
   const sessionId = c.req.param('sessionId')
-  const user = c.get('user' as never) as { id: string; name: string } & UserImageFields
 
   // Otherwise this puts the caller's name in the typing indicator of a session
   // in someone else's agent.
@@ -2987,7 +2942,7 @@ agents.post('/:id/sessions/:sessionId/typing', AgentUser(), async (c) => {
 
   messagePersister.broadcastSessionEvent(getAgentId(c), sessionId, {
     type: 'user_typing',
-    sender: { id: user.id, name: user.name, image: getUserImage(user) },
+    sender: toUserSender(c.get('user' as never) as UserSenderSource),
   })
 
   return c.json({ ok: true })

--- a/src/shared/lib/services/agent-members-service.ts
+++ b/src/shared/lib/services/agent-members-service.ts
@@ -3,20 +3,19 @@ import { db } from '@shared/lib/db'
 import { agentAcl, user } from '@shared/lib/db/schema'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { agentMembersSchema } from '@shared/lib/agent-members-schema'
-import { getUserImage } from '@shared/lib/user-profile-schema'
+import { getUserSummaries } from './user-profile-service'
 import { publishCollaborationEvent } from './collaboration-events'
 
 export function listAgentMembers(agentSlug: string) {
-  const rows = db.select({
-    id: user.id, name: user.name, email: user.email, image: user.image,
-    avatarOverride: user.avatarOverride, role: agentAcl.role,
-  }).from(agentAcl).innerJoin(user, eq(agentAcl.userId, user.id))
+  const rows = db.select({ id: agentAcl.userId, role: agentAcl.role }).from(agentAcl)
     .where(eq(agentAcl.agentSlug, agentSlug))
     // Joining time + stable ID keep faces stationary when names or roles change.
-    .orderBy(asc(agentAcl.createdAt), asc(user.id)).all()
-  return agentMembersSchema.parse(rows.map(({ avatarOverride, ...row }) => ({
-    ...row, image: getUserImage({ ...row, avatarOverride }),
-  })))
+    .orderBy(asc(agentAcl.createdAt), asc(agentAcl.userId)).all()
+  const profiles = getUserSummaries(rows.map(row => row.id))
+  return agentMembersSchema.parse(rows.flatMap(row => {
+    const profile = profiles.get(row.id)
+    return profile ? [{ ...profile, role: row.role }] : []
+  }))
 }
 
 export function notifyAgentMembersChanged(agentSlug: string, removedUserId?: string): void {

--- a/src/shared/lib/services/user-profile-service.test.ts
+++ b/src/shared/lib/services/user-profile-service.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+let directory: string
+let database: typeof import('@shared/lib/db')
+let profiles: typeof import('./user-profile-service')
+const override = '/api/profile/images/00000000-0000-4000-8000-000000000001.png'
+
+beforeAll(async () => {
+  directory = fs.mkdtempSync(path.join(os.tmpdir(), 'user-profiles-'))
+  vi.stubEnv('SUPERAGENT_DATA_DIR', directory)
+  database = await import('@shared/lib/db')
+  profiles = await import('./user-profile-service')
+  const { user } = await import('@shared/lib/db/schema')
+  database.db.insert(user).values([
+    { id: 'ada', name: 'Ada Lovelace', email: 'ada@example.test', image: 'https://example.test/ada.png', avatarOverride: override, role: 'admin' },
+    { id: 'maya', name: 'Maya Chen', email: 'maya@example.test', image: 'https://example.test/maya.png' },
+    { id: 'percent', name: '100% Person', email: 'percent@example.test', image: 'javascript:invalid' },
+    { id: 'underscore', name: 'Under_score', email: 'underscore@example.test' },
+    { id: 'backslash', name: 'Back\\slash', email: 'backslash@example.test' },
+    ...Array.from({ length: 55 }, (_, index) => ({
+      id: `team-${index}`, name: `Team Person ${index}`, email: `team-${index}@example.test`,
+    })),
+  ]).run()
+})
+
+afterAll(() => {
+  database.sqlite.close()
+  vi.unstubAllEnvs()
+  fs.rmSync(directory, { recursive: true, force: true })
+})
+
+describe('user profile reads', () => {
+  it('resolves distinct requested users with effective images and no internal fields', () => {
+    const result = profiles.getUserSummaries(['ada', 'ada', 'missing', 'maya', 'percent'])
+    expect(result.size).toBe(3)
+    expect(result.get('ada')).toEqual({ id: 'ada', name: 'Ada Lovelace', email: 'ada@example.test', image: override })
+    expect(result.get('maya')?.image).toBe('https://example.test/maya.png')
+    expect(result.get('percent')?.image).toBeNull()
+    expect(profiles.getUserSummaries([]).size).toBe(0)
+    expect(profiles.userExists('ada')).toBe(true)
+    expect(profiles.userExists('missing')).toBe(false)
+  })
+
+  it('keeps live sender summaries limited to the existing event fields', () => {
+    const user = { id: 'ada', name: 'Ada Lovelace', email: 'ada@example.test', image: 'https://example.test/ada.png', avatarOverride: override, role: 'admin' }
+    expect(profiles.toUserSender(user)).toEqual({ id: 'ada', name: 'Ada Lovelace', image: override })
+  })
+
+  it.each([
+    ['  ADA  ', 'ada'],
+    ['MAYA@EXAMPLE', 'maya'],
+    ['%', 'percent'],
+    ['_', 'underscore'],
+    ['\\', 'backslash'],
+  ])('searches names and emails literally for %s', (query, expectedId) => {
+    expect(profiles.searchUserSummaries(query, []).map(profile => profile.id)).toEqual([expectedId])
+  })
+
+  it('excludes current members before applying the invitation result limit', () => {
+    const existing = profiles.searchUserSummaries('Team Person', [])
+    expect(existing).toHaveLength(50)
+    const remaining = profiles.searchUserSummaries('Team Person', existing.map(profile => profile.id))
+    expect(remaining).toHaveLength(5)
+    expect(remaining.every(profile => !existing.some(member => member.id === profile.id))).toBe(true)
+    expect(profiles.searchUserSummaries(undefined, [])).toHaveLength(50)
+  })
+})

--- a/src/shared/lib/services/user-profile-service.ts
+++ b/src/shared/lib/services/user-profile-service.ts
@@ -1,0 +1,48 @@
+import { and, eq, inArray, notInArray, or, sql, type AnyColumn } from 'drizzle-orm'
+import { db } from '@shared/lib/db'
+import { user } from '@shared/lib/db/schema'
+import { getUserImage, type UserImageFields } from '@shared/lib/user-profile-schema'
+
+const profileFields = {
+  id: user.id, name: user.name, email: user.email,
+  image: user.image, avatarOverride: user.avatarOverride,
+}
+
+type ProfileRow = Pick<typeof user.$inferSelect, keyof typeof profileFields>
+export type UserSenderSource = { id: string; name: string } & UserImageFields
+
+/** The existing live-message/typing summary intentionally excludes email. */
+export function toUserSender(profile: UserSenderSource) {
+  return { id: profile.id, name: profile.name, image: getUserImage(profile) }
+}
+
+function toUserProfile(profile: ProfileRow) {
+  return { ...toUserSender(profile), email: profile.email }
+}
+
+/** Internal read API: callers authorize IDs through their agent/session first. */
+export function getUserSummaries(userIds: readonly string[]) {
+  const ids = [...new Set(userIds)]
+  const profiles = ids.length
+    ? db.select(profileFields).from(user).where(inArray(user.id, ids)).all()
+    : []
+  return new Map(profiles.map(profile => [profile.id, toUserProfile(profile)]))
+}
+
+export function userExists(userId: string): boolean {
+  return !!db.select({ id: user.id }).from(user).where(eq(user.id, userId)).get()
+}
+
+/** Callers authorize directory access and supply users to exclude. */
+export function searchUserSummaries(query: string | undefined, excludeIds: readonly string[]) {
+  // SQLite LIKE is case-insensitive. Treat %, _ and backslash as literals.
+  const escaped = query?.trim().replace(/[\\%_]/g, '\\$&') ?? ''
+  const matchesQuery = (column: AnyColumn) =>
+    sql`${column} LIKE ${`%${escaped}%`} ESCAPE '\\'`
+  const profiles = db.select(profileFields).from(user).where(and(
+    // Exclude before limiting, so existing members don't consume result slots.
+    excludeIds.length ? notInArray(user.id, [...excludeIds]) : undefined,
+    escaped ? or(matchesQuery(user.name), matchesQuery(user.email)) : undefined,
+  )).limit(50).all()
+  return profiles.map(toUserProfile)
+}


### PR DESCRIPTION
Agent routes currently query user storage directly for names, emails, and image overrides. Move those reads into a small user-profile service so agent code owns membership and authorization while the service owns user summaries, directory search, and avatar resolution.

Profile lookups deduplicate IDs and fetch each batch in one database query. Access lists, rosters, message authors, and live sender events retain their existing response fields and image behavior. Invitation permissions, literal search matching, result limits, and roster ordering are preserved. No UI change.

Stacked on #1028 (`codex/collaboration-member-stack`), following #1027.

Validation:

- 519 backend tests passed, covering agent routes, roster integration, and user-profile reads; author attribution is checked for legacy, paginated, and delta responses.
- Both auth collaboration browser tests passed (profile photos and shared rosters/invitations/revocation).
- `npm run typecheck` and `npm run lint` passed; lint reports existing warnings only.
