### PR TITLE
fix(browser): wait up to 2s for a loading document before taking a snapshot

### DIFF
--- a/agent-container/docs/browser-use.md
+++ b/agent-container/docs/browser-use.md
@@ -42,7 +42,8 @@ footer reports how much page text was dropped and what the live regions
 Every snapshot starts with a status line: `[page] URL · "title" · HTTP status ·
 readyState · N refs`, followed by `⚠` warnings when the site is unreachable, a
 bot challenge is up, the server answered 4xx/5xx, the document is a raw file, or
-content is still loading. `browser_open` reports the same facts for the page it
+content is still loading (a snapshot first waits up to 2s for a loading
+document, so "still loading" means the page is genuinely slow). `browser_open` reports the same facts for the page it
 actually landed on (final URL, redirect, HTTP status) and is marked as an error
 when that page is a net error, a bot wall or an HTTP error. Act on a warning
 before reading the tree: a bot wall or login page needs the user, a loading page

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -817,7 +817,7 @@ import { resolveCommittedValue } from './field-value-readback';
 import { capBrowserOutput, redactCdpUrls, MAX_BROWSER_OUTPUT_CHARS, MAX_BROWSER_ERROR_CHARS } from './browser-output';
 import {
   capSnapshot, compactWithText, countRefs, formatIframePlaceholders, formatStatusHeader, formatTextFooter,
-  pageProbeScript, parsePageProbe, EMPTY_PROBE, THIN_TREE_PREVIEW_CHARS, THIN_TREE_REFS,
+  pageProbeScript, parsePageProbe, waitForDocumentReady, EMPTY_PROBE, THIN_TREE_PREVIEW_CHARS, THIN_TREE_REFS,
 } from './snapshot-format';
 import { diffFingerprints, fingerprintScript, parseFingerprint, HOVER_SETTLE_MS, type ActionEffect } from './action-effect';
 import {
@@ -1496,6 +1496,16 @@ app.post('/browser/snapshot', async (c) => {
     if (body.scope) snapshotArgs.push('-s', body.scope);
     if (body.includeUrls) snapshotArgs.push('--urls');
 
+    // A snapshot right after a navigation used to return `loading · 0 refs`;
+    // wait briefly for the document to finish loading before reading it, so
+    // the common "press Enter, snapshot" sequence lands on the real page.
+    const { waitedMs } = await waitForDocumentReady(async () => {
+      const r = await execBrowser(['eval', 'document.readyState'], browserState.cdpUrl || undefined);
+      if (r.exitCode !== 0) return null;
+      const s = r.stdout.trim().replace(/^"|"$/g, '');
+      return s || null;
+    });
+
     const result = await execBrowser(snapshotArgs, browserState.cdpUrl || undefined);
 
     if (result.exitCode !== 0) {
@@ -1529,7 +1539,7 @@ app.post('/browser/snapshot', async (c) => {
     const fullText = Boolean(body.fullText);
     const tree = fullText && body.compact !== false ? compactWithText(result.stdout) : result.stdout;
 
-    const header = formatStatusHeader(probe, refCount);
+    const header = formatStatusHeader(probe, refCount, { waitedMs });
     return c.json({
       snapshot:
         (header ? `${header}\n\n` : '') +

--- a/agent-container/src/snapshot-format.test.ts
+++ b/agent-container/src/snapshot-format.test.ts
@@ -10,6 +10,7 @@ import {
   pageWarnings,
   countRefs,
   landedElsewhere,
+  waitForDocumentReady,
   pageProbeScript,
   PAGE_PROBE_SCRIPT,
   EMPTY_PROBE,
@@ -265,6 +266,50 @@ describe('pageWarnings / formatStatusHeader', () => {
     expect(pageWarnings({ ...healthy, httpStatus: 401 }, 1)[0]).toContain('login or permission required')
     expect(pageWarnings({ ...healthy, httpStatus: 404 }, 1)[0]).toContain('not found')
     expect(pageWarnings({ ...healthy, contentType: 'application/json' }, 1)[0]).toContain('raw application/json document')
+  })
+})
+
+describe('waitForDocumentReady', () => {
+  function clock() {
+    let t = 0
+    return { now: () => t, sleep: async (ms: number) => { t += ms } }
+  }
+
+  it('returns at once when the document is already complete', async () => {
+    const c = clock()
+    const reads: string[] = []
+    const out = await waitForDocumentReady(async () => { reads.push('r'); return 'complete' }, { ...c, timeoutMs: 2000, pollMs: 150 })
+    expect(out).toEqual({ readyState: 'complete', waitedMs: 0 })
+    expect(reads).toHaveLength(1)
+  })
+
+  it('polls until complete and reports how long it waited', async () => {
+    const c = clock()
+    const states = ['loading', 'loading', 'interactive', 'complete']
+    const out = await waitForDocumentReady(async () => states.shift() ?? 'complete', { ...c, timeoutMs: 2000, pollMs: 150 })
+    expect(out).toEqual({ readyState: 'complete', waitedMs: 450 })
+  })
+
+  it('gives up at the timeout and returns the last state', async () => {
+    const c = clock()
+    const out = await waitForDocumentReady(async () => 'loading', { ...c, timeoutMs: 2000, pollMs: 150 })
+    expect(out.readyState).toBe('loading')
+    expect(out.waitedMs).toBeGreaterThanOrEqual(2000)
+  })
+
+  it('stops when the read fails (dead page) instead of spinning', async () => {
+    const c = clock()
+    let n = 0
+    const out = await waitForDocumentReady(async () => { n++; return null }, { ...c })
+    expect(out).toEqual({ readyState: null, waitedMs: 0 })
+    expect(n).toBe(1)
+  })
+
+  it('names the wait in the still-loading warning', () => {
+    const loading = { ...EMPTY_PROBE, url: 'https://a.com', readyState: 'loading' }
+    expect(pageWarnings(loading, 0, { waitedMs: 2010 })[0]).toMatch(/^page still loading after waiting 2\.0s — /)
+    expect(pageWarnings(loading, 0, { waitedMs: 30 })[0]).toMatch(/^page still loading — /)
+    expect(formatStatusHeader(loading, 0, { waitedMs: 2010 })).toContain('after waiting 2.0s')
   })
 })
 

--- a/agent-container/src/snapshot-format.ts
+++ b/agent-container/src/snapshot-format.ts
@@ -224,7 +224,7 @@ export function parsePageProbe(stdout: string): PageProbe {
  * or content is still arriving. Ordered by how completely each one
  * invalidates what follows. Empty for a healthy page.
  */
-export function pageWarnings(probe: PageProbe, refCount: number | null): string[] {
+export function pageWarnings(probe: PageProbe, refCount: number | null, opts: { waitedMs?: number } = {}): string[] {
   const warns: string[] = []
   if (probe.netError) {
     const code = probe.netError === 'net error' ? '' : ` (${probe.netError})`
@@ -244,7 +244,8 @@ export function pageWarnings(probe: PageProbe, refCount: number | null): string[
     warns.push(`raw ${probe.contentType} document, not a web page — the tree shows Chrome's viewer. Read the body with fullText:true or browser_eval.`)
   }
   if (probe.readyState && probe.readyState !== 'complete') {
-    warns.push(`page still ${probe.readyState} — content may be incomplete. browser_wait for the element you need, then re-snapshot.`)
+    const waited = opts.waitedMs && opts.waitedMs >= 100 ? ` after waiting ${(opts.waitedMs / 1000).toFixed(1)}s` : ''
+    warns.push(`page still ${probe.readyState}${waited} — content may be incomplete. browser_wait for the element you need, then re-snapshot.`)
   }
   if (probe.busy > 0) {
     warns.push(`${probe.busy} loading indicator${probe.busy === 1 ? '' : 's'} visible (aria-busy/progressbar/skeleton) — content still arriving. browser_wait for the element you need, then re-snapshot.`)
@@ -261,7 +262,7 @@ export function pageWarnings(probe: PageProbe, refCount: number | null): string[
  * and how many refs the tree holds — followed by any warnings. '' when the
  * probe could not run (no URL), so a dead browser does not get a fake header.
  */
-export function formatStatusHeader(probe: PageProbe, refCount: number | null): string {
+export function formatStatusHeader(probe: PageProbe, refCount: number | null, opts: { waitedMs?: number } = {}): string {
   if (!probe.url) return ''
   const facts = [
     probe.url,
@@ -270,8 +271,36 @@ export function formatStatusHeader(probe: PageProbe, refCount: number | null): s
   if (probe.httpStatus > 0) facts.push(`HTTP ${probe.httpStatus}`)
   if (probe.readyState) facts.push(probe.readyState)
   if (refCount !== null) facts.push(`${refCount} ref${refCount === 1 ? '' : 's'}`)
-  const warns = pageWarnings(probe, refCount)
+  const warns = pageWarnings(probe, refCount, opts)
   return `[page] ${facts.join(' · ')}` + warns.map(w => `\n⚠ ${w}`).join('')
+}
+
+/** How long a snapshot waits for a loading document before giving up and reporting it as loading. */
+export const SNAPSHOT_READY_WAIT_MS = 2000
+export const SNAPSHOT_READY_POLL_MS = 150
+
+/**
+ * Wait for document.readyState to reach "complete", polling `read` until
+ * `timeoutMs`. A snapshot taken right after a navigation (Enter on a search
+ * box, a link click) came back as `loading · 0 refs` 7ms later; the header
+ * said so, but the agent still paid a round trip to wait and ask again. A
+ * read that fails (null) ends the wait — the header will show the truth.
+ */
+export async function waitForDocumentReady(
+  read: () => Promise<string | null>,
+  opts: { timeoutMs?: number; pollMs?: number; sleep?: (ms: number) => Promise<void>; now?: () => number } = {},
+): Promise<{ readyState: string | null; waitedMs: number }> {
+  const timeoutMs = opts.timeoutMs ?? SNAPSHOT_READY_WAIT_MS
+  const pollMs = opts.pollMs ?? SNAPSHOT_READY_POLL_MS
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)))
+  const now = opts.now ?? (() => Date.now())
+  const start = now()
+  let readyState = await read()
+  while (readyState !== null && readyState !== 'complete' && now() - start < timeoutMs) {
+    await sleep(pollMs)
+    readyState = await read()
+  }
+  return { readyState, waitedMs: now() - start }
 }
 
 /** Count the refs a rendered tree exposes (`[ref=e12]`, `[level=1, ref=e2]`). */


### PR DESCRIPTION
**Stacked on #1047** (→ #1045 → #1043). Retarget as the chain merges.

## Why

Validating the stack against real sites: a snapshot taken right after `Enter` on Wikipedia's search box returned 7ms later as `[page] … · untitled · HTTP 200 · loading · 0 refs` with the still-loading warning. Correct, but the agent then pays a `browser_wait` plus a second snapshot for the most common sequence there is.

## What changed

- `waitForDocumentReady()` in `snapshot-format.ts`: poll a reader until `complete`, up to a timeout; stops at once if the read fails.
- `/browser/snapshot` polls `document.readyState` (one ~3ms eval) every 150ms for up to 2s before reading the tree. `browser_get_state` inherits it.
- The still-loading warning names the wait: `page still loading after waiting 2.0s — …`, so a genuinely slow page is distinguishable from an instant read.

Cost on an already-loaded page: one tiny eval. Nothing changes for `browser_open` (the CLI already waits for load) or for actions.

## Verified

- 5 new unit tests with an injected clock: immediate return, poll-until-complete with the waited time, timeout, dead-read stop, and the warning text.
- `tsc --noEmit` and `eslint` clean.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01792FWz3b1emZ8z1H1DyP3u
