### PR TITLE
Batch sidebar roster loads and profile refreshes

### DIFF
--- a/e2e/auth/specs/collaboration-roster-batching.spec.ts
+++ b/e2e/auth/specs/collaboration-roster-batching.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test'
+import { agentMembersBatchRequestSchema } from '../../../src/shared/lib/agent-members-schema'
+
+test('sidebar rosters load and refresh together without per-agent requests', async ({ browser, page, baseURL }) => {
+  const stamp = Date.now()
+  const peer = await browser.newContext({ baseURL })
+  try {
+    const ownerSignup = await page.request.post('/api/auth/sign-up/email', {
+      data: { name: 'Roster Owner', email: `roster-owner-${stamp}@example.test`, password: 'RosterTesting123!' },
+    })
+    expect(ownerSignup.ok()).toBeTruthy()
+    expect((await page.request.put('/api/user-settings', { data: { setupCompleted: true } })).ok()).toBeTruthy()
+    const peerSignup = await peer.request.post('/api/auth/sign-up/email', {
+      data: { name: 'Roster Peer', email: `roster-peer-${stamp}@example.test`, password: 'RosterTesting123!' },
+    })
+    expect(peerSignup.ok()).toBeTruthy()
+    const peerUser = (await peerSignup.json()).user
+    const slugs: string[] = []
+    for (let i = 0; i < 5; i++) {
+      const created = await page.request.post('/api/agents', { data: { name: `Batch Agent ${i}` } })
+      expect(created.ok()).toBeTruthy()
+      const agent = await created.json()
+      slugs.push(agent.slug)
+      expect((await page.request.post(`/api/agents/${agent.slug}/access`, { data: { userId: peerUser.id, role: 'viewer' } })).ok()).toBeTruthy()
+    }
+
+    const batches: string[][] = []
+    const individual: string[] = []
+    page.on('request', request => {
+      const path = new URL(request.url()).pathname
+      if (path === '/api/agents/members/batch') batches.push(agentMembersBatchRequestSchema.parse(request.postDataJSON()).agentSlugs)
+      else if (/\/api\/agents\/[^/]+\/members$/.test(path)) individual.push(path)
+    })
+    await page.goto('/')
+    for (const slug of slugs) {
+      await expect(page.getByTestId(`sidebar-members-${slug}`).locator('[role="img"]')).toHaveCount(2)
+    }
+    expect(batches).toHaveLength(1)
+    expect(new Set(batches[0])).toEqual(new Set(slugs))
+    expect(individual).toEqual([])
+
+    // The peer's profile hint invalidates all five active per-agent caches.
+    const refresh = page.waitForResponse(response => response.url().endsWith('/api/agents/members/batch'))
+    expect((await peer.request.post('/api/auth/update-user', { headers: { Origin: baseURL! }, data: { name: 'Updated Roster Peer' } })).ok()).toBeTruthy()
+    expect((await refresh).ok()).toBeTruthy()
+    for (const slug of slugs) {
+      await expect(page.getByTestId(`sidebar-members-${slug}`).locator('[role="img"][aria-label="Updated Roster Peer"]')).toBeVisible()
+    }
+    expect(batches).toHaveLength(2)
+    expect(new Set(batches[1])).toEqual(new Set(slugs))
+
+    // Opening the header and member popover reuses the refreshed roster cache.
+    await page.getByTestId(`agent-item-${slugs[0]}`).click()
+    await expect(page.getByTestId('agent-member-stack').locator('[role="img"][aria-label="Updated Roster Peer"]')).toBeVisible()
+    await page.getByTestId(`sidebar-members-${slugs[0]}`).hover()
+    await expect(page.getByTestId(`sidebar-members-list-${slugs[0]}`)).toContainText('Updated Roster Peer')
+    expect(batches).toHaveLength(2)
+    expect(individual).toEqual([])
+  } finally {
+    await peer.close()
+  }
+})

--- a/src/api/middleware/auth.ts
+++ b/src/api/middleware/auth.ts
@@ -1,5 +1,5 @@
 import type { Context, Next, MiddlewareHandler } from 'hono'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import { isAuthMode } from '@shared/lib/auth/mode'
 import { runWithOptionalUser, runWithRequestUser } from '@shared/lib/platform-attribution'
 import { db } from '@shared/lib/db'
