### PR TITLE
feat: fork opens the copy before resolving, add a fork-and-compact hook (SUP-793)

### DIFF
--- a/src/renderer/components/agents/agent-home/agent-home.test.tsx
+++ b/src/renderer/components/agents/agent-home/agent-home.test.tsx
@@ -67,7 +67,7 @@ let mockSessionsData: unknown = []
 vi.mock('@renderer/hooks/use-sessions', () => ({
   // The session list rows now render SessionContextMenu, which reads these.
   useSetSessionMarkedUnread: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useForkSession: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useForkSession: () => ({ mutate: vi.fn(), isPending: false }),
   useCreateSession: () => mockCreateSession,
   useSessions: () => ({ data: mockSessionsData }),
   useDeleteSession: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),

--- a/src/renderer/components/sessions/session-context-menu.test.tsx
+++ b/src/renderer/components/sessions/session-context-menu.test.tsx
@@ -106,7 +106,7 @@ vi.mock('@renderer/hooks/use-sessions', () => ({
   useDeleteSession: () => ({ mutateAsync: vi.fn() }),
   useUpdateSessionName: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useSetSessionMarkedUnread: () => ({ mutateAsync: mockSetMarkedUnread, isPending: false }),
-  useForkSession: () => ({ mutateAsync: mockFork, isPending: false }),
+  useForkSession: () => ({ mutate: mockFork, isPending: false }),
 }))
 
 const mockCanAdminAgent = vi.fn(() => true)
@@ -377,28 +377,13 @@ describe('Fork Session item', () => {
     expect(screen.getByTestId('fork-session-item')).toHaveAttribute('data-disabled')
   })
 
-  it('forks and navigates; draft and cache seed live in the hook', async () => {
-    mockFork.mockResolvedValue({ id: 'fork-1', agentSlug: 'agent-a', name: 'Pricing (fork)' })
+  it('forks; navigation, draft and cache seed live in the hook', async () => {
     renderMenu()
     fireEvent.click(screen.getByTestId('fork-session-item'))
-    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith({
-      to: '/agents/$slug/sessions/$sessionId',
-      params: { slug: 'agent-a', sessionId: 'fork-1' },
-    }))
-    expect(mockFork).toHaveBeenCalledWith({ sessionId: 'src-1', agentSlug: 'agent-a' })
+    await waitFor(() => expect(mockFork).toHaveBeenCalledWith({ sessionId: 'src-1', agentSlug: 'agent-a' }))
+    expect(mockNavigate).not.toHaveBeenCalled()
     expect(mockSnapshot).not.toHaveBeenCalled()
     expect(mockSeed).not.toHaveBeenCalled()
     expect(mockSetQueryData).not.toHaveBeenCalled()
-  })
-
-  it('stays put and logs when the fork fails', async () => {
-    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
-    mockFork.mockRejectedValue(new Error('nope'))
-    renderMenu()
-    fireEvent.click(screen.getByTestId('fork-session-item'))
-    await waitFor(() => expect(err).toHaveBeenCalled())
-    expect(mockNavigate).not.toHaveBeenCalled()
-    expect(mockSeed).not.toHaveBeenCalled()
-    err.mockRestore()
   })
 })

--- a/src/renderer/components/sessions/session-context-menu.tsx
+++ b/src/renderer/components/sessions/session-context-menu.tsx
@@ -114,14 +114,8 @@ export function SessionContextMenu({
     }
   }
 
-  const handleFork = async () => {
-    try {
-      const fork = await forkSession.mutateAsync({ sessionId, agentSlug })
-      void navigate({ to: '/agents/$slug/sessions/$sessionId', params: { slug: agentSlug, sessionId: fork.id } })
-    } catch (error) {
-      console.error('Failed to fork session:', error)
-    }
-  }
+  // The hook opens the copy and logs its own failures; `mutate` settles without throwing.
+  const handleFork = () => forkSession.mutate({ sessionId, agentSlug })
 
   const handleRename = async () => {
     const trimmed = newName.trim()

--- a/src/renderer/hooks/use-sessions.fork.test.ts
+++ b/src/renderer/hooks/use-sessions.fork.test.ts
@@ -4,7 +4,13 @@ import { act, renderHook } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DraftsProvider, useDraftsStore } from '@renderer/context/drafts-context'
-import { useForkSession } from './use-sessions'
+import { useForkAndCompact, useForkSession } from './use-sessions'
+
+const { mockNavigate } = vi.hoisted(() => ({ mockNavigate: vi.fn() }))
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
 
 const mockApiFetch = vi.fn()
 vi.mock('@renderer/lib/api', () => ({
@@ -28,9 +34,13 @@ describe('useForkSession', () => {
   beforeEach(() => {
     mockApiFetch.mockReset()
     mockTrack.mockReset()
+    mockNavigate.mockReset()
   })
 
-  it('seeds the fork cache and draft on success', async () => {
+  it('seeds the fork cache and draft, then opens the copy before resolving', async () => {
+    // Navigation is held open so the test can see the mutation wait for it.
+    let finishNavigation!: () => void
+    mockNavigate.mockImplementation(() => new Promise<void>((resolve) => { finishNavigation = resolve }))
     mockApiFetch.mockResolvedValue({
       ok: true,
       json: async () => ({ id: 'fork-1', agentSlug: 'agent-a', name: 'Pricing (fork)' }),
@@ -40,7 +50,19 @@ describe('useForkSession', () => {
       result.current.store.set('session:src-1', 'unsent')
     })
     await act(async () => {
-      await result.current.fork.mutateAsync({ sessionId: 'src-1', agentSlug: 'agent-a' })
+      let settled = false
+      const forked = result.current.fork.mutateAsync({ sessionId: 'src-1', agentSlug: 'agent-a' }).then(() => { settled = true })
+      await vi.waitFor(() => expect(mockNavigate).toHaveBeenCalled())
+      await Promise.resolve()
+      // A caller that acts on the opened copy (e.g. sends into it) relies on this.
+      expect(settled).toBe(false)
+      finishNavigation()
+      await forked
+      expect(settled).toBe(true)
+    })
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/agents/$slug/sessions/$sessionId',
+      params: { slug: 'agent-a', sessionId: 'fork-1' },
     })
     expect(result.current.store.get('session:fork-1')).toBe('unsent')
     expect(result.current.store.get('session:src-1')).toBe('unsent')
@@ -51,7 +73,8 @@ describe('useForkSession', () => {
     expect(mockTrack).not.toHaveBeenCalledWith('session_fork_failed', expect.anything())
   })
 
-  it('throws the server error text', async () => {
+  it('throws and logs the server error text', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
     mockApiFetch.mockResolvedValue({
       ok: false,
       text: async () => JSON.stringify({ error: 'Session is currently running' }),
@@ -62,5 +85,62 @@ describe('useForkSession', () => {
     ).rejects.toThrow('Session is currently running')
     expect(mockTrack).toHaveBeenCalledWith('session_fork_failed', { reason: 'Session is currently running' })
     expect(mockTrack).not.toHaveBeenCalledWith('session_forked')
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(err).toHaveBeenCalledWith('Failed to fork session:', expect.any(Error))
+    err.mockRestore()
+  })
+})
+
+describe('useForkAndCompact', () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset()
+    mockTrack.mockReset()
+    mockNavigate.mockReset()
+  })
+
+  it('forks, opens the copy, then sends /compact into the copy', async () => {
+    const order: string[] = []
+    let finishNavigation!: () => void
+    mockNavigate.mockImplementation(() => new Promise<void>((resolve) => {
+      order.push('navigate')
+      finishNavigation = resolve
+    }))
+    mockApiFetch.mockImplementation(async (url: string, init?: { body?: string }) => {
+      if (url.endsWith('/fork')) {
+        order.push('fork')
+        return { ok: true, json: async () => ({ id: 'fork-1', agentSlug: 'agent-a', name: 'Pricing (fork)' }) }
+      }
+      order.push(`send:${url}:${init?.body ?? ''}`)
+      return { ok: true, json: async () => ({ success: true, uuid: 'u1', queued: false }) }
+    })
+    const { result } = renderHook(() => useForkAndCompact(), { wrapper })
+    await act(async () => {
+      const done = result.current.mutateAsync({ sessionId: 'src-1', agentSlug: 'agent-a' })
+      await vi.waitFor(() => expect(order).toContain('navigate'))
+      await Promise.resolve()
+      // The send waits for the copy to open; nothing is posted while navigation is pending.
+      expect(order).toEqual(['fork', 'navigate'])
+      finishNavigation()
+      await done
+    })
+    expect(order).toEqual([
+      'fork',
+      'navigate',
+      `send:/api/agents/agent-a/sessions/fork-1/messages:${JSON.stringify({ content: '/compact' })}`,
+    ])
+  })
+
+  it('sends nothing when the fork fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockApiFetch.mockResolvedValue({
+      ok: false,
+      text: async () => JSON.stringify({ error: 'Session is currently running' }),
+    })
+    const { result } = renderHook(() => useForkAndCompact(), { wrapper })
+    await expect(
+      result.current.mutateAsync({ sessionId: 'src-1', agentSlug: 'agent-a' }),
+    ).rejects.toThrow('Session is currently running')
+    expect(mockApiFetch).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/hooks/use-sessions.ts
+++ b/src/renderer/hooks/use-sessions.ts
@@ -1,8 +1,10 @@
 import { apiFetch, apiJson } from '@renderer/lib/api'
 import { useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
 import { useAnalyticsTracking } from '@renderer/context/analytics-context'
 import { useDraftsStore, snapshotSessionDraft, seedSessionDraft } from '@renderer/context/drafts-context'
+import { useSendMessage } from '@renderer/hooks/use-messages'
 import { useAgents, resolveRouteAgentId, type ApiAgent } from '@renderer/hooks/use-agents'
 import { applySessionActivityStatus, patchSessionInCaches } from '@renderer/lib/agent-cache'
 import type { ApiSession } from '@shared/lib/types/api'
@@ -266,6 +268,7 @@ export function useClearSessionUnread() {
 export function useForkSession() {
   const queryClient = useQueryClient()
   const draftsStore = useDraftsStore()
+  const navigate = useNavigate()
   const { track } = useAnalyticsTracking()
 
   return useMutation({
@@ -286,6 +289,7 @@ export function useForkSession() {
     },
     onMutate: ({ sessionId }) => ({ draft: snapshotSessionDraft(draftsStore, sessionId) }),
     onError: (error) => {
+      console.error('Failed to fork session:', error)
       track('session_fork_failed', { reason: error instanceof Error ? error.message : 'unknown' })
     },
     onSuccess: (fork, variables, context) => {
@@ -295,6 +299,31 @@ export function useForkSession() {
       queryClient.invalidateQueries({
         queryKey: ['sessions', resolveAgentSlugFromCache(queryClient, variables.agentSlug)],
       })
+      // Open the copy. Returned so the mutation resolves only once the route
+      // transition is done and a caller that acts next does so from inside it.
+      return navigate({
+        to: '/agents/$slug/sessions/$sessionId',
+        params: { slug: variables.agentSlug, sessionId: fork.id },
+      })
+    },
+  })
+}
+
+/**
+ * Fork, open the copy, then compact the copy. The source is never mutated.
+ * useForkSession opens the copy before it resolves, so the user watches the
+ * compaction from inside the copy.
+ */
+export function useForkAndCompact() {
+  const forkSession = useForkSession()
+  const sendMessage = useSendMessage()
+  return useMutation({
+    // Both inner mutations already log and toast their own failures; this
+    // one adds nothing, so callers use `mutate` and let it settle quietly.
+    meta: { skipGlobalErrorToast: true },
+    mutationFn: async ({ sessionId, agentSlug }: { sessionId: string; agentSlug: string }) => {
+      const fork = await forkSession.mutateAsync({ sessionId, agentSlug })
+      await sendMessage.mutateAsync({ sessionId: fork.id, agentSlug: fork.agentSlug, content: '/compact' })
     },
   })
 }


### PR DESCRIPTION
Fork Session now opens the copy before its mutation resolves, and a new `useForkAndCompact` hook chains that fork with a `/compact` send into the copy, so a caller can shrink a long conversation into a fresh one without a new endpoint or summarizer. Nothing calls the new hook yet: the stale-conversation card wires it in #1054 and the session context menu in a follow-up, so on its own this PR only changes how the existing Fork Session entry navigates. The source conversation is never touched, which is what replaces the custom summary flow in #276.

Related to https://linear.app/datawizz/issue/SUP-793/stale-notice-continue-in-a-compacted-fork-fork-compact

Footprint: production +31 / -8 across 2 files, tests +89 / -24 across 3.

```
forkAndCompact.mutate
  → fork the conversation
  → open the copy (the fork mutation resolves here)
  → send /compact into the copy
       └─ fork fails → nothing is sent, the user stays on the original
```

- `useForkSession` returns the navigation from `onSuccess`, so the user is inside the copy when the compaction starts.
- The context menu's Fork entry drops its own navigate and try/catch and calls `mutate`. The hook logs and tracks the failure.
- `useForkAndCompact` skips the global error toast because both inner mutations already toast their own failures.
- The copy's stream connects after its compaction has begun, so the copy showed "Working" instead of "Compacting..." until the summary landed. That is a gap for every late-joining stream, not only forks, and the fix ships separately as the compaction-state PR.

No UI change.
