### PR TITLE
fix(browser): stop the default snapshot from silently hiding page text

### DIFF
--- a/agent-container/docs/browser-use.md
+++ b/agent-container/docs/browser-use.md
@@ -34,19 +34,23 @@ available.
 
 ## Observe Efficiently
 
-Use `browser_snapshot(interactive: true, compact: true)` for normal observation.
-It returns actionable refs such as `@e1`.
+Use `browser_snapshot()` for normal observation. It returns actionable refs
+such as `@e1` and, in the default interactive view, no static text at all. A
+footer reports how much page text was dropped and what the live regions
+(alerts, status, toasts) currently say.
 
 Useful snapshot options:
 
+- `fullText: true`: add the page's static text (prices, prose, validation
+  errors, table values) to the same compact tree. This is the way to read a
+  page; refs are identical in both views;
 - `scope`: restrict a large page to a form, dialog, or other CSS-selected
-  region without invalidating refs elsewhere;
-- `fullText: true`: include static text such as validation errors, prices,
-  instructions, and toasts;
+  region without invalidating refs elsewhere. Combine with `fullText`;
 - `includeUrls: true`: inline link URLs when labels are ambiguous.
 
 Use `browser_get_state` when the URL, screenshot, and accessibility snapshot
-are all useful together. Use `browser_screenshot` only for pixel-level facts
+are all useful together; it takes the same `scope`/`fullText` knobs and
+`screenshot: false` skips the image. Use `browser_screenshot` only for pixel-level facts
 that the accessibility tree cannot express, such as visual layout, charts,
 images, or color.
 

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -815,7 +815,7 @@ import { prepareEvalScript, finalizeEvalOutput, evalErrorHint } from './eval-scr
 import { judgeSelectCommit, SELECT_COMMIT_SETTLE_MS } from './select-verify';
 import { resolveCommittedValue } from './field-value-readback';
 import { capBrowserOutput, redactCdpUrls, MAX_BROWSER_OUTPUT_CHARS, MAX_BROWSER_ERROR_CHARS } from './browser-output';