@@ -140,6 +140,16 @@ function resolvedAgentSlug(c: Context): string {
   return (c.get('agentId' as never) as string | undefined) ?? c.req.param('id')!
 }
 
+/** AgentRead's policy for a collection of already-resolved IDs, in one ACL query. */
+export function getReadableAgentIds(c: Context, agentIds: readonly string[]): Set<string> {
+  if (!isAuthMode()) return new Set(agentIds)
+  const user = getUser(c)
+  if (isAdmin(user)) return new Set(agentIds)
+  if (!agentIds.length) return new Set()
+  const rows = db.select({ agentSlug: agentAcl.agentSlug, role: agentAcl.role }).from(agentAcl)
+    .where(and(eq(agentAcl.userId, user.id), inArray(agentAcl.agentSlug, [...agentIds]))).all()
+  return new Set(rows.filter(row => hasMinRole(row.role, 'viewer')).map(row => row.agentSlug))
+}
 
 /**
  * AgentRead — user has any role on the agent (viewer+).

--- a/src/api/routes/agent-members.integration.test.ts
+++ b/src/api/routes/agent-members.integration.test.ts
@@ -4,7 +4,9 @@ import os from 'node:os'
 import path from 'node:path'
 import { Hono } from 'hono'
 import { randomUUID } from 'node:crypto'
-import type { CollaborationEvent } from '@shared/lib/agent-members-schema'
+import Database from 'better-sqlite3'
+import { MAX_AGENT_MEMBERS_BATCH_SIZE, type CollaborationEvent } from '@shared/lib/agent-members-schema'
+import { persistedSettingsSchema } from '@shared/lib/config/settings-schema'
 
 let directory: string
 let db: typeof import('@shared/lib/db')
@@ -13,12 +15,17 @@ let service: typeof import('@shared/lib/services/agent-members-service')
 let events: typeof import('@shared/lib/services/collaboration-events')
 let app: Hono
 const agentSlug = '0123456789'
+const secondAgent = '9876543210'
+const privateAgent = 'private-agent'
+const emptyAgent = 'empty-agent'
 const people: Record<string, { id: string; token: string }> = {}
 
 beforeAll(async () => {
   directory = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-members-'))
-  fs.mkdirSync(path.join(directory, 'agents', agentSlug), { recursive: true })
-  fs.writeFileSync(path.join(directory, 'settings.json'), JSON.stringify({ auth: { signupMode: 'open', requireAdminApproval: false } }))
+  for (const slug of [agentSlug, secondAgent, privateAgent, emptyAgent]) {
+    fs.mkdirSync(path.join(directory, 'agents', slug), { recursive: true })
+  }
+  fs.writeFileSync(path.join(directory, 'settings.json'), JSON.stringify(persistedSettingsSchema.parse({ auth: { signupMode: 'open', requireAdminApproval: false } })))
   vi.stubEnv('SUPERAGENT_DATA_DIR', directory)
   vi.stubEnv('AUTH_MODE', 'true')
   vi.stubEnv('AUTH_PROVIDERS_JSON', '[]')
@@ -28,9 +35,11 @@ beforeAll(async () => {
   service = await import('@shared/lib/services/agent-members-service')
   events = await import('@shared/lib/services/collaboration-events')
   const { Authenticated, ResolveAgent, AgentAdmin } = await import('../middleware/auth')
-  const members = (await import('./agent-members')).default
+  const { default: members, agentMembersBatch } = await import('./agent-members')
   app = new Hono()
-  app.use('/api/agents/:id/*', Authenticated(), ResolveAgent())
+  app.use('/api/agents/*', Authenticated())
+  app.route('/api/agents/members/batch', agentMembersBatch)
+  app.use('/api/agents/:id/*', ResolveAgent())
   app.route('/api/agents/:id/members', members)
   app.get('/api/agents/:id/access', AgentAdmin(), (c) => c.json({ management: true }))
   for (const name of ['admin', 'owner', 'user', 'viewer', 'outsider']) {
@@ -41,6 +50,12 @@ beforeAll(async () => {
   for (const [index, role] of ['owner', 'user', 'viewer'].entries()) {
     db.db.insert(agentAcl).values({ id: randomUUID(), userId: people[role].id, agentSlug, role: role as 'owner' | 'user' | 'viewer', createdAt: new Date(index * 1000) }).run()
   }
+  db.db.insert(agentAcl).values([
+    { id: randomUUID(), userId: people.viewer.id, agentSlug: secondAgent, role: 'owner', createdAt: new Date(0) },
+    { id: randomUUID(), userId: people.owner.id, agentSlug: secondAgent, role: 'viewer', createdAt: new Date(1000) },
+    { id: randomUUID(), userId: people.outsider.id, agentSlug: privateAgent, role: 'owner', createdAt: new Date(0) },
+  ]).run()
+
 })
 afterAll(() => {
   authModule.resetAuth()
@@ -50,6 +65,15 @@ afterAll(() => {
 })
 function get(name: string | null, resource = 'members', slug = agentSlug) {
   return app.request(`/api/agents/${slug}/${resource}`, name ? { headers: { authorization: `Bearer ${people[name].token}` } } : {})
+}
+
+
+function batch(name: string | null, agentSlugs: string[]) {
+  return app.request('/api/agents/members/batch', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...(name ? { authorization: `Bearer ${people[name].token}` } : {}) },
+    body: JSON.stringify({ agentSlugs }),
+  })
 }
 
 describe('authorized agent roster', () => {
@@ -71,6 +95,59 @@ describe('authorized agent roster', () => {
     expect((await get('viewer', 'members', 'does-not-exist')).status).toBe(404)
     for (const name of ['user', 'viewer', 'outsider']) expect((await get(name, 'access')).status).toBe(403)
     for (const name of ['owner', 'admin']) expect((await get(name, 'access')).status).toBe(200)
+  })
+
+  it('batches authorized rosters and isolates forbidden or missing agents', async () => {
+    for (const name of ['owner', 'viewer', 'user', 'admin']) {
+      const response = await batch(name, [agentSlug, `launch-${secondAgent}`, privateAgent, 'missing', agentSlug])
+      expect(response.status).toBe(200)
+      const result = await response.json()
+      expect(Object.keys(result)).toHaveLength(4)
+      expect(result[agentSlug]).toEqual({ status: 200, members: await (await get(name)).json() })
+      expect(result[`launch-${secondAgent}`]).toEqual(name === 'user'
+        ? { status: 403 }
+        : { status: 200, members: await (await get(name, 'members', secondAgent)).json() })
+      expect(result[privateAgent]).toEqual(name === 'admin'
+        ? { status: 200, members: await (await get(name, 'members', privateAgent)).json() }
+        : { status: 403 })
+      expect(result.missing).toEqual({ status: 404 })
+    }
+    expect(await (await batch('outsider', [agentSlug, secondAgent])).json()).toEqual({
+      [agentSlug]: { status: 403 }, [secondAgent]: { status: 403 },
+    })
+    expect(await (await batch('admin', [emptyAgent])).json()).toEqual({ [emptyAgent]: { status: 200, members: [] } })
+  })
+
+  it('loads multiple rosters in two data queries with distinct per-agent roles and stable order', () => {
+    const prepare = vi.spyOn(Database.prototype, 'prepare')
+    try {
+      const result = service.listAgentMembersByAgent([agentSlug, secondAgent, emptyAgent, agentSlug])
+      expect(prepare).toHaveBeenCalledTimes(2) // One membership query and one shared user lookup.
+      expect(result[agentSlug].map(member => member.id)).toEqual([people.owner.id, people.user.id, people.viewer.id])
+      expect(result[secondAgent].map(member => [member.id, member.role])).toEqual([
+        [people.viewer.id, 'owner'], [people.owner.id, 'viewer'],
+      ])
+      expect(result[emptyAgent]).toEqual([])
+      expect(result[secondAgent][0].image).toBe(result[agentSlug][2].image)
+      prepare.mockClear()
+      expect(service.listAgentMembersByAgent([])).toEqual({})
+      expect(prepare).not.toHaveBeenCalled()
+    } finally {
+      prepare.mockRestore()
+    }
+  })
+
+  it('requires a session, limits batch size, and disables batch reads outside auth mode', async () => {
+    expect((await batch(null, [agentSlug])).status).toBe(401)
+    expect((await batch('owner', [])).status).toBe(400)
+    expect((await batch('owner', Array(MAX_AGENT_MEMBERS_BATCH_SIZE + 1).fill(agentSlug))).status).toBe(400)
+    expect((await batch('owner', ['a'.repeat(40_000)])).status).toBe(413)
+    vi.stubEnv('AUTH_MODE', 'false')
+    try {
+      expect((await batch(null, [agentSlug])).status).toBe(404)
+    } finally {
+      vi.stubEnv('AUTH_MODE', 'true')
+    }
   })
 
   it('sends a membership change when a removed deployment admin retains access', async () => {
@@ -108,6 +185,8 @@ describe('authorized agent roster', () => {
       expect(received.user.at(-1)).toEqual({ type: 'agent_members_changed', agentSlug })
       expect(received.viewer.at(-1)).toEqual({ type: 'agent_access_revoked', agentSlug })
       expect((await get('viewer')).status).toBe(403)
+      expect((await (await batch('viewer', [agentSlug, secondAgent])).json())[agentSlug]).toEqual({ status: 403 })
+      db.sqlite.prepare('DELETE FROM agent_acl WHERE agent_slug = ? AND user_id = ?').run(secondAgent, people.viewer.id)
       service.notifyUserProfileChanged(people.owner.id)
       expect(received.viewer).toHaveLength(3)
       expect(received.outsider).toEqual([])

--- a/src/api/routes/agent-members.ts
+++ b/src/api/routes/agent-members.ts
@@ -1,7 +1,11 @@
 import { Hono } from 'hono'
-import { AgentRead, getAgentId } from '../middleware/auth'
+import { AgentRead, getAgentId, getReadableAgentIds } from '../middleware/auth'
+import { bodyLimit } from 'hono/body-limit'
+import { zValidator } from '@hono/zod-validator'
+import { agentMembersBatchRequestSchema, agentMembersBatchResponseSchema } from '@shared/lib/agent-members-schema'
+import { resolveAgentId } from '@shared/lib/utils/file-storage'
 import { isAuthMode } from '@shared/lib/auth/mode'
-import { listAgentMembers } from '@shared/lib/services/agent-members-service'
+import { listAgentMembers, listAgentMembersByAgent } from '@shared/lib/services/agent-members-service'
 
 // Mounted after Authenticated() and ResolveAgent() in the agent router.
 const agentMembers = new Hono()
@@ -10,3 +14,21 @@ agentMembers.get('/', AgentRead(), (c) => {
   return c.json(listAgentMembers(getAgentId(c)))
 })
 export default agentMembers
+
+// Collection route: mounted after Authenticated(), before /:id/* resolution.
+export const agentMembersBatch = new Hono().post('/',
+  bodyLimit({ maxSize: 32 * 1024 }),
+  zValidator('json', agentMembersBatchRequestSchema),
+  async (c) => {
+    if (!isAuthMode()) return c.notFound()
+    const slugs = [...new Set(c.req.valid('json').agentSlugs)]
+    const resolved = await Promise.all(slugs.map(async slug => [slug, await resolveAgentId(slug)] as const))
+    const ids = [...new Set(resolved.flatMap(([, id]) => id ? [id] : []))]
+    const readable = getReadableAgentIds(c, ids)
+    const members = listAgentMembersByAgent([...readable])
+    return c.json(agentMembersBatchResponseSchema.parse(Object.fromEntries(resolved.map(([slug, id]) => [
+      slug,
+      !id ? { status: 404 } : !readable.has(id) ? { status: 403 } : { status: 200, members: members[id] },
+    ]))))
+  },
+)

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1,4 +1,4 @@
-import agentMembers from './agent-members'
+import agentMembers, { agentMembersBatch } from './agent-members'
 import { notifyAgentMembersChanged } from '@shared/lib/services/agent-members-service'
 import { getUserSummaries, searchUserSummaries, toUserSender, userExists, type UserSenderSource } from '@shared/lib/services/user-profile-service'
 import { Hono, type Context } from 'hono'
@@ -903,6 +903,9 @@ export async function resolveInterruptedSubagents(
 const agents = new Hono()
 
 agents.use('*', Authenticated())
+
+// Collection roster reads must be mounted before /:id/* resolution.
+agents.route('/members/batch', agentMembersBatch)
 
 // ============================================================
 // Routes that must be registered BEFORE /:id middleware

--- a/src/renderer/hooks/use-agent-members.test.tsx
+++ b/src/renderer/hooks/use-agent-members.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { apiFetch } from '@renderer/lib/api'
+import { loadAgentMembers } from '@renderer/lib/agent-members-loader'
+import { MAX_AGENT_MEMBERS_BATCH_SIZE } from '@shared/lib/agent-members-schema'
+import { useAgentMembers } from './use-agent-members'
+
+vi.mock('@renderer/lib/api', () => ({ apiFetch: vi.fn() }))
+vi.mock('@renderer/context/user-context', () => ({ useUser: () => ({ isAuthMode: true }) }))
+const member = { id: 'person', name: 'Ada', email: 'ada@example.test', image: null, role: 'owner' }
+const clients: QueryClient[] = []
+const response = (body: unknown) => new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } })
+
+function setup() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  clients.push(client)
+  const wrapper = ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  return { client, wrapper }
+}
+function fetchRoster(client: QueryClient, slug: string) {
+  return client.fetchQuery({ queryKey: ['agent-members', slug], queryFn: ({ signal }) => loadAgentMembers(client, slug, signal) })
+}
+function requestedBatches(): string[][] {
+  return vi.mocked(apiFetch).mock.calls.map(([, init]) => JSON.parse(init!.body as string).agentSlugs)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(apiFetch).mockImplementation(async (_url, init) => {
+    const { agentSlugs } = JSON.parse(init!.body as string) as { agentSlugs: string[] }
+    return response(Object.fromEntries(agentSlugs.map(slug => [slug, { status: 200, members: [member] }])))
+  })
+})
+afterEach(() => {
+  cleanup()
+  for (const client of clients.splice(0)) client.clear()
+})
+
+describe('batched roster queries', () => {
+  it('shares one request across rows and the header, and batches broad invalidations', async () => {
+    const { client, wrapper } = setup()
+    const { result } = renderHook(() => ({
+      first: useAgentMembers('first'),
+      second: useAgentMembers('second'),
+      header: useAgentMembers('first'),
+      privateAgent: useAgentMembers('private', false),
+    }), { wrapper })
+    await waitFor(() => expect(result.current.second.isSuccess).toBe(true))
+    expect(result.current.first.data).toEqual([member])
+    expect(result.current.header.data).toEqual([member])
+    expect(requestedBatches()).toEqual([['first', 'second']])
+    expect(vi.mocked(apiFetch).mock.calls[0][0]).toBe('/api/agents/members/batch')
+
+    await act(() => client.invalidateQueries({ queryKey: ['agent-members'] }))
+    expect(requestedBatches()).toEqual([['first', 'second'], ['first', 'second']])
+    await act(() => client.invalidateQueries({ queryKey: ['agent-members', 'second'] }))
+    expect(requestedBatches().at(-1)).toEqual(['second'])
+
+    renderHook(() => useAgentMembers('first'), { wrapper })
+    expect(apiFetch).toHaveBeenCalledTimes(3) // The fresh per-agent cache is reusable.
+  })
+
+  it('keeps an inaccessible roster from failing an authorized sibling', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(response({ first: { status: 200, members: [member] }, second: { status: 403 } }))
+    const { wrapper } = setup()
+    const { result } = renderHook(() => ({ first: useAgentMembers('first'), second: useAgentMembers('second') }), { wrapper })
+    await waitFor(() => expect(result.current.second.isError).toBe(true))
+    expect(result.current.first.data).toEqual([member])
+    expect(apiFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels a revoked roster without cancelling its sibling or restoring revoked cache data', async () => {
+    let finish!: (value: Response) => void
+    vi.mocked(apiFetch).mockImplementation(() => new Promise(resolve => { finish = resolve }))
+    const { client } = setup()
+    const revoked = fetchRoster(client, 'revoked').catch(() => undefined)
+    const kept = fetchRoster(client, 'kept')
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1))
+    await client.cancelQueries({ queryKey: ['agent-members', 'revoked'] })
+    client.removeQueries({ queryKey: ['agent-members', 'revoked'] })
+    expect(vi.mocked(apiFetch).mock.calls[0][1]?.signal?.aborted).toBe(false)
+    finish(response({ revoked: { status: 200, members: [member] }, kept: { status: 200, members: [member] } }))
+    await expect(kept).resolves.toEqual([member])
+    await revoked
+    expect(client.getQueryData(['agent-members', 'revoked'])).toBeUndefined()
+  })
+
+  it('aborts shared work on cache clear and excludes cancelled work before dispatch', async () => {
+    const { client } = setup()
+    const queued = fetchRoster(client, 'queued').catch(() => undefined)
+    client.clear()
+    await queued
+    await new Promise(resolve => setTimeout(resolve, 5))
+    expect(apiFetch).not.toHaveBeenCalled()
+
+    vi.mocked(apiFetch).mockImplementation((_url, init) => new Promise((_resolve, reject) => {
+      init!.signal!.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+    }))
+    const pending = [fetchRoster(client, 'first'), fetchRoster(client, 'second')].map(promise => promise.catch(() => undefined))
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1))
+    client.clear()
+    await Promise.all(pending)
+    expect(vi.mocked(apiFetch).mock.calls[0][1]?.signal?.aborted).toBe(true)
+    expect(client.getQueryCache().getAll()).toHaveLength(0)
+  })
+
+  it('keeps different query clients isolated', async () => {
+    const first = setup().client
+    const second = setup().client
+    await Promise.all([fetchRoster(first, 'first'), fetchRoster(second, 'second')])
+    expect(requestedBatches()).toEqual([['first'], ['second']])
+  })
+
+  it('splits large sidebars into bounded batches', async () => {
+    const { client } = setup()
+    await Promise.all(Array.from({ length: MAX_AGENT_MEMBERS_BATCH_SIZE + 1 }, (_, i) => fetchRoster(client, `agent-${i}`)))
+    expect(requestedBatches().map(batch => batch.length)).toEqual([MAX_AGENT_MEMBERS_BATCH_SIZE, 1])
+  })
+
+  it.each([{}, { first: { status: 200, members: [{ ...member, role: 'invalid' }] } }])(
+    'rejects missing or malformed batch results', async body => {
+      vi.mocked(apiFetch).mockResolvedValue(response(body))
+      const { client } = setup()
+      await expect(fetchRoster(client, 'first')).rejects.toThrow()
+      expect(client.getQueryData(['agent-members', 'first'])).toBeUndefined()
+    },
+  )
+
+  it('surfaces transport errors to all affected queries', async () => {
+    vi.mocked(apiFetch).mockRejectedValue(new Error('Network failed'))
+    const { client } = setup()
+    const results = await Promise.allSettled([fetchRoster(client, 'first'), fetchRoster(client, 'second')])
+    expect(results.every(result => result.status === 'rejected')).toBe(true)
+  })
+})

--- a/src/renderer/hooks/use-agent-members.ts
+++ b/src/renderer/hooks/use-agent-members.ts
@@ -1,18 +1,14 @@
-import { useQuery } from '@tanstack/react-query'
-import { apiFetch } from '@renderer/lib/api'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { loadAgentMembers } from '@renderer/lib/agent-members-loader'
 import { useUser } from '@renderer/context/user-context'
-import { agentMembersSchema } from '@shared/lib/agent-members-schema'
 
 /** Sidebar, header, and sharing pane reuse the same live roster per agent. */
 export function useAgentMembers(agentSlug: string, enabled = true) {
   const { isAuthMode } = useUser()
+  const queryClient = useQueryClient()
   return useQuery({
     queryKey: ['agent-members', agentSlug],
-    queryFn: async () => {
-      const response = await apiFetch(`/api/agents/${agentSlug}/members`)
-      if (!response.ok) throw new Error('Could not load members')
-      return agentMembersSchema.parse(await response.json())
-    },
+    queryFn: ({ signal }) => loadAgentMembers(queryClient, agentSlug, signal),
     enabled: isAuthMode && enabled,
     staleTime: 30_000,
   })

--- a/src/renderer/lib/agent-members-loader.ts
+++ b/src/renderer/lib/agent-members-loader.ts
@@ -1,0 +1,88 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { apiFetch } from './api'
+import {
+  MAX_AGENT_MEMBERS_BATCH_SIZE,
+  agentMembersBatchResponseSchema,
+  type AgentMember,
+} from '@shared/lib/agent-members-schema'
+
+type PendingRoster = {
+  agentSlug: string
+  signal: AbortSignal
+  resolve: (members: AgentMember[]) => void
+  reject: (error: unknown) => void
+}
+
+async function fetchBatch(requests: PendingRoster[]) {
+  const controller = new AbortController()
+  const abortIfUnused = () => {
+    if (requests.every(request => request.signal.aborted)) controller.abort()
+  }
+  for (const request of requests) request.signal.addEventListener('abort', abortIfUnused)
+  try {
+    const response = await apiFetch('/api/agents/members/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentSlugs: requests.map(request => request.agentSlug) }),
+      signal: controller.signal,
+    })
+    if (!response.ok) throw new Error('Could not load members')
+    const results = agentMembersBatchResponseSchema.parse(await response.json())
+    for (const request of requests) {
+      if (request.signal.aborted) continue
+      const result = results[request.agentSlug]
+      if (result?.status === 200) request.resolve(result.members)
+      else request.reject(new Error(`Could not load members (${result?.status ?? 'missing result'})`))
+    }
+  } catch (error) {
+    for (const request of requests) request.reject(error)
+  } finally {
+    for (const request of requests) request.signal.removeEventListener('abort', abortIfUnused)
+  }
+}
+
+function createLoader() {
+  let pending: PendingRoster[] = []
+  let timer: ReturnType<typeof setTimeout> | undefined
+  return (agentSlug: string, signal: AbortSignal): Promise<AgentMember[]> => new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason)
+      return
+    }
+    const onAbort = () => reject(signal.reason)
+    signal.addEventListener('abort', onAbort, { once: true })
+    pending.push({
+      agentSlug,
+      signal,
+      resolve: members => {
+        signal.removeEventListener('abort', onAbort)
+        resolve(members)
+      },
+      reject: error => {
+        signal.removeEventListener('abort', onAbort)
+        reject(error)
+      },
+    })
+    // Collect the queries started by one render or cache invalidation together.
+    timer ??= setTimeout(() => {
+      const requests = pending.filter(request => !request.signal.aborted)
+      pending = []
+      timer = undefined
+      for (let start = 0; start < requests.length; start += MAX_AGENT_MEMBERS_BATCH_SIZE) {
+        void fetchBatch(requests.slice(start, start + MAX_AGENT_MEMBERS_BATCH_SIZE))
+      }
+    }, 0)
+  })
+}
+
+// Scope pending work to the cache. Query cancellation on sign-out/revocation
+// rejects just that roster; the shared fetch stops when all callers cancel.
+const loaders = new WeakMap<QueryClient, ReturnType<typeof createLoader>>()
+export function loadAgentMembers(client: QueryClient, agentSlug: string, signal: AbortSignal) {
+  let loader = loaders.get(client)
+  if (!loader) {
+    loader = createLoader()
+    loaders.set(client, loader)
+  }
+  return loader(agentSlug, signal)
+}

