### PR TITLE
fix(browser): report page identity and readiness on open and every snapshot

### DIFF
--- a/agent-container/docs/browser-use.md
+++ b/agent-container/docs/browser-use.md
@@ -39,6 +39,15 @@ such as `@e1` and, in the default interactive view, no static text at all. A
 footer reports how much page text was dropped and what the live regions
 (alerts, status, toasts) currently say.
 
+Every snapshot starts with a status line: `[page] URL · "title" · HTTP status ·
+readyState · N refs`, followed by `⚠` warnings when the site is unreachable, a
+bot challenge is up, the server answered 4xx/5xx, the document is a raw file, or
+content is still loading. `browser_open` reports the same facts for the page it
+actually landed on (final URL, redirect, HTTP status) and is marked as an error
+when that page is a net error, a bot wall or an HTTP error. Act on a warning
+before reading the tree: a bot wall or login page needs the user, a loading page
+needs `browser_wait` for the element you need.
+
 Useful snapshot options:
 
 - `fullText: true`: add the page's static text (prices, prose, validation

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -815,7 +815,10 @@ import { prepareEvalScript, finalizeEvalOutput, evalErrorHint } from './eval-scr
 import { judgeSelectCommit, SELECT_COMMIT_SETTLE_MS } from './select-verify';
 import { resolveCommittedValue } from './field-value-readback';
 import { capBrowserOutput, redactCdpUrls, MAX_BROWSER_OUTPUT_CHARS, MAX_BROWSER_ERROR_CHARS } from './browser-output';