-import { capSnapshot, formatIframePlaceholders, parseIframeInfo, IFRAME_ENUM_SCRIPT } from './snapshot-format';
+import { capSnapshot, compactWithText, formatIframePlaceholders, formatTextFooter, parsePageProbe, EMPTY_PROBE, PAGE_PROBE_SCRIPT } from './snapshot-format';
 import {
   observeUrl, resetUrlTracking,
   CLICK_SETTLE_MS, FILL_SETTLE_MS, PRESS_ENTER_SETTLE_MS, PRESS_SETTLE_MS,
@@ -1463,10 +1463,13 @@ app.post('/browser/snapshot', async (c) => {
       return c.json({ error: result.stdout, success: false }, 500);
     }
 
-    // Enumerate cross-origin iframes so the agent knows about fields the a11y
-    // tree cannot see (e.g. Stripe payment frames — audit P2).
-    const iframeProbe = await execBrowser(['eval', IFRAME_ENUM_SCRIPT], browserState.cdpUrl || undefined);
-    const iframes = iframeProbe.exitCode === 0 ? parseIframeInfo(iframeProbe.stdout) : [];
+    // One probe eval per snapshot: cross-origin iframes (fields the a11y tree
+    // cannot see — audit P2), plus how much page text the interactive view
+    // dropped and what the live regions say, so the default view never
+    // silently hides a price, an error or a toast (transcript-mining theme 1).
+    const probeResult = await execBrowser(['eval', PAGE_PROBE_SCRIPT], browserState.cdpUrl || undefined);
+    const probe = probeResult.exitCode === 0 ? parsePageProbe(probeResult.stdout) : EMPTY_PROBE;
+    const iframes = probe.iframes;
 
     if (body.json) {
       // Try to parse JSON output
@@ -1478,8 +1481,16 @@ app.post('/browser/snapshot', async (c) => {
       }
     }
 
+    // fullText fetches the unfiltered tree (the CLI's -i and -c each strip
+    // static text), so compaction has to happen here to stay text-preserving.
+    const fullText = Boolean(body.fullText);
+    const tree = fullText && body.compact !== false ? compactWithText(result.stdout) : result.stdout;
+
     return c.json({
-      snapshot: capSnapshot(result.stdout, Boolean(body.scope)) + formatIframePlaceholders(iframes),
+      snapshot:
+        capSnapshot(tree, Boolean(body.scope)) +
+        formatTextFooter(probe, { fullText, scoped: Boolean(body.scope) }) +
+        formatIframePlaceholders(iframes),
       iframes,
       tabCount: tabManager.getTabCount(),
     });

--- a/agent-container/src/snapshot-format.test.ts
+++ b/agent-container/src/snapshot-format.test.ts
@@ -3,7 +3,14 @@ import {
   parseIframeInfo,
   formatIframePlaceholders,
   capSnapshot,
+  parsePageProbe,
+  compactWithText,
+  formatTextFooter,
+  PAGE_PROBE_SCRIPT,
+  EMPTY_PROBE,
   SNAPSHOT_SOFT_CAP_CHARS,
+  TEXT_FOOTER_MIN_CHARS,
+  PREVIEW_CHARS,
   type IframeInfo,
 } from './snapshot-format'
 
@@ -67,5 +74,288 @@ describe('capSnapshot', () => {
   it('gives a tighter-scope hint when already scoped', () => {
     const out = capSnapshot('e'.repeat(SNAPSHOT_SOFT_CAP_CHARS + 5000), true)
     expect(out).toContain('tighter scope')
+  })
+})
+
+describe('parsePageProbe', () => {
+  it('parses CLI double-encoded probe output', () => {
+    const raw = JSON.stringify(JSON.stringify({
+      iframes: [{ title: 'pay', host: 'js.stripe.com', sameOrigin: false }],
+      textChars: 4200,
+      live: ['Password must be at least 8 characters'],
+      preview: 'Welcome back',
+    }))
+    expect(parsePageProbe(raw)).toEqual({
+      iframes: [{ title: 'pay', host: 'js.stripe.com', sameOrigin: false }],
+      textChars: 4200,
+      liveRegions: ['Password must be at least 8 characters'],
+      preview: 'Welcome back',
+    })
+  })
+
+  it('defaults missing or malformed parts', () => {
+    expect(parsePageProbe('{"textChars":"x","live":[1,"ok",""],"preview":null}')).toEqual({
+      iframes: [], textChars: 0, liveRegions: ['ok'], preview: '',
+    })
+  })
+
+  it('returns the empty probe on garbage, arrays or eval errors', () => {
+    expect(parsePageProbe('✗ Error: Execution context was destroyed')).toEqual(EMPTY_PROBE)
+    expect(parsePageProbe('[1,2]')).toEqual(EMPTY_PROBE)
+    expect(parsePageProbe('')).toEqual(EMPTY_PROBE)
+  })
+})
+
+describe('PAGE_PROBE_SCRIPT', () => {
+  // Minimal fake DOM: enough for the script's querySelectorAll/innerText/getClientRects calls.
+  function el(o: { text?: string; visible?: boolean; src?: string; title?: string; sameOrigin?: boolean }) {
+    return {
+      innerText: o.text ?? '',
+      title: o.title ?? '',
+      src: o.src ?? '',
+      offsetParent: o.visible === false ? null : {},
+      getClientRects: () => (o.visible === false ? [] : [{}]),
+      get contentDocument() {
+        if (o.sameOrigin) return {}
+        throw new Error('cross-origin')
+      },
+    }
+  }
+  const LIVE_SELECTOR = '[role="alert"],[role="status"],[aria-live]:not([aria-live="off"]),output'
+  function run(sel: Record<string, unknown[]>, body: { innerText: string }, main: unknown = null) {
+    const document = {
+      body,
+      querySelectorAll: (q: string) => sel[q] ?? [],
+      querySelector: (q: string) => (q === 'main,[role=main]' ? main : null),
+    }
+    const fn = new Function('document', 'URL', `return ${PAGE_PROBE_SCRIPT}`)
+    return JSON.parse(fn(document, URL))
+  }
+
+  it('reports text length, live regions, preview and iframes in one object', () => {
+    const out = run(
+      {
+        iframe: [el({ src: 'https://js.stripe.com/v3/elements', title: 'Secure payment', visible: true })],
+        [LIVE_SELECTOR]: [
+          el({ text: '  Email is   required ' }),
+          el({ text: 'Email is required' }),          // duplicate after whitespace collapse
+          el({ text: 'hidden toast', visible: false }), // no client rects → skipped
+          el({ text: '' }),                            // empty live region placeholder → skipped
+        ],
+      },
+      { innerText: 'Hello\n\n  world  ' },
+      { innerText: 'Main   content ' + 'x'.repeat(500) },
+    )
+    expect(out.iframes).toEqual([{ title: 'Secure payment', host: 'js.stripe.com', sameOrigin: false }])
+    expect(out.textChars).toBe('Hello world'.length)
+    expect(out.live).toEqual(['Email is required'])
+    expect(out.preview.startsWith('Main content x')).toBe(true)
+    expect(out.preview.length).toBe(PREVIEW_CHARS)
+  })
+
+  it('falls back to body for the preview and survives a broken part', () => {
+    const document = {
+      body: { innerText: 'Body text here' },
+      querySelectorAll: (q: string) => { if (q === 'iframe') throw new Error('boom'); return [] },
+      querySelector: () => null,
+    }
+    const fn = new Function('document', 'URL', `return ${PAGE_PROBE_SCRIPT}`)
+    const out = JSON.parse(fn(document, URL))
+    expect(out.iframes).toEqual([])
+    expect(out.textChars).toBe(14)
+    expect(out.preview).toBe('Body text here')
+  })
+})
+
+describe('compactWithText', () => {
+  const full = [
+    '- banner',
+    '  - link "Home" [ref=e1]',
+    '- main',
+    '  - heading "Checkout" [level=1, ref=e2]',
+    '  - generic',
+    '    - list',
+    '      - listitem',
+    '        - generic',
+    '  - paragraph',
+    '    - StaticText "Total: $42.00"',
+    '  - alert',
+    '    - StaticText "Card declined"',
+    '  - textbox "Card number" [ref=e3]: 4242',
+    '  - image "Product photo"',
+    '  - image',
+    '- contentinfo',
+    '  - list',
+    '    - listitem',
+  ].join('\n')
+
+  it('keeps refs, StaticText, values and named images with their ancestors, drops bare structure', () => {
+    expect(compactWithText(full).split('\n')).toEqual([
+      '- banner',
+      '  - link "Home" [ref=e1]',
+      '- main',
+      '  - heading "Checkout" [level=1, ref=e2]',
+      '  - paragraph',
+      '    - StaticText "Total: $42.00"',
+      '  - alert',
+      '    - StaticText "Card declined"',
+      '  - textbox "Card number" [ref=e3]: 4242',
+      '  - image "Product photo"',
+    ])
+  })
+
+  it('marks only true ancestors, not earlier siblings at a lower depth', () => {
+    const tree = ['- a', '  - b', '    - c', '  - d', '    - StaticText "kept"'].join('\n')
+    expect(compactWithText(tree)).toBe(['- a', '  - d', '    - StaticText "kept"'].join('\n'))
+  })
+
+  it('passes sentinels and text-free trees through unchanged', () => {
+    expect(compactWithText('(empty page)')).toBe('(empty page)')
+    expect(compactWithText('- generic\n  - list\n')).toBe('- generic\n  - list')
+  })
+
+  it('re-joins prose split by inline wrappers, including nested ones', () => {
+    const tree = [
+      '- paragraph',
+      '  - StaticText "Total "',
+      '  - strong',
+      '    - emphasis',
+      '      - StaticText "$42"',
+      '  - StaticText " due "',
+      '  - link "today" [ref=e1]',
+      '  - StaticText "."',
+    ].join('\n')
+    expect(compactWithText(tree).split('\n')).toEqual([
+      '- paragraph',
+      '  - StaticText "Total $42 due "',
+      '  - link "today" [ref=e1]',
+      '  - StaticText "."',
+    ])
+  })
+
+  it('keeps a wrapper that also contains a control', () => {
+    const tree = ['- strong', '  - StaticText "Go "', '  - link "here" [ref=e1]'].join('\n')
+    expect(compactWithText(tree).split('\n')).toEqual(['- strong', '  - StaticText "Go "', '  - link "here" [ref=e1]'])
+  })
+
+  // Captured from agent-browser 0.27.2 (`snapshot` with no flags) inside the
+  // container image, against a checkout-like test page. This is exactly what
+  // fullText fetches; the expectation is what the agent should read.
+  const CAPTURED_FULL_TREE = `- banner
+  - navigation
+    - link "Home" [ref=e4]
+    - StaticText " "
+    - link "Shop" [ref=e5]
+- main
+  - heading "Checkout" [level=1, ref=e2]
+  - paragraph
+    - StaticText "Your order total is "
+    - strong
+      - StaticText "$42.00"
+    - StaticText " including tax. Delivery on "
+    - emphasis
+      - StaticText "Friday"
+    - StaticText "."
+  - list
+    - listitem [level=1]
+      - ListMarker "• "
+      - StaticText "Item A — $20.00"
+    - listitem [level=1]
+      - ListMarker "• "
+      - StaticText "Item B — $22.00"
+  - table
+    - row
+      - columnheader "SKU" [ref=e7]
+      - columnheader "Price" [ref=e8]
+    - row
+      - cell "A-1" [ref=e9]
+      - cell "$20.00" [ref=e10]
+  - form
+    - LabelText
+      - StaticText "Card number "
+      - textbox "Card number " [ref=e11]: 4242
+        - StaticText "4242"
+    - alert
+      - StaticText "Card declined — try another card"
+    - button "Pay now" [ref=e6]
+  - image "Product photo"
+- status
+  - StaticText "Saved 2 seconds ago"
+- contentinfo
+  - link "Privacy" [ref=e3]
+  - StaticText "© 2026 Acme"
+- Iframe "Secure payment" [ref=e1]
+  - heading "Example Domain" [level=1, ref=e12]
+  - paragraph
+    - StaticText "This domain is for use in documentation examples without needing permission. Avoid use in operations."
+  - paragraph
+    - link "Learn more" [ref=e13]`
+
+  it('turns a real full tree into a readable compact tree', () => {
+    expect(compactWithText(CAPTURED_FULL_TREE)).toBe(`- banner
+  - navigation
+    - link "Home" [ref=e4]
+    - link "Shop" [ref=e5]
+- main
+  - heading "Checkout" [level=1, ref=e2]
+  - paragraph
+    - StaticText "Your order total is $42.00 including tax. Delivery on Friday."
+  - list
+    - listitem [level=1]
+      - StaticText "Item A — $20.00"
+    - listitem [level=1]
+      - StaticText "Item B — $22.00"
+  - table
+    - row
+      - columnheader "SKU" [ref=e7]
+      - columnheader "Price" [ref=e8]
+    - row
+      - cell "A-1" [ref=e9]
+      - cell "$20.00" [ref=e10]
+  - form
+    - LabelText
+      - textbox "Card number " [ref=e11]: 4242
+    - alert
+      - StaticText "Card declined — try another card"
+    - button "Pay now" [ref=e6]
+  - image "Product photo"
+- status
+  - StaticText "Saved 2 seconds ago"
+- contentinfo
+  - link "Privacy" [ref=e3]
+  - StaticText "© 2026 Acme"
+- Iframe "Secure payment" [ref=e1]
+  - heading "Example Domain" [level=1, ref=e12]
+  - paragraph
+    - StaticText "This domain is for use in documentation examples without needing permission. Avoid use in operations."
+  - paragraph
+    - link "Learn more" [ref=e13]`)
+  })
+})
+
+describe('formatTextFooter', () => {
+  const probe = { ...EMPTY_PROBE, textChars: 4200, preview: 'Welcome to Acme', liveRegions: ['Saved', 'Email is required'] }
+
+  it('is empty in fullText mode (the text is in the tree)', () => {
+    expect(formatTextFooter(probe, { fullText: true, scoped: false })).toBe('')
+  })
+
+  it('names the dropped text, its size, a preview and the fullText knob', () => {
+    const out = formatTextFooter(probe, { fullText: false, scoped: false })
+    expect(out).toContain('Live regions (alert/status): "Saved" | "Email is required"')
+    expect(out).toContain('~4,200 chars')
+    expect(out).toContain('Starts: "Welcome to Acme"')
+    expect(out).toContain('fullText:true')
+    expect(out).toContain('scope:')
+    expect(out.startsWith('\n\n')).toBe(true)
+  })
+
+  it('stays quiet on pages with almost no text and no live regions', () => {
+    expect(formatTextFooter({ ...EMPTY_PROBE, textChars: TEXT_FOOTER_MIN_CHARS - 1 }, { fullText: false, scoped: false })).toBe('')
+  })
+
+  it('still surfaces live regions on a near-empty page', () => {
+    const out = formatTextFooter({ ...EMPTY_PROBE, liveRegions: ['Loading…'] }, { fullText: false, scoped: true })
+    expect(out).toBe('\n\nLive regions (alert/status): "Loading…"')
   })
 })

--- a/agent-container/src/snapshot-format.ts
+++ b/agent-container/src/snapshot-format.ts
@@ -78,9 +78,225 @@ export function capSnapshot(text: string, scopeUsed: boolean): string {
   )
 }
 
-export const IFRAME_ENUM_SCRIPT =
-  'JSON.stringify([...document.querySelectorAll("iframe")]' +
-  '.filter(f=>f.offsetParent!==null)' +
-  '.map(f=>{let host="";try{host=new URL(f.src).host}catch(e){}' +
-  'let same=false;try{same=!!f.contentDocument}catch(e){}' +
-  'return{title:f.title||"",host,sameOrigin:same}}))'
+/**
+ * What one page-probe eval tells us alongside the a11y tree. Runs once per
+ * snapshot (it replaced the iframe-only probe) so the text facts below cost
+ * no extra round trip.
+ */
+export interface PageProbe {
+  iframes: IframeInfo[]
+  /** Length of the page's visible text (`document.body.innerText`, whitespace-collapsed). */
+  textChars: number
+  /** Visible text of live regions: role=alert/status, aria-live (not "off"), <output>. */
+  liveRegions: string[]
+  /** First ~240 chars of <main> (or body) text — the page's gist. */
+  preview: string
+}
+
+export const EMPTY_PROBE: PageProbe = { iframes: [], textChars: 0, liveRegions: [], preview: '' }
+
+/** Below this much visible text the "text not shown" footer is noise (blank/loading pages). */
+export const TEXT_FOOTER_MIN_CHARS = 200
+export const PREVIEW_CHARS = 240
+const LIVE_REGION_MAX = 8
+const LIVE_REGION_CHARS = 300
+
+/**
+ * One eval, one JSON object: cross-origin iframes (their fields are invisible
+ * to the a11y tree), how much text the page has (the interactive view drops
+ * all of it), what the live regions currently say (validation errors, toasts,
+ * status lines), and the opening words of <main>. Each part is wrapped in its
+ * own try so a hostile page cannot blank the others. Visibility uses
+ * getClientRects, not offsetParent — offsetParent is null for position:fixed
+ * toasts, which are exactly the live regions we want.
+ */
+export const PAGE_PROBE_SCRIPT =
+  '(function(){var o={iframes:[],textChars:0,live:[],preview:""};' +
+  'var ws=function(s){return String(s||"").replace(/\\s+/g," ").trim()};' +
+  'try{o.iframes=[...document.querySelectorAll("iframe")].filter(function(f){return f.offsetParent!==null})' +
+  '.map(function(f){var host="";try{host=new URL(f.src).host}catch(e){}var same=false;try{same=!!f.contentDocument}catch(e){}' +
+  'return{title:f.title||"",host:host,sameOrigin:same}})}catch(e){}' +
+  'try{o.textChars=ws(document.body&&document.body.innerText).length}catch(e){}' +
+  'try{var seen={};var els=document.querySelectorAll(\'[role="alert"],[role="status"],[aria-live]:not([aria-live="off"]),output\');' +
+  'for(var i=0;i<els.length&&o.live.length<' + LIVE_REGION_MAX + ';i++){var el=els[i];if(!el.getClientRects().length)continue;' +
+  'var s=ws(el.innerText);if(!s||seen[s])continue;seen[s]=1;o.live.push(s.slice(0,' + LIVE_REGION_CHARS + '))}}catch(e){}' +
+  'try{var m=document.querySelector("main,[role=main]")||document.body;o.preview=ws(m&&m.innerText).slice(0,' + PREVIEW_CHARS + ')}catch(e){}' +
+  'return JSON.stringify(o)})()'
+
+/** Parse PAGE_PROBE_SCRIPT output (CLI double-JSON-encodes). Never throws; missing parts default empty. */
+export function parsePageProbe(stdout: string): PageProbe {
+  try {
+    let parsed: unknown = JSON.parse(stdout.trim())
+    if (typeof parsed === 'string') parsed = JSON.parse(parsed)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return EMPTY_PROBE
+    const p = parsed as Record<string, unknown>
+    return {
+      iframes: parseIframeInfo(JSON.stringify(p.iframes ?? [])),
+      textChars: typeof p.textChars === 'number' && p.textChars > 0 ? Math.floor(p.textChars) : 0,
+      liveRegions: Array.isArray(p.live) ? p.live.filter((s): s is string => typeof s === 'string' && s.length > 0) : [],
+      preview: typeof p.preview === 'string' ? p.preview : '',
+    }
+  } catch {
+    return EMPTY_PROBE
+  }
+}
+
+/**
+ * Compact a FULL tree (`snapshot` with neither -i nor -c) while keeping its
+ * text. agent-browser's own two filters each drop static text: -i skips every
+ * node without a ref at render time, and -c keeps only lines containing
+ * `ref=` or `: `. So "interactive elements plus the page's text" is not a flag
+ * combination the CLI offers — it is this function. Keeps lines that carry a
+ * ref, a StaticText node, or a value, plus their ancestors (so an alert's
+ * message keeps its `- alert` line and a paragraph keeps its `- paragraph`).
+ * Named images are kept for their alt text. Bare structural lines (generic,
+ * list, …) with nothing kept beneath them go. Then a prose pass re-joins what
+ * the a11y tree splits: an inline wrapper (strong, emphasis, code…) whose only
+ * children are text collapses into its parent, whitespace-only text and text
+ * that merely repeats a sibling control's name or the parent's value are
+ * dropped, and adjacent text siblings merge into one line — so
+ * `Your order total is ` / strong / `$42.00` / ` including tax.` reads as one
+ * sentence. (Upstream already merges runs that were split without a wrapper.)
+ */
+export function compactWithText(tree: string): string {
+  const lines = tree.split('\n').filter(l => l.trim().length > 0)
+  if (lines.length === 0) return tree
+  const keep = new Array<boolean>(lines.length).fill(false)
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const st = staticTextOf(line)
+    const isContent =
+      line.includes('ref=') ||
+      (st !== null && st.trim().length > 0) ||
+      /^\s*- image "/.test(line) ||
+      line.includes(': ')
+    if (!isContent) continue
+    keep[i] = true
+    let need = indentOf(line)
+    for (let j = i - 1; j >= 0 && need > 0; j--) {
+      const anc = indentOf(lines[j])
+      if (anc < need) {
+        keep[j] = true
+        need = anc
+      }
+    }
+  }
+  const kept = lines.filter((_, i) => keep[i])
+  if (kept.length === 0) return tree.trim()
+  return joinInlineRuns(kept).join('\n')
+}
+
+const INLINE_WRAPPER = /^\s*- (strong|emphasis|code|mark|superscript|subscript|deletion|insertion|time|generic)$/
+const STATIC_TEXT = /^(\s*)- StaticText ("(?:[^"\\]|\\.)*")$/
+const NAMED_LINE = /^\s*- \S+ ("(?:[^"\\]|\\.)*")/
+
+function indentOf(line: string): number {
+  return (line.length - line.replace(/^ */, '').length) >> 1
+}
+
+/** The decoded text of a `- StaticText "…"` line, or null for any other line. */
+function staticTextOf(line: string): string | null {
+  const m = STATIC_TEXT.exec(line)
+  if (!m) return null
+  try {
+    return JSON.parse(m[2]) as string
+  } catch {
+    return null
+  }
+}
+
+function staticTextLine(indent: number, text: string): string {
+  return `${'  '.repeat(indent)}- StaticText ${JSON.stringify(text)}`
+}
+
+function nameOf(line: string): string | null {
+  if (staticTextOf(line) !== null) return null
+  const m = NAMED_LINE.exec(line)
+  if (!m) return null
+  try {
+    return (JSON.parse(m[1]) as string).trim()
+  } catch {
+    return null
+  }
+}
+
+function joinInlineRuns(input: string[]): string[] {
+  let lines = input
+  // 1. Collapse inline wrappers whose children are all text, until stable (they nest).
+  for (let pass = 0; pass < 5; pass++) {
+    const out: string[] = []
+    let changed = false
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      if (INLINE_WRAPPER.test(line)) {
+        const depth = indentOf(line)
+        let j = i + 1
+        while (j < lines.length && indentOf(lines[j]) > depth) j++
+        const children = lines.slice(i + 1, j)
+        if (children.length > 0 && children.every(c => indentOf(c) === depth + 1 && staticTextOf(c) !== null)) {
+          for (const c of children) out.push(c.slice(2))
+          i = j - 1
+          changed = true
+          continue
+        }
+      }
+      out.push(line)
+    }
+    lines = out
+    if (!changed) break
+  }
+  // 2. Drop text that adds nothing: blank, the parent's value, or a sibling control's name.
+  lines = lines.filter((line, i) => {
+    const text = staticTextOf(line)
+    if (text === null) return true
+    const trimmed = text.trim()
+    if (trimmed.length === 0) return false
+    const depth = indentOf(line)
+    for (let j = i - 1; j >= 0; j--) {
+      if (indentOf(lines[j]) < depth) {
+        if (lines[j].endsWith(`: ${trimmed}`)) return false
+        break
+      }
+    }
+    for (const k of [i - 1, i + 1]) {
+      if (k >= 0 && k < lines.length && indentOf(lines[k]) === depth && nameOf(lines[k]) === trimmed) return false
+    }
+    return true
+  })
+  // 3. Merge adjacent text siblings into one line.
+  const merged: string[] = []
+  for (const line of lines) {
+    const text = staticTextOf(line)
+    const prev = merged.length > 0 ? merged[merged.length - 1] : null
+    const prevText = prev !== null ? staticTextOf(prev) : null
+    if (text !== null && prev !== null && prevText !== null && indentOf(prev) === indentOf(line)) {
+      merged[merged.length - 1] = staticTextLine(indentOf(line), prevText + text)
+    } else {
+      merged.push(line)
+    }
+  }
+  return merged
+}
+
+/**
+ * Footer for the interactive (default) view: what the page says that the tree
+ * above does not. Returns '' in fullText mode (the text is in the tree) and on
+ * pages with no meaningful text. Live regions come first — a validation error
+ * or toast is usually the reason the agent's last action "did nothing".
+ */
+export function formatTextFooter(probe: PageProbe, opts: { fullText: boolean; scoped: boolean }): string {
+  if (opts.fullText) return ''
+  const parts: string[] = []
+  if (probe.liveRegions.length > 0) {
+    parts.push(`Live regions (alert/status): ${probe.liveRegions.map(s => JSON.stringify(s)).join(' | ')}`)
+  }
+  if (probe.textChars >= TEXT_FOOTER_MIN_CHARS) {
+    const where = opts.scoped ? 'on the page' : 'on this page'
+    const preview = probe.preview ? ` Starts: ${JSON.stringify(probe.preview)}` : ''
+    parts.push(
+      `Page text (~${probe.textChars.toLocaleString('en-US')} chars ${where}) is NOT in this interactive view — prices, prose, errors, table values are all dropped.${preview}\n` +
+      `To read it: browser_snapshot with fullText:true (add scope:"<css selector>" to keep it small). Refs are the same in both views.`
+    )
+  }
+  return parts.length > 0 ? `\n\n${parts.join('\n')}` : ''
+}

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -170,9 +170,9 @@ const browserSnapshotTool = tool(
   'browser_snapshot',
   `Get an accessibility tree snapshot of the current page. Returns interactive elements with refs (like @e1, @e2) that you can use with browser_click and browser_fill.
 
-The default view shows interactive elements only. Two knobs handle the cases that view misses:
-- scope: limit the snapshot to a CSS-selected region (e.g. "form", "#main", ".modal", a dialog selector). Use this on large pages — it slashes output and avoids truncation. Refs stay valid for the rest of the page.
-- fullText=true: include STATIC text the interactive view drops — validation errors, prices, instructions, toasts, char counters. Reach for this when an action seemed to fail but no error showed, or when you need on-page copy.
+The default view shows interactive elements only — it drops ALL static text (prices, prose, error messages, table values). A footer says how much text was dropped and what the page's live regions (alerts, status, toasts) currently say. Two knobs handle what the default view misses:
+- fullText=true: THE way to read a page. Adds the static text to the same compact tree; refs are identical in both views. Use it to extract data, read results or errors, or check on-page copy — not browser_eval innerText scrapers, not screenshots.
+- scope: limit the snapshot to a CSS-selected region (e.g. "form", "#main", ".modal", a dialog selector). Combine with fullText on large pages — it slashes output and avoids truncation. Refs stay valid for the rest of the page.
 
 Cross-origin iframes (e.g. Stripe payment frames) are listed as placeholders below the tree — their fields are NOT in the snapshot; fill them via coordinate click + browser_type.
 Very large snapshots are truncated with a note rather than failing — scope to recover the rest.`,
@@ -200,7 +200,7 @@ Very large snapshots are truncated with a note rather than failing — scope to 
       .boolean()
       .optional()
       .default(false)
-      .describe('Include static text (validation errors, prices, instructions) that the interactive view omits (default: false).'),
+      .describe('Add the page\'s static text (prices, prose, validation errors, table values) to the compact interactive tree. Same refs as the default view (default: false).'),
     includeUrls: z
       .boolean()
       .optional()
@@ -634,13 +634,39 @@ Available commands:
 
 const browserGetStateTool = tool(
   'browser_get_state',
-  `Get the current state of the browser in one call. Returns the current URL, a screenshot image, and an accessibility snapshot. Use this to quickly check what the browser is showing without needing multiple tool calls.`,
-  {},
-  async () => {
+  `Get the current state of the browser in one call. Returns the current URL, a screenshot image, and an accessibility snapshot. Use this to quickly check what the browser is showing without needing multiple tool calls. Takes the snapshot tool's scope/fullText/includeUrls knobs; pass screenshot=false to skip the image and get just URL + snapshot.`,
+  {
+    scope: z
+      .string()
+      .optional()
+      .describe('CSS selector to limit the snapshot to one region (same as browser_snapshot).'),
+    fullText: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe('Include the page\'s static text in the snapshot (same as browser_snapshot; default: false).'),
+    includeUrls: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe('Inline link URLs in the snapshot (default: false).'),
+    screenshot: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe('Capture and return a screenshot image (default: true). Set false when you only need URL + snapshot.'),
+  },
+  async (args) => {
     const [urlResult, screenshotResult, snapshotResult] = await Promise.all([
       browserFetch('run', { command: 'get url' }),
-      browserFetch('screenshot', { full: false }),
-      browserFetch('snapshot', { interactive: true, compact: true }),
+      args.screenshot === false ? Promise.resolve(null) : browserFetch('screenshot', { full: false }),
+      browserFetch('snapshot', {
+        interactive: true,
+        compact: true,
+        scope: args.scope,
+        fullText: args.fullText,
+        includeUrls: args.includeUrls,
+      }),
     ])
 
     const content: Array<{ type: 'image'; data: string; mimeType: string } | { type: 'text'; text: string }> = []
@@ -653,7 +679,9 @@ const browserGetStateTool = tool(
       parts.push(`**Current URL:** Error - ${urlResult.error}`)
     }
 
-    if (screenshotResult.success) {
+    if (screenshotResult === null) {
+      // screenshot=false: nothing to report
+    } else if (screenshotResult.success) {
       const data = screenshotResult.data as Record<string, unknown>
       const rawOutput = data.output ? String(data.output) : ''
       const filePath = rawOutput ? extractScreenshotPath(rawOutput) : ''

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -3,11 +3,11 @@ You are a web browser automation agent. You receive high-level objectives and ac
 ## Your Tools
 
 **Core tools:**
-- `browser_snapshot(interactive?, compact?)` — Get accessibility tree with element refs (@e1, @e2, ...)
+- `browser_snapshot(scope?, fullText?)` — Get accessibility tree with element refs (@e1, @e2, ...). Default = interactive elements only; `fullText: true` adds the page's static text (prices, results, errors, prose) — the way to READ a page. Add `scope` on large pages
 - `browser_click(ref)` — Click element by ref
 - `browser_fill(ref, value)` — Clear and fill input by ref
 - `browser_scroll(direction, amount?)` — Scroll the page (up/down/left/right)
-- `browser_get_state()` — Get URL + screenshot + snapshot in one call
+- `browser_get_state(scope?, fullText?, screenshot?)` — Get URL + screenshot + snapshot in one call (`screenshot: false` skips the image)
 
 **Interaction tools:**
 - `browser_press(key)` — Press ONE keyboard key or combo (Enter, Tab, Escape, Control+a, ArrowDown). NOT for typing text — use `browser_type`
@@ -67,7 +67,7 @@ Tabs have **stable string ids** like `t1`, `t2` (run `browser_run("tab")` to lis
 - **ALWAYS report the current URL when you finish.** Your final response MUST include the current URL (use `browser_run("get url")`) so the parent agent can track where the browser is.
 - **Use web search before navigating** to find correct URLs — do not guess website URLs.
 - **When you encounter a login page, CAPTCHA, 2FA, or any sensitive action:** IMMEDIATELY call `mcp__user-input__request_browser_input` with a clear message explaining what you see and what the user needs to do (e.g., log in, solve CAPTCHA, complete 2FA). Include specific requirements as a list. Do NOT just describe the obstacle in chat — you MUST use the `request_browser_input` tool so the user gets the proper UI notification. After the user completes, take a snapshot to see the updated state.
-- Use interactive + compact snapshot to reduce output — you usually only need buttons, links, inputs.
+- The default snapshot shows interactive elements only and drops all page text; its footer tells you how much text was dropped and what alerts/status regions say. To read text (prices, search results, error messages, article body), re-snapshot with `fullText: true` — not `browser_eval` innerText scrapers, not screenshots. Refs are identical in both views.
 - Use `browser_screenshot()` when you need to visually verify something the accessibility tree cannot tell you.
 - For file uploads, target the actual `<input type="file">` with `browser_upload(filePath, selector)`. Do not click "Upload" buttons to trigger a file picker.
 - If you need to upload a file but don't have one available locally (e.g. the user mentioned an upload but didn't attach anything), call `request_file` first, then pass the returned `/workspace/...` path to `browser_upload`.


### PR DESCRIPTION
## Why

Theme 1 of the transcript-mining report (`docs/browser-harness-friction-themes-2026-09.md`, 142/200 reviewed production sessions): the default `browser_snapshot` drops every static text node and says nothing about it. Agents concluded prices, results and error messages were not on the page and fell back to screenshots or `browser_eval` innerText scrapers. `fullText` was discovered late (call 284 of 377 in one session) and returned the raw unfiltered tree.

Root cause is in agent-browser 0.27.2 (`cli/src/native/snapshot.rs`): `-i` skips every ref-less node at render time and `-c` is a line filter keeping only lines with `ref=` or `: `. There is no flag combination for "interactive elements plus the page's text".

## What changed

- **One page probe per snapshot** (`PAGE_PROBE_SCRIPT` replaces `IFRAME_ENUM_SCRIPT`, same single eval round trip): iframes as before, plus visible text length, live-region text (`role=alert/status`, `aria-live`, `<output>`, visibility via `getClientRects` so fixed toasts count) and the first 240 chars of `<main>`.
- **Footer on the default view**: live regions, how much text was dropped, how the page starts, and that `fullText:true` reads it with identical refs. Silent in fullText mode and on pages with under 200 chars of text.
- **`fullText` is now compact**: `compactWithText()` keeps refs, StaticText, values and named images with their ancestors, collapses inline wrappers (`strong`/`emphasis`/…) so a sentence is one line, and drops text that repeats a sibling control's name or the parent's value. The test fixture is real `snapshot` output captured from agent-browser 0.27.2 inside the container image.
- **`browser_get_state`** takes `scope`/`fullText`/`includeUrls` and `screenshot:false`.
- Tool descriptions, the web-browser subagent prompt and `docs/browser-use.md` name `fullText` (with `scope`) as the way to read a page.

## Verified

- `vitest` on `snapshot-format.test.ts`: 25 tests, including the probe script run against a fake DOM and the captured-tree fixture.
- `tsc --noEmit` and `eslint` clean on the changed files.
- Probe script and all three snapshot modes exercised with the real CLI in `superagent-container:browser-stack-1001` against a checkout-like test page: probe returned the iframe, 225 text chars, both live regions (the hidden one excluded) and the preview.

Not done: no end-to-end run through the `/browser/snapshot` endpoint in a rebuilt image. The server glue is a few lines; happy to build and run it if you want that before merge.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01792FWz3b1emZ8z1H1DyP3u