--- a/src/shared/lib/agent-members-schema.ts
+++ b/src/shared/lib/agent-members-schema.ts
@@ -11,7 +11,19 @@ export const agentMemberSchema = z.object({
 export const agentMembersSchema = z.array(agentMemberSchema)
 export type AgentMember = z.infer<typeof agentMemberSchema>
 
-// Invalidation hints only. Member details always come from an authorized GET.
+// Bound each read; larger sidebars are split into chunks by the client.
+export const MAX_AGENT_MEMBERS_BATCH_SIZE = 100
+export const agentMembersBatchRequestSchema = z.object({
+  agentSlugs: z.array(z.string().min(1).max(255)).min(1).max(MAX_AGENT_MEMBERS_BATCH_SIZE),
+})
+export const agentMembersByAgentSchema = z.record(z.string(), agentMembersSchema)
+export const agentMembersBatchResponseSchema = z.record(z.string(), z.discriminatedUnion('status', [
+  z.object({ status: z.literal(200), members: agentMembersSchema }),
+  z.object({ status: z.literal(403) }),
+  z.object({ status: z.literal(404) }),
+]))
+
+// Invalidation hints only. Member details always come from an authorized roster read.
 export const collaborationEventSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('agent_members_changed'), agentSlug: z.string().min(1) }),
   z.object({ type: z.literal('agent_access_revoked'), agentSlug: z.string().min(1) }),