-import { capSnapshot, compactWithText, formatIframePlaceholders, formatTextFooter, parsePageProbe, EMPTY_PROBE, PAGE_PROBE_SCRIPT } from './snapshot-format';
+import {
+  capSnapshot, compactWithText, countRefs, formatIframePlaceholders, formatStatusHeader, formatTextFooter,
+  pageProbeScript, parsePageProbe, EMPTY_PROBE, THIN_TREE_PREVIEW_CHARS, THIN_TREE_REFS,
+} from './snapshot-format';
 import {
   observeUrl, resetUrlTracking,
   CLICK_SETTLE_MS, FILL_SETTLE_MS, PRESS_ENTER_SETTLE_MS, PRESS_SETTLE_MS,
@@ -1288,16 +1291,23 @@ app.post('/browser/open', async (c) => {
     _setBrowserState({ active: true, sessionId: body.sessionId, cdpUrl: cdpUrl || null, location });
     tabManager.resetTabCount();
     resetUrlTracking();
-    // Seed the URL baseline so the FIRST post-action digest can distinguish
-    // "navigated" from "unchanged" (validation found a click that navigated
-    // away from the opened page being reported as "URL unchanged").
-    const landed = await execBrowser(['get', 'url'], cdpUrl);
-    if (landed.exitCode === 0 && landed.stdout.trim()) {
-      observeUrl(landed.stdout.trim());
+    // Read the landing page once: it seeds the URL baseline so the FIRST
+    // post-action digest can distinguish "navigated" from "unchanged", and it
+    // tells the tool where the browser actually ended up — final URL, title,
+    // HTTP status, bot wall, net error — instead of echoing the requested URL
+    // (transcript-mining theme 2: a 429, a login redirect and about:blank all
+    // used to read "Browser opened and navigating to <url>").
+    const landed = await execBrowser(['eval', pageProbeScript({ previewChars: THIN_TREE_PREVIEW_CHARS })], cdpUrl);
+    const page = landed.exitCode === 0 ? parsePageProbe(landed.stdout) : EMPTY_PROBE;
+    if (page.url) {
+      observeUrl(page.url);
+    } else {
+      const fallback = await execBrowser(['get', 'url'], cdpUrl);
+      if (fallback.exitCode === 0 && fallback.stdout.trim()) observeUrl(fallback.stdout.trim());
     }
     broadcastBrowserEvent(true);
 
-    return c.json({ success: true, location, switchedFrom });
+    return c.json({ success: true, location, switchedFrom, page });
   } catch (error: any) {
     console.error('[Browser] Error opening browser:', error);
     return c.json({ error: error.message || 'Failed to open browser' }, 500);
@@ -1464,10 +1474,14 @@ app.post('/browser/snapshot', async (c) => {
     }
 
     // One probe eval per snapshot: cross-origin iframes (fields the a11y tree
-    // cannot see — audit P2), plus how much page text the interactive view
-    // dropped and what the live regions say, so the default view never
-    // silently hides a price, an error or a toast (transcript-mining theme 1).
-    const probeResult = await execBrowser(['eval', PAGE_PROBE_SCRIPT], browserState.cdpUrl || undefined);
+    // cannot see — audit P2), how much page text the interactive view dropped
+    // and what the live regions say (transcript-mining theme 1), and the
+    // page's identity/readiness for the status header (theme 2). A thin tree
+    // gets a long text preview: `(no interactive elements)` looks the same
+    // for a 401 body, a bot wall and a hydrating SPA — the text tells them apart.
+    const refCount = countRefs(result.stdout);
+    const probeScript = pageProbeScript({ previewChars: refCount < THIN_TREE_REFS ? THIN_TREE_PREVIEW_CHARS : undefined });
+    const probeResult = await execBrowser(['eval', probeScript], browserState.cdpUrl || undefined);
     const probe = probeResult.exitCode === 0 ? parsePageProbe(probeResult.stdout) : EMPTY_PROBE;
     const iframes = probe.iframes;
 
@@ -1486,12 +1500,15 @@ app.post('/browser/snapshot', async (c) => {
     const fullText = Boolean(body.fullText);
     const tree = fullText && body.compact !== false ? compactWithText(result.stdout) : result.stdout;
 
+    const header = formatStatusHeader(probe, refCount);
     return c.json({
       snapshot:
+        (header ? `${header}\n\n` : '') +
         capSnapshot(tree, Boolean(body.scope)) +
         formatTextFooter(probe, { fullText, scoped: Boolean(body.scope) }) +
         formatIframePlaceholders(iframes),
       iframes,
+      page: probe,
       tabCount: tabManager.getTabCount(),
     });
   } catch (error: any) {

--- a/agent-container/src/snapshot-format.test.ts
+++ b/agent-container/src/snapshot-format.test.ts
@@ -6,8 +6,14 @@ import {
   parsePageProbe,
   compactWithText,
   formatTextFooter,
+  formatStatusHeader,
+  pageWarnings,
+  countRefs,
+  landedElsewhere,
+  pageProbeScript,
   PAGE_PROBE_SCRIPT,
   EMPTY_PROBE,
+  THIN_TREE_PREVIEW_CHARS,
   SNAPSHOT_SOFT_CAP_CHARS,
   TEXT_FOOTER_MIN_CHARS,
   PREVIEW_CHARS,
@@ -86,6 +92,7 @@ describe('parsePageProbe', () => {
       preview: 'Welcome back',
     }))
     expect(parsePageProbe(raw)).toEqual({
+      ...EMPTY_PROBE,
       iframes: [{ title: 'pay', host: 'js.stripe.com', sameOrigin: false }],
       textChars: 4200,
       liveRegions: ['Password must be at least 8 characters'],
@@ -93,9 +100,20 @@ describe('parsePageProbe', () => {
     })
   })
 
+  it('parses the identity and readiness fields', () => {
+    const out = parsePageProbe(JSON.stringify({
+      url: 'https://a.com/x', title: 'A', readyState: 'complete', http: 429, contentType: 'text/html',
+      busy: 2, blocker: 'Cloudflare', netError: '',
+    }))
+    expect(out).toMatchObject({
+      url: 'https://a.com/x', title: 'A', readyState: 'complete', httpStatus: 429, contentType: 'text/html',
+      busy: 2, blocker: 'Cloudflare', netError: '',
+    })
+  })
+
   it('defaults missing or malformed parts', () => {
-    expect(parsePageProbe('{"textChars":"x","live":[1,"ok",""],"preview":null}')).toEqual({
-      iframes: [], textChars: 0, liveRegions: ['ok'], preview: '',
+    expect(parsePageProbe('{"textChars":"x","live":[1,"ok",""],"preview":null,"http":"200"}')).toEqual({
+      ...EMPTY_PROBE, liveRegions: ['ok'],
     })
   })
 
@@ -122,14 +140,25 @@ describe('PAGE_PROBE_SCRIPT', () => {
     }
   }
   const LIVE_SELECTOR = '[role="alert"],[role="status"],[aria-live]:not([aria-live="off"]),output'
-  function run(sel: Record<string, unknown[]>, body: { innerText: string }, main: unknown = null) {
+  const BUSY_SELECTOR = '[aria-busy="true"],[role="progressbar"],[class*="skeleton"]'
+  type FakeDoc = {
+    title?: string; readyState?: string; contentType?: string; errorPage?: boolean
+    href?: string; status?: number; script?: string
+  }
+  function run(sel: Record<string, unknown[]>, body: { innerText: string }, main: unknown = null, doc: FakeDoc = {}) {
     const document = {
       body,
+      title: doc.title ?? '',
+      readyState: doc.readyState ?? 'complete',
+      contentType: doc.contentType ?? 'text/html',
       querySelectorAll: (q: string) => sel[q] ?? [],
       querySelector: (q: string) => (q === 'main,[role=main]' ? main : null),
+      getElementById: (id: string) => (id === 'main-frame-error' && doc.errorPage ? {} : null),
     }
-    const fn = new Function('document', 'URL', `return ${PAGE_PROBE_SCRIPT}`)
-    return JSON.parse(fn(document, URL))
+    const location = { href: doc.href ?? 'https://example.com/page' }
+    const performance = { getEntriesByType: () => [{ responseStatus: doc.status ?? 200 }] }
+    const fn = new Function('document', 'URL', 'location', 'performance', `return ${doc.script ?? PAGE_PROBE_SCRIPT}`)
+    return JSON.parse(fn(document, URL, location, performance))
   }
 
   it('reports text length, live regions, preview and iframes in one object', () => {
@@ -153,6 +182,38 @@ describe('PAGE_PROBE_SCRIPT', () => {
     expect(out.preview.length).toBe(PREVIEW_CHARS)
   })
 
+  it('reports identity and readiness: url, title, readyState, HTTP status, content type', () => {
+    const out = run({}, { innerText: 'x' }, null, { title: ' Acme  Shop ', readyState: 'interactive', status: 404, href: 'https://acme.com/a?b=1' })
+    expect(out).toMatchObject({ url: 'https://acme.com/a?b=1', title: 'Acme Shop', readyState: 'interactive', http: 404, contentType: 'text/html', busy: 0, blocker: '', netError: '' })
+  })
+
+  it('counts visible loading indicators only', () => {
+    const out = run({ [BUSY_SELECTOR]: [el({ text: 'a' }), el({ text: 'b', visible: false }), el({ text: 'c' })] }, { innerText: 'x' })
+    expect(out.busy).toBe(2)
+  })
+
+  it('recognises bot walls by vendor signature, including Google via the URL', () => {
+    expect(run({}, { innerText: 'Checking your browser before accessing example.com. Ray ID: 8f3' }, null, { title: 'Just a moment...' }).blocker).toBe('Cloudflare')
+    expect(run({}, { innerText: 'Access denied. Error 15. Incident ID: 123-456' }).blocker).toBe('Imperva/Incapsula')
+    expect(run({}, { innerText: "You don't have permission to access \"/\" on this server. Reference #18.4f2e1cb8.1725" }).blocker).toBe('Akamai')
+    expect(run({}, { innerText: 'To continue, please type the characters below' }, null, { href: 'https://www.google.com/sorry/index?continue=x' }).blocker).toBe('Google')
+    expect(run({}, { innerText: 'Please Press & Hold to confirm you are a human' }).blocker).toBe('PerimeterX')
+    expect(run({}, { innerText: 'Welcome to our store. Prices in USD.' }, null, { title: 'Store' }).blocker).toBe('')
+  })
+
+  it("names Chrome's net error page by its ERR_ code", () => {
+    const out = run({}, { innerText: "This site can't be reached. example.com's server IP address could not be found. ERR_NAME_NOT_RESOLVED" }, null, { errorPage: true })
+    expect(out.netError).toBe('ERR_NAME_NOT_RESOLVED')
+    expect(run({}, { innerText: 'fine' }).netError).toBe('')
+    // Headless shell: empty error document, only the URL gives it away (captured in the container image).
+    expect(run({}, { innerText: '' }, null, { href: 'chrome-error://chromewebdata/' }).netError).toBe('net error')
+  })
+
+  it('takes a longer preview when asked (thin trees)', () => {
+    const out = run({}, { innerText: 'y'.repeat(3000) }, null, { script: pageProbeScript({ previewChars: THIN_TREE_PREVIEW_CHARS }) })
+    expect(out.preview.length).toBe(THIN_TREE_PREVIEW_CHARS)
+  })
+
   it('falls back to body for the preview and survives a broken part', () => {
     const document = {
       body: { innerText: 'Body text here' },
@@ -164,6 +225,64 @@ describe('PAGE_PROBE_SCRIPT', () => {
     expect(out.iframes).toEqual([])
     expect(out.textChars).toBe(14)
     expect(out.preview).toBe('Body text here')
+    expect(out.url).toBe('')
+    expect(out.http).toBe(0)
+  })
+})
+
+describe('pageWarnings / formatStatusHeader', () => {
+  const healthy = { ...EMPTY_PROBE, url: 'https://acme.com/checkout', title: 'Checkout — Acme', readyState: 'complete', httpStatus: 200, contentType: 'text/html' }
+
+  it('is one clean line for a healthy page', () => {
+    expect(pageWarnings(healthy, 84)).toEqual([])
+    expect(formatStatusHeader(healthy, 84)).toBe('[page] https://acme.com/checkout · "Checkout — Acme" · HTTP 200 · complete · 84 refs')
+  })
+
+  it('omits HTTP when unknown and refs when not counted, and is empty without a URL', () => {
+    expect(formatStatusHeader({ ...healthy, httpStatus: 0, title: '' }, null)).toBe('[page] https://acme.com/checkout · untitled · complete')
+    expect(formatStatusHeader(EMPTY_PROBE, 3)).toBe('')
+  })
+
+  it('warns, most invalidating first, with the action to take', () => {
+    const bad = { ...healthy, httpStatus: 429, blocker: 'Cloudflare', readyState: 'loading', busy: 3 }
+    const warns = pageWarnings(bad, 0)
+    expect(warns.map(w => w.split(' ')[0])).toEqual(['bot-block:', 'HTTP', 'page', '3'])
+    expect(warns[0]).toContain('request_browser_input')
+    expect(warns[1]).toContain('rate limited')
+    const header = formatStatusHeader(bad, 0)
+    expect(header.split('\n')).toHaveLength(5)
+    expect(header).toContain('\n⚠ bot-block: Cloudflare')
+  })
+
+  it('explains an empty tree only when nothing else does', () => {
+    expect(pageWarnings(healthy, 0)[0]).toContain('no interactive elements')
+    expect(pageWarnings({ ...healthy, netError: 'ERR_CONNECTION_REFUSED' }, 0)).toHaveLength(1)
+    expect(pageWarnings({ ...healthy, netError: 'ERR_CONNECTION_REFUSED' }, 0)[0]).toContain('site unreachable (ERR_CONNECTION_REFUSED)')
+    expect(pageWarnings({ ...healthy, netError: 'net error' }, 0)[0]).toMatch(/^site unreachable — /)
+  })
+
+  it('flags 401/403/404 and non-HTML documents', () => {
+    expect(pageWarnings({ ...healthy, httpStatus: 401 }, 1)[0]).toContain('login or permission required')
+    expect(pageWarnings({ ...healthy, httpStatus: 404 }, 1)[0]).toContain('not found')
+    expect(pageWarnings({ ...healthy, contentType: 'application/json' }, 1)[0]).toContain('raw application/json document')
+  })
+})
+
+describe('countRefs / landedElsewhere', () => {
+  it('counts ref tokens in any attribute position', () => {
+    expect(countRefs('- link "a" [ref=e1]\n- heading "b" [level=1, ref=e2]\n- StaticText "ref=e3 in text"')).toBe(3)
+    expect(countRefs('(no interactive elements)')).toBe(0)
+  })
+
+  it('ignores scheme, trailing slash, fragment and host case', () => {
+    expect(landedElsewhere('example.com', 'https://example.com/')).toBe(false)
+    expect(landedElsewhere('http://Example.com/a/', 'https://example.com/a#top')).toBe(false)
+  })
+
+  it('detects redirects to another path or host', () => {
+    expect(landedElsewhere('https://app.com/dashboard', 'https://app.com/login?next=%2Fdashboard')).toBe(true)
+    expect(landedElsewhere('https://a.com', 'https://b.com')).toBe(true)
+    expect(landedElsewhere('not a url', 'https://b.com')).toBe(false)
   })
 })
 

--- a/agent-container/src/snapshot-format.ts
+++ b/agent-container/src/snapshot-format.ts
@@ -80,8 +80,8 @@ export function capSnapshot(text: string, scopeUsed: boolean): string {
 
 /**
  * What one page-probe eval tells us alongside the a11y tree. Runs once per
- * snapshot (it replaced the iframe-only probe) so the text facts below cost
- * no extra round trip.
+ * snapshot and once per open (it replaced the iframe-only probe and the
+ * discarded `get url` read) so none of this costs an extra round trip.
  */
 export interface PageProbe {
   iframes: IframeInfo[]
@@ -89,56 +89,206 @@ export interface PageProbe {
   textChars: number
   /** Visible text of live regions: role=alert/status, aria-live (not "off"), <output>. */
   liveRegions: string[]
-  /** First ~240 chars of <main> (or body) text — the page's gist. */
+  /** Opening text of <main> (or body) — the page's gist. Longer when the tree is nearly empty. */
   preview: string
+  /** location.href — '' when the probe could not run (dead browser, no page). */
+  url: string
+  title: string
+  /** document.readyState: loading | interactive | complete. */
+  readyState: string
+  /** Navigation response status from PerformanceNavigationTiming (Chrome 109+); 0 when unknown (cache, file:, old Chrome). */
+  httpStatus: number
+  /** document.contentType, e.g. text/html, application/json, application/pdf. */
+  contentType: string
+  /** Visible loading indicators: aria-busy=true, role=progressbar, skeleton classes. */
+  busy: number
+  /** Bot-challenge vendor detected from title/body signatures, or ''. */
+  blocker: string
+  /** Chrome net-error code (ERR_NAME_NOT_RESOLVED …) when the document is Chrome's error page, or ''. */
+  netError: string
 }
 
-export const EMPTY_PROBE: PageProbe = { iframes: [], textChars: 0, liveRegions: [], preview: '' }
+export const EMPTY_PROBE: PageProbe = {
+  iframes: [], textChars: 0, liveRegions: [], preview: '',
+  url: '', title: '', readyState: '', httpStatus: 0, contentType: '', busy: 0, blocker: '', netError: '',
+}
 
 /** Below this much visible text the "text not shown" footer is noise (blank/loading pages). */
 export const TEXT_FOOTER_MIN_CHARS = 200
 export const PREVIEW_CHARS = 240
+/** Preview length when the tree has fewer than THIN_TREE_REFS refs — the text is all the agent has. */
+export const THIN_TREE_PREVIEW_CHARS = 1500
+export const THIN_TREE_REFS = 5
 const LIVE_REGION_MAX = 8
 const LIVE_REGION_CHARS = 300
+
+/**
+ * Bot-challenge signatures, matched case-insensitively against title + the
+ * first 3k chars of body text (and the URL for Google's /sorry/). Kept to
+ * vendor-specific phrases: a generic "access denied" is often the app's own
+ * auth wall, which the HTTP status and the text already convey.
+ */
+const BLOCKER_SIGNATURES: Array<[string, string]> = [
+  ['Cloudflare', 'just a moment|checking your browser|verify you are human|cloudflare ray id|attention required.{0,40}cloudflare|cf-browser-verification'],
+  ['Imperva/Incapsula', 'incapsula|imperva|incident id|request unsuccessful\\.'],
+  ['Akamai', 'reference #\\d+\\.[0-9a-f]+\\.\\d+|access denied.{0,120}permission to access'],
+  ['Google', '/sorry/|unusual traffic from your computer network'],
+  ['PerimeterX', 'press (&|and) hold|px-captcha|perimeterx'],
+  ['DataDome', 'datadome'],
+  ['CAPTCHA', 'hcaptcha|recaptcha|arkose|funcaptcha'],
+]
 
 /**
  * One eval, one JSON object: cross-origin iframes (their fields are invisible
  * to the a11y tree), how much text the page has (the interactive view drops
  * all of it), what the live regions currently say (validation errors, toasts,
- * status lines), and the opening words of <main>. Each part is wrapped in its
- * own try so a hostile page cannot blank the others. Visibility uses
+ * status lines), the opening words of <main>, and the page's identity and
+ * readiness (URL, title, HTTP status, readyState, content type, loading
+ * indicators, bot-challenge and net-error signatures). Each part is wrapped
+ * in its own try so a hostile page cannot blank the others. Visibility uses
  * getClientRects, not offsetParent — offsetParent is null for position:fixed
  * toasts, which are exactly the live regions we want.
  */
-export const PAGE_PROBE_SCRIPT =
-  '(function(){var o={iframes:[],textChars:0,live:[],preview:""};' +
-  'var ws=function(s){return String(s||"").replace(/\\s+/g," ").trim()};' +
-  'try{o.iframes=[...document.querySelectorAll("iframe")].filter(function(f){return f.offsetParent!==null})' +
-  '.map(function(f){var host="";try{host=new URL(f.src).host}catch(e){}var same=false;try{same=!!f.contentDocument}catch(e){}' +
-  'return{title:f.title||"",host:host,sameOrigin:same}})}catch(e){}' +
-  'try{o.textChars=ws(document.body&&document.body.innerText).length}catch(e){}' +
-  'try{var seen={};var els=document.querySelectorAll(\'[role="alert"],[role="status"],[aria-live]:not([aria-live="off"]),output\');' +
-  'for(var i=0;i<els.length&&o.live.length<' + LIVE_REGION_MAX + ';i++){var el=els[i];if(!el.getClientRects().length)continue;' +
-  'var s=ws(el.innerText);if(!s||seen[s])continue;seen[s]=1;o.live.push(s.slice(0,' + LIVE_REGION_CHARS + '))}}catch(e){}' +
-  'try{var m=document.querySelector("main,[role=main]")||document.body;o.preview=ws(m&&m.innerText).slice(0,' + PREVIEW_CHARS + ')}catch(e){}' +
-  'return JSON.stringify(o)})()'
+export function pageProbeScript(opts: { previewChars?: number } = {}): string {
+  const previewChars = opts.previewChars ?? PREVIEW_CHARS
+  const sigs = JSON.stringify(BLOCKER_SIGNATURES)
+  return (
+    '(function(){var o={iframes:[],textChars:0,live:[],preview:"",url:"",title:"",readyState:"",http:0,contentType:"",busy:0,blocker:"",netError:""};' +
+    'var ws=function(s){return String(s||"").replace(/\\s+/g," ").trim()};var body="";' +
+    'try{o.url=String(location.href||"")}catch(e){}' +
+    'try{o.title=ws(document.title).slice(0,200);o.readyState=String(document.readyState||"");o.contentType=String(document.contentType||"")}catch(e){}' +
+    'try{var nav=performance.getEntriesByType("navigation")[0];o.http=(nav&&nav.responseStatus)|0}catch(e){}' +
+    'try{o.iframes=[...document.querySelectorAll("iframe")].filter(function(f){return f.offsetParent!==null})' +
+    '.map(function(f){var host="";try{host=new URL(f.src).host}catch(e){}var same=false;try{same=!!f.contentDocument}catch(e){}' +
+    'return{title:f.title||"",host:host,sameOrigin:same}})}catch(e){}' +
+    'try{body=ws(document.body&&document.body.innerText);o.textChars=body.length}catch(e){}' +
+    'try{var seen={};var els=document.querySelectorAll(\'[role="alert"],[role="status"],[aria-live]:not([aria-live="off"]),output\');' +
+    'for(var i=0;i<els.length&&o.live.length<' + LIVE_REGION_MAX + ';i++){var el=els[i];if(!el.getClientRects().length)continue;' +
+    'var s=ws(el.innerText);if(!s||seen[s])continue;seen[s]=1;o.live.push(s.slice(0,' + LIVE_REGION_CHARS + '))}}catch(e){}' +
+    'try{var m=document.querySelector("main,[role=main]")||document.body;o.preview=ws(m&&m.innerText).slice(0,' + previewChars + ')}catch(e){}' +
+    'try{var bs=document.querySelectorAll(\'[aria-busy="true"],[role="progressbar"],[class*="skeleton"]\');' +
+    'for(var b=0;b<bs.length;b++){if(bs[b].getClientRects().length)o.busy++}}catch(e){}' +
+    // Chrome's error document: full Chrome renders #main-frame-error with the
+    // ERR_ code in its text; the headless shell shows an empty page whose only
+    // tell is the chrome-error:// URL (verified in the container image).
+    'try{if(document.getElementById("main-frame-error")||/^chrome-error:/.test(o.url)){var em=/\\bERR_[A-Z_]{3,}\\b/.exec(body);o.netError=em?em[0]:"net error"}}catch(e){}' +
+    'try{var hay=(o.title+" "+body.slice(0,3000)).toLowerCase();var sg=' + sigs + ';' +
+    'for(var k=0;k<sg.length&&!o.blocker;k++){if(new RegExp(sg[k][1],"i").test(sg[k][0]==="Google"?hay+" "+o.url:hay))o.blocker=sg[k][0]}}catch(e){}' +
+    'return JSON.stringify(o)})()'
+  )
+}
 
-/** Parse PAGE_PROBE_SCRIPT output (CLI double-JSON-encodes). Never throws; missing parts default empty. */
+export const PAGE_PROBE_SCRIPT = pageProbeScript()
+
+/** Parse page-probe output (CLI double-JSON-encodes). Never throws; missing parts default empty. */
 export function parsePageProbe(stdout: string): PageProbe {
   try {
     let parsed: unknown = JSON.parse(stdout.trim())
     if (typeof parsed === 'string') parsed = JSON.parse(parsed)
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return EMPTY_PROBE
     const p = parsed as Record<string, unknown>
+    const str = (v: unknown): string => (typeof v === 'string' ? v : '')
+    const num = (v: unknown): number => (typeof v === 'number' && v > 0 ? Math.floor(v) : 0)
     return {
       iframes: parseIframeInfo(JSON.stringify(p.iframes ?? [])),
-      textChars: typeof p.textChars === 'number' && p.textChars > 0 ? Math.floor(p.textChars) : 0,
+      textChars: num(p.textChars),
       liveRegions: Array.isArray(p.live) ? p.live.filter((s): s is string => typeof s === 'string' && s.length > 0) : [],
-      preview: typeof p.preview === 'string' ? p.preview : '',
+      preview: str(p.preview),
+      url: str(p.url),
+      title: str(p.title),
+      readyState: str(p.readyState),
+      httpStatus: num(p.http),
+      contentType: str(p.contentType),
+      busy: num(p.busy),
+      blocker: str(p.blocker),
+      netError: str(p.netError),
     }
   } catch {
     return EMPTY_PROBE
   }
+}
+
+/**
+ * Warnings the agent must act on before reading the tree: the site did not
+ * load, a bot wall is up, the server refused, the document is not a web page,
+ * or content is still arriving. Ordered by how completely each one
+ * invalidates what follows. Empty for a healthy page.
+ */
+export function pageWarnings(probe: PageProbe, refCount: number | null): string[] {
+  const warns: string[] = []
+  if (probe.netError) {
+    const code = probe.netError === 'net error' ? '' : ` (${probe.netError})`
+    warns.push(`site unreachable${code} — this is Chrome's error page, not the site. Check the URL or retry.`)
+  }
+  if (probe.blocker) {
+    warns.push(`bot-block: ${probe.blocker} — the site is challenging automated access. Hand it to the user with request_browser_input; more scraping will not get past it.`)
+  }
+  if (probe.httpStatus >= 400) {
+    const why =
+      probe.httpStatus === 401 || probe.httpStatus === 403 ? ' (login or permission required)' :
+      probe.httpStatus === 404 ? ' (not found — check the URL)' :
+      probe.httpStatus === 429 ? ' (rate limited — slow down or ask the user)' : ''
+    warns.push(`HTTP ${probe.httpStatus}${why} — the server refused this page; what follows is the error response, not the content you asked for.`)
+  }
+  if (probe.contentType && !/html/i.test(probe.contentType)) {
+    warns.push(`raw ${probe.contentType} document, not a web page — the tree shows Chrome's viewer. Read the body with fullText:true or browser_eval.`)
+  }
+  if (probe.readyState && probe.readyState !== 'complete') {
+    warns.push(`page still ${probe.readyState} — content may be incomplete. browser_wait for the element you need, then re-snapshot.`)
+  }
+  if (probe.busy > 0) {
+    warns.push(`${probe.busy} loading indicator${probe.busy === 1 ? '' : 's'} visible (aria-busy/progressbar/skeleton) — content still arriving. browser_wait for the element you need, then re-snapshot.`)
+  }
+  if (refCount === 0 && warns.length === 0) {
+    warns.push('no interactive elements — read the page text below before concluding the page is empty; an overlay, a login wall or a plain-text body all look like this.')
+  }
+  return warns
+}
+
+/**
+ * The status line every snapshot starts with: where the browser is, what the
+ * page calls itself, whether the server said yes, whether it finished loading,
+ * and how many refs the tree holds — followed by any warnings. '' when the
+ * probe could not run (no URL), so a dead browser does not get a fake header.
+ */
+export function formatStatusHeader(probe: PageProbe, refCount: number | null): string {
+  if (!probe.url) return ''
+  const facts = [
+    probe.url,
+    probe.title ? JSON.stringify(probe.title.slice(0, 120)) : 'untitled',
+  ]
+  if (probe.httpStatus > 0) facts.push(`HTTP ${probe.httpStatus}`)
+  if (probe.readyState) facts.push(probe.readyState)
+  if (refCount !== null) facts.push(`${refCount} ref${refCount === 1 ? '' : 's'}`)
+  const warns = pageWarnings(probe, refCount)
+  return `[page] ${facts.join(' · ')}` + warns.map(w => `\n⚠ ${w}`).join('')
+}
+
+/** Count the refs a rendered tree exposes (`[ref=e12]`, `[level=1, ref=e2]`). */
+export function countRefs(tree: string): number {
+  return (tree.match(/\bref=e\d+/g) ?? []).length
+}
+
+/**
+ * True when the browser landed somewhere other than what was asked for —
+ * ignoring the differences a normal load introduces (scheme added, http→https
+ * upgrade, trailing slash, fragment, case of the host).
+ */
+export function landedElsewhere(requested: string, landed: string): boolean {
+  const norm = (u: string): string | null => {
+    try {
+      const withScheme = /^[a-z][a-z0-9+.-]*:/i.test(u) ? u : `https://${u}`
+      const p = new URL(withScheme)
+      const path = p.pathname.replace(/\/+$/, '')
+      return `${p.host.toLowerCase()}${path}${p.search}`
+    } catch {
+      return null
+    }
+  }
+  const a = norm(requested)
+  const b = norm(landed)
+  if (a === null || b === null) return false
+  return a !== b
 }
 
 /**

--- a/agent-container/src/snapshot-format.ts
+++ b/agent-container/src/snapshot-format.ts
@@ -155,6 +155,8 @@ export function pageProbeScript(opts: { previewChars?: number } = {}): string {
   return (
     '(function(){var o={iframes:[],textChars:0,live:[],preview:"",url:"",title:"",readyState:"",http:0,contentType:"",busy:0,blocker:"",netError:""};' +
     'var ws=function(s){return String(s||"").replace(/\\s+/g," ").trim()};var body="";' +
+    // checkVisibility also excludes visibility:hidden / opacity:0 (see action-effect.ts).
+    'var vis=function(el){try{if(typeof el.checkVisibility==="function")return el.checkVisibility({visibilityProperty:true,opacityProperty:true,checkVisibilityCSS:true,checkOpacity:true});return el.getClientRects().length>0}catch(e){return false}};' +
     'try{o.url=String(location.href||"")}catch(e){}' +
     'try{o.title=ws(document.title).slice(0,200);o.readyState=String(document.readyState||"");o.contentType=String(document.contentType||"")}catch(e){}' +
     'try{var nav=performance.getEntriesByType("navigation")[0];o.http=(nav&&nav.responseStatus)|0}catch(e){}' +
@@ -163,11 +165,11 @@ export function pageProbeScript(opts: { previewChars?: number } = {}): string {
     'return{title:f.title||"",host:host,sameOrigin:same}})}catch(e){}' +
     'try{body=ws(document.body&&document.body.innerText);o.textChars=body.length}catch(e){}' +
     'try{var seen={};var els=document.querySelectorAll(\'[role="alert"],[role="status"],[aria-live]:not([aria-live="off"]),output\');' +
-    'for(var i=0;i<els.length&&o.live.length<' + LIVE_REGION_MAX + ';i++){var el=els[i];if(!el.getClientRects().length)continue;' +
+    'for(var i=0;i<els.length&&o.live.length<' + LIVE_REGION_MAX + ';i++){var el=els[i];if(!vis(el))continue;' +
     'var s=ws(el.innerText);if(!s||seen[s])continue;seen[s]=1;o.live.push(s.slice(0,' + LIVE_REGION_CHARS + '))}}catch(e){}' +
     'try{var m=document.querySelector("main,[role=main]")||document.body;o.preview=ws(m&&m.innerText).slice(0,' + previewChars + ')}catch(e){}' +
     'try{var bs=document.querySelectorAll(\'[aria-busy="true"],[role="progressbar"],[class*="skeleton"]\');' +
-    'for(var b=0;b<bs.length;b++){if(bs[b].getClientRects().length)o.busy++}}catch(e){}' +
+    'for(var b=0;b<bs.length;b++){if(vis(bs[b]))o.busy++}}catch(e){}' +
     // Chrome's error document: full Chrome renders #main-frame-error with the
     // ERR_ code in its text; the headless shell shows an empty page whose only
     // tell is the chrome-error:// URL (verified in the container image).
@@ -180,7 +182,14 @@ export function pageProbeScript(opts: { previewChars?: number } = {}): string {
 
 export const PAGE_PROBE_SCRIPT = pageProbeScript()
 
-/** Parse page-probe output (CLI double-JSON-encodes). Never throws; missing parts default empty. */
+/**
+ * Parse page-probe output. Accepts the raw eval shape (`http`, `live`; CLI
+ * double-JSON-encodes it) and the normalized PageProbe shape the server
+ * forwards to the tools (`httpStatus`, `liveRegions`) — the browser_open tool
+ * re-parses the server's `page` field, and reading only the raw keys there
+ * silently dropped the HTTP status (caught driving the built container).
+ * Never throws; missing parts default empty.
+ */
 export function parsePageProbe(stdout: string): PageProbe {
   try {
     let parsed: unknown = JSON.parse(stdout.trim())
@@ -189,15 +198,16 @@ export function parsePageProbe(stdout: string): PageProbe {
     const p = parsed as Record<string, unknown>
     const str = (v: unknown): string => (typeof v === 'string' ? v : '')
     const num = (v: unknown): number => (typeof v === 'number' && v > 0 ? Math.floor(v) : 0)
+    const strs = (v: unknown): string[] => (Array.isArray(v) ? v.filter((s): s is string => typeof s === 'string' && s.length > 0) : [])
     return {
       iframes: parseIframeInfo(JSON.stringify(p.iframes ?? [])),
       textChars: num(p.textChars),
-      liveRegions: Array.isArray(p.live) ? p.live.filter((s): s is string => typeof s === 'string' && s.length > 0) : [],
+      liveRegions: strs(p.live ?? p.liveRegions),
       preview: str(p.preview),
       url: str(p.url),
       title: str(p.title),
       readyState: str(p.readyState),
-      httpStatus: num(p.http),
+      httpStatus: num(p.http ?? p.httpStatus),
       contentType: str(p.contentType),
       busy: num(p.busy),
       blocker: str(p.blocker),

--- a/agent-container/src/tools/browser.test.ts
+++ b/agent-container/src/tools/browser.test.ts
@@ -106,7 +106,7 @@ describe('browser_open location', () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
       success: true,
       location: 'host',
-      page: { url: 'https://app.com/login?next=%2Fdashboard', title: 'Sign in', readyState: 'complete', http: 200, contentType: 'text/html' },
+      page: { url: 'https://app.com/login?next=%2Fdashboard', title: 'Sign in', readyState: 'complete', httpStatus: 200, contentType: 'text/html' },
     }), { status: 200, headers: { 'Content-Type': 'application/json' } })))
 
     const openTool = createBrowserTools(() => 'session-4')
@@ -122,7 +122,7 @@ describe('browser_open location', () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
       success: true,
       location: 'host',
-      page: { url: 'https://drinkolipop.com/', title: '', readyState: 'complete', http: 429, contentType: 'text/plain', preview: 'local_rate_limited' },
+      page: { url: 'https://drinkolipop.com/', title: '', readyState: 'complete', httpStatus: 429, contentType: 'text/plain', preview: 'local_rate_limited' },
     }), { status: 200, headers: { 'Content-Type': 'application/json' } })))
 
     const openTool = createBrowserTools(() => 'session-5')

--- a/agent-container/src/tools/browser.test.ts
+++ b/agent-container/src/tools/browser.test.ts
@@ -102,6 +102,55 @@ describe('browser_open location', () => {
     expect(result.content[0].text).toContain(BROWSER_USE_GUIDANCE_HINT)
   })
 
+  it('reports the landing page — final URL, redirect, HTTP status — when the server probed it', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      success: true,
+      location: 'host',
+      page: { url: 'https://app.com/login?next=%2Fdashboard', title: 'Sign in', readyState: 'complete', http: 200, contentType: 'text/html' },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })))
+
+    const openTool = createBrowserTools(() => 'session-4')
+      .find(candidate => candidate.name === 'browser_open') as any
+    const result = await openTool.handler({ url: 'https://app.com/dashboard' })
+
+    expect(result.isError).toBeUndefined()
+    expect(result.content[0].text).toContain('Loaded "Sign in" at https://app.com/login?next=%2Fdashboard (redirected from https://app.com/dashboard) · HTTP 200')
+    expect(result.content[0].text).not.toContain('navigating to')
+  })
+
+  it('is an error, with the page text, when the landing page is a bot wall or HTTP error', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      success: true,
+      location: 'host',
+      page: { url: 'https://drinkolipop.com/', title: '', readyState: 'complete', http: 429, contentType: 'text/plain', preview: 'local_rate_limited' },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })))
+
+    const openTool = createBrowserTools(() => 'session-5')
+      .find(candidate => candidate.name === 'browser_open') as any
+    const result = await openTool.handler({ url: 'https://drinkolipop.com' })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('Loaded an untitled page at https://drinkolipop.com/ · HTTP 429')
+    expect(result.content[0].text).toContain('⚠ HTTP 429 (rate limited')
+    expect(result.content[0].text).toContain('⚠ raw text/plain document')
+    expect(result.content[0].text).toContain('Page text: "local_rate_limited"')
+  })
+
+  it('falls back to intent-shaped text, and says so, when the probe could not run', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      success: true,
+      location: 'host',
+      page: { url: '' },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })))
+
+    const openTool = createBrowserTools(() => 'session-6')
+      .find(candidate => candidate.name === 'browser_open') as any
+    const result = await openTool.handler({ url: 'https://example.com' })
+
+    expect(result.content[0].text).toContain('navigating to https://example.com')
+    expect(result.content[0].text).toContain('landing page could not be read')
+  })
+
   it('omits location so the server can preserve the current browser', async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
       success: true,

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -17,6 +17,7 @@ import {
 import { hostAuthHeaders } from '../host-auth'
 import { tabManager } from '../tab-manager'
 import { formatUrlDigest, formatUrlDigestBrief, formatFillReadback, formatScrollDigest, type UrlDigest, type ScrollInfo } from '../browser-digest'
+import { landedElsewhere, pageWarnings, parsePageProbe, EMPTY_PROBE } from '../snapshot-format'
 
 const CONTAINER_URL = `http://localhost:${process.env.PORT || '3000'}`
 // Conditional on purpose: it has to agree with the prompt, which tells a parent
@@ -140,11 +141,29 @@ Omit location to keep using the current browser where it is; when no browser is 
       }
     }
 
+    // Report where the browser landed, not what was asked for. The server's
+    // page probe is the source; when it could not run (dead page, eval
+    // blocked) fall back to the old intent-shaped text and say so.
+    const page = data?.page ? parsePageProbe(JSON.stringify(data.page)) : EMPTY_PROBE
+    if (page.url) {
+      const title = page.title ? JSON.stringify(page.title.slice(0, 120)) : 'an untitled page'
+      const redirect = landedElsewhere(args.url, page.url) ? ` (redirected from ${args.url})` : ''
+      const http = page.httpStatus > 0 ? ` · HTTP ${page.httpStatus}` : ''
+      const warns = pageWarnings(page, null)
+      const severe = Boolean(page.netError || page.blocker || page.httpStatus >= 400)
+      const text =
+        `Loaded ${title} at ${page.url}${redirect}${http} in ${locationText}.${switchText}` +
+        warns.map(w => `\n⚠ ${w}`).join('') +
+        (severe && page.preview ? `\nPage text: ${JSON.stringify(page.preview.slice(0, 400))}` : '') +
+        ` The user can see the browser live. Use browser_snapshot to see the page content.${localhostWarning}\n\n${BROWSER_USE_GUIDANCE_HINT}`
+      return { content: [{ type: 'text' as const, text }], ...(severe ? { isError: true } : {}) }
+    }
+
     return {
       content: [
         {
           type: 'text' as const,
-          text: `Browser opened in ${locationText} and navigating to ${args.url}.${switchText} The user can see the browser live. Use browser_snapshot to see the page content.${localhostWarning}\n\n${BROWSER_USE_GUIDANCE_HINT}`,
+          text: `Browser opened in ${locationText} and navigating to ${args.url}.${switchText} The landing page could not be read — take a browser_snapshot to see where you are; its status line shows the URL, title and HTTP status.${localhostWarning}\n\n${BROWSER_USE_GUIDANCE_HINT}`,
         },
       ],
     }