--- a/src/shared/lib/services/agent-members-service.ts
+++ b/src/shared/lib/services/agent-members-service.ts
@@ -2,20 +2,29 @@ import { asc, eq, inArray } from 'drizzle-orm'
 import { db } from '@shared/lib/db'
 import { agentAcl, user } from '@shared/lib/db/schema'
 import { isAuthMode } from '@shared/lib/auth/mode'
-import { agentMembersSchema } from '@shared/lib/agent-members-schema'
+import { agentMembersByAgentSchema, type AgentMember } from '@shared/lib/agent-members-schema'
 import { getUserSummaries } from './user-profile-service'
 import { publishCollaborationEvent } from './collaboration-events'
 
-export function listAgentMembers(agentSlug: string) {
-  const rows = db.select({ id: agentAcl.userId, role: agentAcl.role }).from(agentAcl)
-    .where(eq(agentAcl.agentSlug, agentSlug))
+/** Callers must authorize every agent before reading its roster. */
+export function listAgentMembersByAgent(agentSlugs: readonly string[]) {
+  const slugs = [...new Set(agentSlugs)]
+  const members = new Map(slugs.map(slug => [slug, [] as AgentMember[]]))
+  if (!slugs.length) return {}
+  const rows = db.select({ agentSlug: agentAcl.agentSlug, id: agentAcl.userId, role: agentAcl.role }).from(agentAcl)
+    .where(inArray(agentAcl.agentSlug, slugs))
     // Joining time + stable ID keep faces stationary when names or roles change.
     .orderBy(asc(agentAcl.createdAt), asc(agentAcl.userId)).all()
   const profiles = getUserSummaries(rows.map(row => row.id))
-  return agentMembersSchema.parse(rows.flatMap(row => {
+  for (const row of rows) {
     const profile = profiles.get(row.id)
-    return profile ? [{ ...profile, role: row.role }] : []
-  }))
+    if (profile) members.get(row.agentSlug)!.push({ ...profile, role: row.role })
+  }
+  return agentMembersByAgentSchema.parse(Object.fromEntries(members))
+}
+
+export function listAgentMembers(agentSlug: string) {
+  return listAgentMembersByAgent([agentSlug])[agentSlug]
 }
 
 export function notifyAgentMembersChanged(agentSlug: string, removedUserId?: string): void {


### PR DESCRIPTION
The sidebar previously fetched a complete roster separately for every shared agent. Coalesce roster queries started together into one batch request while retaining the existing per-agent caches. A browser regression verifies that five shared agents load in one request and refresh in one request after a profile change; opening the header and member popover reuses that data.

`POST /api/agents/members/batch` resolves and authorizes each agent, returning independent 200/403/404 results. Each batch uses one membership query and one lookup of distinct users through the profile service, plus one ACL query for non-admin callers. Requests are capped at 100 agents and 32 KiB; larger sidebars are chunked. Cancelling a roster preserves sibling requests, and clearing the cache cancels outstanding work.

Stacked on #1028, including its merged #1036 refactor. The visual layout is unchanged.

Validation:

- 656 unit/integration tests passed, including constant roster query count, mixed permissions, admin access, ordering, batching, cache reuse, and revocation/sign-out cancellation.
- All three collaboration browser specs passed, covering photos, invitations/revocation, and roster request counts.
- Typecheck and lint passed; lint reports existing warnings only.
- Synthetic auth preview checked in light and dark mode with loaded photos.

## Screenshots

| Light | Dark |
| --- | --- |
| ![Sidebar roster with batched data, light](https://github.com/user-attachments/assets/257fa682-3097-454d-b897-b3203bb0b22f) | ![Sidebar roster with batched data, dark](https://github.com/user-attachments/assets/75718a1a-d46d-451c-8e4b-e6422e051c51) |