@@ -321,7 +340,7 @@ const browserScrollTool = tool(
 
 const browserWaitTool = tool(
   'browser_wait',
-  `Wait for a CSS selector to appear on the page. Only use this when you need to wait for a specific element to render (e.g. after triggering dynamic content). Do NOT use for "networkidle", "load", or "domcontentloaded" — browser_open already waits for the page to load.`,
+  `Wait for a CSS selector to appear on the page. Use it after triggering dynamic content, or when a snapshot's status line says the page is still loading or shows loading indicators — wait for the element you need instead of re-snapshotting in a loop. Do NOT pass "networkidle", "load", or "domcontentloaded" — browser_open already waits for the page to load and reports the landing page.`,
   {
     for: z
       .string()

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -16,7 +16,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - `browser_select(ref, value)` — Select an option in a NATIVE `<select>` (by value or visible label; commit is verified). Custom dropdowns (role=combobox/listbox divs): click the trigger, re-snapshot, type into the filter input, click the option's FRESH ref — refs renumber after each committed selection, so re-snapshot between selections
 - `browser_upload(filePath, selector?)` — Upload a local file into an `<input type="file">`. Use this for Dropbox, Box, Dropzone, and any file picker flow.
 - `browser_download(url, filename?)` — Download a file/image/asset through the browser (cookies + login state apply) into `/workspace/downloads/`. To save an image: get its URL first (`browser_run("get attr @e5 src")` or `browser_eval`), then download it. Report the returned path to the parent agent.
-- `browser_wait(for)` — Wait for a CSS selector to appear on the page. Do NOT use for load states — `browser_open` already waits for the page to load.
+- `browser_wait(for)` — Wait for a CSS selector to appear on the page. Use it when a snapshot's status line says the page is still loading or busy, or after triggering dynamic content — not in a re-snapshot loop. Not for load states: `browser_open` waits for the load and reports the landing page.
 - `browser_screenshot(full?)` — Take a screenshot (returns file path; use Read to see the image)
 
 **Navigation:**
@@ -41,6 +41,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - `request_file(description, fileTypes?)` — Open an upload prompt for the user when you need a file but don't have one available locally. Returns a `/workspace/...` path you can pass to `browser_upload`.
 
 ## Core Workflow
+0. **Read the status line first.** `browser_open` reports where the browser actually landed (final URL, title, HTTP status), and every snapshot starts with `[page] URL · "title" · HTTP status · readyState · N refs`. A `⚠` there (site unreachable, bot-block, HTTP 4xx/5xx, raw file, still loading) is the first thing to act on: a bot-block or login wall means `request_browser_input`, not more scraping; "still loading" means `browser_wait`, not a re-snapshot loop.
 1. Start with `browser_snapshot()` to see the current page state
 2. Interact using refs: `browser_click("@e1")`, `browser_fill("@e2", "text")`
 3. `browser_press("Enter")` to submit forms after filling inputs


### PR DESCRIPTION
**Stacked on #1043** (it extends the page probe that PR adds). Base is `fix/snapshot-text-visibility`; retarget to `main` once #1043 merges.

## Why

Theme 2 of the transcript-mining report (130/200 reviewed sessions): `browser_open` echoed the requested URL for a 200, a 429, a login redirect and `about:blank` alike, and no snapshot carried URL, title, HTTP status or readiness. `(no interactive elements)` was the same string for a hydrating SPA, a 401 JSON body, a Chrome net-error page and an Imperva ban. One session spent 120 calls on a rate-limited site before `network requests` revealed the 429.

## What changed

- **Probe** (the one eval per snapshot from #1043) now also reads `location.href`, title, `readyState`, `document.contentType`, the navigation response status via `PerformanceNavigationTiming.responseStatus` (Chrome 109+, no CDP), visible loading indicators, Chrome net-error pages, and bot-wall signatures (Cloudflare, Imperva, Akamai, Google sorry, PerimeterX, DataDome, CAPTCHA vendors).
- **Status line on every snapshot / get_state**: `[page] URL · "title" · HTTP 200 · complete · 84 refs`, then `⚠` lines ordered by how much each invalidates the tree, each with the action to take (request_browser_input for a bot wall, browser_wait when still loading). Trees with fewer than 5 refs get a 1,500-char text preview.
- **`browser_open` reports the landing, not the intent**: the discarded `get url` read becomes the probe. Text is `Loaded "Sign in" at <final url> (redirected from <requested>) · HTTP 200`; a net error, bot wall or HTTP ≥ 400 is returned as a tool error with the page text attached. If the probe cannot run, the old text is used with an explicit "landing page could not be read".
- **Prompt and docs**: read the status line first; `browser_wait` guidance no longer says "browser_open already waits" as the reason never to wait.

Cut from the report's proposal on purpose: an `observe:` parameter on open, in-flight request counts, cookie-based classifiers, viewport size, and a header on screenshot results.

## Verified

- 57 tests across `snapshot-format.test.ts` and `tools/browser.test.ts`, including the probe script executed against a fake DOM for every signature and the three new open-tool outcomes.
- `tsc --noEmit` and `eslint` clean.
- Real CLI in the container image (`superagent-container:browser-stack-1001`):
  - `example.org/definitely-missing-page` renders a normal-looking tree (heading + link) while `responseStatus` reports **404**. Exactly the case the header is for.
  - A dead host lands on `chrome-error://chromewebdata/` with an empty body and no `#main-frame-error`, so detection also keys on the URL (found by this check, fixed, test added).
  - A normal page: `HTTP 200 · complete`, both live regions, iframe, preview.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01792FWz3b1emZ8z1H1DyP3u
