### PR TITLE
fix(browser): re-read before claiming "no DOM change"; report typed field values

### DIFF
--- a/agent-container/src/action-effect.test.ts
+++ b/agent-container/src/action-effect.test.ts
@@ -173,6 +173,12 @@ describe('focused field value', () => {
   it('effectHasChange is false for an identical fingerprint', () => {
     expect(effectHasChange(diffFingerprints(base, { ...base }))).toBe(false)
   })
+
+  it('a focus move counts as a change for press but not for click (the click itself moves focus)', () => {
+    const moved = diffFingerprints(base, { ...base, focus: 'button "Add to cart"' })
+    expect(effectHasChange(moved, { countFocus: true })).toBe(true)
+    expect(effectHasChange(moved, { countFocus: false })).toBe(false)
+  })
 })
 
 describe('diffFingerprints + formatActionEffect', () => {

--- a/agent-container/src/action-effect.test.ts
+++ b/agent-container/src/action-effect.test.ts
@@ -3,6 +3,7 @@ import {
   fingerprintScript,
   parseFingerprint,
   diffFingerprints,
+  effectHasChange,
   formatActionEffect,
   type Fingerprint,
 } from './action-effect'
@@ -134,7 +135,7 @@ describe('parseFingerprint', () => {
     }))
     expect(parseFingerprint(raw)).toEqual({
       t: 12.5, url: 'https://a.com', interactive: 3, top: [{ kind: 'dialog', name: 'X' }],
-      live: ['ok'], textLen: 10, textHash: -5, focus: 'button "Go"',
+      live: ['ok'], textLen: 10, textHash: -5, focus: 'button "Go"', focusValue: '',
       failed: [{ url: '/a', status: 500, initiator: 'fetch' }],
     })
   })
@@ -146,8 +147,33 @@ describe('parseFingerprint', () => {
 })
 
 const base: Fingerprint = {
-  t: 0, url: 'https://a.com', interactive: 40, top: [], live: [], textLen: 500, textHash: 1, focus: 'nothing focused', failed: [],
+  t: 0, url: 'https://a.com', interactive: 40, top: [], live: [], textLen: 500, textHash: 1, focus: 'nothing focused', focusValue: '', failed: [],
 }
+
+describe('focused field value', () => {
+  it('is read from inputs and contenteditables', () => {
+    expect(run({ active: { ...el({ tag: 'input', label: 'Search' }), value: '  clay run gtm ' } }).out.focusValue).toBe('clay run gtm')
+    expect(run({ active: { ...el({ tag: 'div', role: 'textbox', label: 'Message', text: 'Hello there' }), isContentEditable: true } }).out.focusValue).toBe('Hello there')
+  })
+
+  it('reports typing into the focused field as an effect, which the page text cannot see', () => {
+    const before: Fingerprint = { ...base, focus: 'textbox "Search"', focusValue: '' }
+    const after: Fingerprint = { ...base, focus: 'textbox "Search"', focusValue: 'monday' }
+    const effect = diffFingerprints(before, after)
+    expect(effectHasChange(effect)).toBe(true)
+    expect(formatActionEffect(effect, { settleMs: 50, verb: 'press' })).toBe('\nEffect: field value now "monday" · focus: textbox "Search"')
+  })
+
+  it('does not count a value difference when focus moved to another field', () => {
+    const effect = diffFingerprints({ ...base, focus: 'textbox "A"', focusValue: 'x' }, { ...base, focus: 'textbox "B"', focusValue: '' })
+    expect(effect.focusValueChanged).toBe(false)
+    expect(effect.focusChanged).toBe(true)
+  })
+
+  it('effectHasChange is false for an identical fingerprint', () => {
+    expect(effectHasChange(diffFingerprints(base, { ...base }))).toBe(false)
+  })
+})
 
 describe('diffFingerprints + formatActionEffect', () => {
   it('reports a dialog opening with its census and announcement', () => {
@@ -191,7 +217,7 @@ describe('diffFingerprints + formatActionEffect', () => {
     expect(formatActionEffect(moved, { settleMs: 50, verb: 'press' })).toBe('\nEffect: focus: textbox "Search"')
     const stayed = diffFingerprints({ ...base, focus: 'textbox "Search"' }, { ...base, focus: 'textbox "Search"' })
     expect(formatActionEffect(stayed, { settleMs: 50, verb: 'press' })).toBe(
-      '\nEffect: no DOM change within 50ms — the key may have been ignored by the focused element. Check what is focused, or browser_wait for what you expect to appear. (focus: textbox "Search")',
+      '\nEffect: no DOM change within 50ms — nothing visible moved — normal for a modifier combo like Control+a or a key the page consumes silently; otherwise the key may have been ignored by the focused element. browser_wait for what you expect to appear. (focus: textbox "Search")',
     )
     const typed = diffFingerprints({ ...base, focus: 'textbox "Search"' }, { ...base, focus: 'textbox "Search"', interactive: 45 })
     expect(formatActionEffect(typed, { settleMs: 50, verb: 'press' })).toBe('\nEffect: +5 interactive elements · focus: textbox "Search"')

--- a/agent-container/src/action-effect.ts
+++ b/agent-container/src/action-effect.ts
@@ -39,6 +39,8 @@ export interface Fingerprint {
   textLen: number
   textHash: number
   focus: string
+  /** Value of the focused field (input/textarea/contenteditable), capped — typing changes this, not the page text. */
+  focusValue: string
   failed: FailedRequest[]
 }
 
@@ -61,7 +63,7 @@ const MAX_FAILED = 5
 export function fingerprintScript(since?: number): string {
   const sinceExpr = typeof since === 'number' && Number.isFinite(since) ? String(since) : 'null'
   return (
-    '(function(){var o={t:0,url:"",interactive:0,top:[],live:[],textLen:0,textHash:0,focus:"",failed:[]};' +
+    '(function(){var o={t:0,url:"",interactive:0,top:[],live:[],textLen:0,textHash:0,focus:"",focusValue:"",failed:[]};' +
     'var ws=function(s){return String(s||"").replace(/\\s+/g," ").trim()};' +
     // checkVisibility covers visibility:hidden / opacity:0, which is how many
     // dropdowns hide their closed state (Wikipedia's Vector menu keeps layout
@@ -93,7 +95,8 @@ export function fingerprintScript(since?: number): string {
     'try{var a=document.activeElement;if(!a||a===document.body){o.focus="nothing focused"}else{' +
     'var tag=a.tagName.toLowerCase();var role=a.getAttribute("role");var an=a.getAttribute("aria-label")||(a.labels&&a.labels[0]&&a.labels[0].innerText)||a.getAttribute("placeholder")||a.getAttribute("name")||a.innerText||"";' +
     'var implied={a:"link",input:a.type==="checkbox"||a.type==="radio"||a.type==="submit"||a.type==="button"?a.type:"textbox",select:"combobox",textarea:"textbox"};' +
-    'o.focus=(role||implied[tag]||tag)+(an?" "+JSON.stringify(ws(an).slice(0,60)):"")}}catch(e){}' +
+    'o.focus=(role||implied[tag]||tag)+(an?" "+JSON.stringify(ws(an).slice(0,60)):"");' +
+    'var fv=typeof a.value==="string"?a.value:(a.isContentEditable?a.innerText:"");o.focusValue=ws(fv).slice(0,120)}}catch(e){}' +
     'return JSON.stringify(o)})()'
   )
 }
@@ -128,6 +131,7 @@ export function parseFingerprint(stdout: string): Fingerprint | null {
       textLen: num(p.textLen),
       textHash: num(p.textHash),
       focus: str(p.focus),
+      focusValue: str(p.focusValue),
       failed,
     }
   } catch {
@@ -145,7 +149,18 @@ export interface ActionEffect {
   textDelta: number
   focus: string
   focusChanged: boolean
+  /** The focused field's value after the action, when it changed (typing, select-all-then-type, clear). */
+  focusValueChanged: boolean
+  focusValue: string
   failed: FailedRequest[]
+}
+
+/** True when the diff found anything at all — used to decide on a second, later read. */
+export function effectHasChange(e: ActionEffect): boolean {
+  return (
+    e.opened.length > 0 || e.closed.length > 0 || e.announced.length > 0 || e.failed.length > 0 ||
+    e.interactiveDelta !== 0 || e.textChanged || e.focusChanged || e.focusValueChanged
+  )
 }
 
 const topKey = (e: TopLayerEntry): string => `${e.kind}|${e.name}`
@@ -164,6 +179,8 @@ export function diffFingerprints(before: Fingerprint, after: Fingerprint): Actio
     textDelta: after.textLen - before.textLen,
     focus: after.focus,
     focusChanged: after.focus !== before.focus,
+    focusValueChanged: after.focus === before.focus && after.focusValue !== before.focusValue,
+    focusValue: after.focusValue,
     failed: after.failed,
   }
 }
@@ -177,7 +194,7 @@ export interface EffectFormatOptions {
 
 const NO_CHANGE_HINT: Record<EffectFormatOptions['verb'], string> = {
   click: 'the element may not be handling clicks (disabled, covered, or needs a different target). Check its state, or browser_wait for what you expect to appear.',
-  press: 'the key may have been ignored by the focused element. Check what is focused, or browser_wait for what you expect to appear.',
+  press: 'nothing visible moved — normal for a modifier combo like Control+a or a key the page consumes silently; otherwise the key may have been ignored by the focused element. browser_wait for what you expect to appear.',
   select: 'the page may not have reacted to the new value yet. browser_wait for what you expect to appear.',
   hover: 'nothing opened on hover. Try browser_click on the element instead.',
 }
@@ -204,6 +221,9 @@ export function formatActionEffect(effect: ActionEffect | null, opts: EffectForm
     const size = d === 0 ? 'same length, different content' : `${d > 0 ? '+' : '−'}${Math.abs(d).toLocaleString('en-US')} chars`
     parts.push(`page text changed (${size})`)
   }
+  if (effect.focusValueChanged) {
+    parts.push(`field value now ${JSON.stringify(effect.focusValue)}`)
+  }
   const focusNote = opts.verb === 'press' && effect.focus ? `focus: ${effect.focus}` : ''
   if (parts.length === 0 && !(opts.verb === 'press' && effect.focusChanged)) {
     return `\nEffect: no DOM change within ${opts.settleMs}ms — ${NO_CHANGE_HINT[opts.verb]}${focusNote ? ` (${focusNote})` : ''}`
@@ -211,6 +231,15 @@ export function formatActionEffect(effect: ActionEffect | null, opts: EffectForm
   if (focusNote) parts.push(focusNote)
   return `\nEffect: ${parts.join(' · ')}`
 }
+
+/**
+ * When the first read after the settle finds nothing, wait this much longer
+ * (from the action) and read once more before claiming "no DOM change".
+ * A Shopify add-to-cart opened its drawer after the 300ms read and the
+ * result said the click did nothing; the second read costs only the cases
+ * that would otherwise be reported as inert.
+ */
+export const NO_CHANGE_RECHECK_MS = 1200
 
 /** Settle before the "after" read on hover (menus animate open). */
 export const HOVER_SETTLE_MS = 300

--- a/agent-container/src/action-effect.ts
+++ b/agent-container/src/action-effect.ts
@@ -155,11 +155,17 @@ export interface ActionEffect {
   failed: FailedRequest[]
 }
 
-/** True when the diff found anything at all — used to decide on a second, later read. */
-export function effectHasChange(e: ActionEffect): boolean {
+/**
+ * True when the diff found anything the result will report — used to decide
+ * on a second, later read. Focus only counts for press: a click moves focus
+ * to the clicked element, which the click result does not treat as an effect,
+ * so counting it there skipped the re-read and still printed "no DOM change".
+ */
+export function effectHasChange(e: ActionEffect, opts: { countFocus?: boolean } = {}): boolean {
+  const countFocus = opts.countFocus ?? true
   return (
     e.opened.length > 0 || e.closed.length > 0 || e.announced.length > 0 || e.failed.length > 0 ||
-    e.interactiveDelta !== 0 || e.textChanged || e.focusChanged || e.focusValueChanged
+    e.interactiveDelta !== 0 || e.textChanged || (countFocus && (e.focusChanged || e.focusValueChanged))
   )
 }
 

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -930,6 +930,7 @@ async function observeUrlDigest(): Promise<UrlDigest | null> {
 async function runWithEffect(
   action: () => Promise<{ exitCode: number; stdout: string }>,
   settleMs: number,
+  verb: 'click' | 'press' | 'select' | 'hover',
 ): Promise<{ result: { exitCode: number; stdout: string }; digest: UrlDigest | null; effect: ActionEffect | null; settleMs: number }> {
   const cdp = browserState.cdpUrl || undefined;
   const beforeRun = await execBrowser(['eval', fingerprintScript()], cdp);
@@ -946,7 +947,7 @@ async function runWithEffect(
   let waited = settleMs;
   // Nothing moved yet: a late effect (ajax cart drawer, animated panel) is the
   // other explanation, so read once more before reporting "no DOM change".
-  if (effect && !effectHasChange(effect) && settleMs < NO_CHANGE_RECHECK_MS) {
+  if (effect && !effectHasChange(effect, { countFocus: verb === 'press' }) && settleMs < NO_CHANGE_RECHECK_MS) {
     await sleep(Math.max(0, NO_CHANGE_RECHECK_MS - (Date.now() - actedAt)));
     afterRun = await execBrowser(['eval', fingerprintScript(before?.t)], cdp);
     const again = afterRun.exitCode === 0 ? parseFingerprint(afterRun.stdout) : null;
@@ -1592,6 +1593,7 @@ app.post('/browser/click', async (c) => {
     const { result, digest, effect, settleMs } = await runWithEffect(
       () => execBrowser(['click', body.ref], browserState.cdpUrl || undefined),
       CLICK_SETTLE_MS,
+      'click',
     );
 
     if (result.exitCode !== 0) {
@@ -1762,6 +1764,7 @@ app.post('/browser/press', async (c) => {
     const { result, digest, effect, settleMs } = await runWithEffect(
       () => execBrowser(['press', body.key], browserState.cdpUrl || undefined),
       body.key.trim() === 'Enter' ? PRESS_ENTER_SETTLE_MS : PRESS_SETTLE_MS,
+      'press',
     );
 
     if (result.exitCode !== 0) {
@@ -1849,6 +1852,7 @@ app.post('/browser/select', async (c) => {
     const { result, effect, settleMs } = await runWithEffect(
       () => execBrowser(['select', body.ref, body.value], browserState.cdpUrl || undefined),
       SELECT_COMMIT_SETTLE_MS,
+      'select',
     );
 
     if (result.exitCode !== 0) {
@@ -1891,6 +1895,7 @@ app.post('/browser/hover', async (c) => {
     const { result, effect, settleMs } = await runWithEffect(
       () => execBrowser(['hover', body.ref], browserState.cdpUrl || undefined),
       HOVER_SETTLE_MS,
+      'hover',
     );
 
     if (result.exitCode !== 0) {

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -819,7 +819,7 @@ import {
   capSnapshot, compactWithText, countRefs, formatIframePlaceholders, formatStatusHeader, formatTextFooter,
   pageProbeScript, parsePageProbe, waitForDocumentReady, EMPTY_PROBE, THIN_TREE_PREVIEW_CHARS, THIN_TREE_REFS,
 } from './snapshot-format';
-import { diffFingerprints, fingerprintScript, parseFingerprint, HOVER_SETTLE_MS, type ActionEffect } from './action-effect';
+import { diffFingerprints, effectHasChange, fingerprintScript, parseFingerprint, HOVER_SETTLE_MS, NO_CHANGE_RECHECK_MS, type ActionEffect } from './action-effect';
 import {
   observeUrl, resetUrlTracking,
   CLICK_SETTLE_MS, FILL_SETTLE_MS, PRESS_ENTER_SETTLE_MS, PRESS_SETTLE_MS,
@@ -930,20 +930,35 @@ async function observeUrlDigest(): Promise<UrlDigest | null> {
 async function runWithEffect(
   action: () => Promise<{ exitCode: number; stdout: string }>,
   settleMs: number,
-): Promise<{ result: { exitCode: number; stdout: string }; digest: UrlDigest | null; effect: ActionEffect | null }> {
+): Promise<{ result: { exitCode: number; stdout: string }; digest: UrlDigest | null; effect: ActionEffect | null; settleMs: number }> {
   const cdp = browserState.cdpUrl || undefined;
   const beforeRun = await execBrowser(['eval', fingerprintScript()], cdp);
   const before = beforeRun.exitCode === 0 ? parseFingerprint(beforeRun.stdout) : null;
 
   const result = await action();
-  if (result.exitCode !== 0) return { result, digest: null, effect: null };
+  if (result.exitCode !== 0) return { result, digest: null, effect: null, settleMs };
 
+  const actedAt = Date.now();
   await sleep(settleMs);
-  const afterRun = await execBrowser(['eval', fingerprintScript(before?.t)], cdp);
-  const after = afterRun.exitCode === 0 ? parseFingerprint(afterRun.stdout) : null;
+  let afterRun = await execBrowser(['eval', fingerprintScript(before?.t)], cdp);
+  let after = afterRun.exitCode === 0 ? parseFingerprint(afterRun.stdout) : null;
+  let effect = before && after && after.url === before.url ? diffFingerprints(before, after) : null;
+  let waited = settleMs;
+  // Nothing moved yet: a late effect (ajax cart drawer, animated panel) is the
+  // other explanation, so read once more before reporting "no DOM change".
+  if (effect && !effectHasChange(effect) && settleMs < NO_CHANGE_RECHECK_MS) {
+    await sleep(Math.max(0, NO_CHANGE_RECHECK_MS - (Date.now() - actedAt)));
+    afterRun = await execBrowser(['eval', fingerprintScript(before?.t)], cdp);
+    const again = afterRun.exitCode === 0 ? parseFingerprint(afterRun.stdout) : null;
+    if (again) {
+      after = again;
+      effect = before && again.url === before.url ? diffFingerprints(before, again) : null;
+    }
+    waited = Math.max(NO_CHANGE_RECHECK_MS, Date.now() - actedAt);
+  }
   const digest = after?.url ? observeUrl(after.url) : await observeUrlDigest();
-  const effect = before && after && !digest?.navigated ? diffFingerprints(before, after) : null;
-  return { result, digest, effect };
+  if (digest?.navigated) effect = null;
+  return { result, digest, effect, settleMs: waited };
 }
 
 /**
@@ -1574,7 +1589,7 @@ app.post('/browser/click', async (c) => {
       return c.json({ error: 'Browser is not active' }, 400);
     }
 
-    const { result, digest, effect } = await runWithEffect(
+    const { result, digest, effect, settleMs } = await runWithEffect(
       () => execBrowser(['click', body.ref], browserState.cdpUrl || undefined),
       CLICK_SETTLE_MS,
     );
@@ -1587,7 +1602,7 @@ app.post('/browser/click', async (c) => {
     notifyBrowserAction();
     return c.json({
       success: true,
-      settleMs: CLICK_SETTLE_MS,
+      settleMs,
       ...(digest && { digest }),
       ...(effect && { effect }),
       ...(tabInfo && { tabInfo }),
@@ -1744,10 +1759,9 @@ app.post('/browser/press', async (c) => {
       return c.json({ error: 'Browser is not active' }, 400);
     }
 
-    const settleMs = body.key.trim() === 'Enter' ? PRESS_ENTER_SETTLE_MS : PRESS_SETTLE_MS;
-    const { result, digest, effect } = await runWithEffect(
+    const { result, digest, effect, settleMs } = await runWithEffect(
       () => execBrowser(['press', body.key], browserState.cdpUrl || undefined),
-      settleMs,
+      body.key.trim() === 'Enter' ? PRESS_ENTER_SETTLE_MS : PRESS_SETTLE_MS,
     );
 
     if (result.exitCode !== 0) {
@@ -1832,7 +1846,7 @@ app.post('/browser/select', async (c) => {
 
     const before = await readValue();
 
-    const { result, effect } = await runWithEffect(
+    const { result, effect, settleMs } = await runWithEffect(
       () => execBrowser(['select', body.ref, body.value], browserState.cdpUrl || undefined),
       SELECT_COMMIT_SETTLE_MS,
     );
@@ -1849,7 +1863,7 @@ app.post('/browser/select', async (c) => {
     }
 
     notifyBrowserAction();
-    return c.json({ success: true, committedValue: judgement.committed, settleMs: SELECT_COMMIT_SETTLE_MS, ...(effect && { effect }) });
+    return c.json({ success: true, committedValue: judgement.committed, settleMs, ...(effect && { effect }) });
   } catch (error: any) {
     console.error('[Browser] Error selecting:', error);
     return c.json({ error: error.message || 'Failed to select' }, 500);
@@ -1874,7 +1888,7 @@ app.post('/browser/hover', async (c) => {
       return c.json({ error: 'Browser is not active' }, 400);
     }
 
-    const { result, effect } = await runWithEffect(
+    const { result, effect, settleMs } = await runWithEffect(
       () => execBrowser(['hover', body.ref], browserState.cdpUrl || undefined),
       HOVER_SETTLE_MS,
     );
@@ -1884,7 +1898,7 @@ app.post('/browser/hover', async (c) => {
     }
 
     notifyBrowserAction();
-    return c.json({ success: true, settleMs: HOVER_SETTLE_MS, ...(effect && { effect }) });
+    return c.json({ success: true, settleMs, ...(effect && { effect }) });
   } catch (error: any) {
     console.error('[Browser] Error hovering:', error);
     return c.json({ error: error.message || 'Failed to hover' }, 500);


### PR DESCRIPTION
**Stacked on #1049** (→ #1047 → #1045 → #1043).

## Why

Replaying mined production sessions with a real model (Sonnet 5) against the stack showed two ways the effect line could be wrong:

- absorbmore.com add-to-cart: the cart drawer opened after the 300ms read. The result said `no DOM change within 300ms — the element may not be handling clicks`. The agent recovered via a screenshot, which is the call the effect line exists to save.
- Meta Ad Library search box: `Control+a` and typed text reported `no DOM change within 50ms — the key may have been ignored`. The value changed; neither the page text hash nor the interactive census can see input values.

## What changed

- **Second read on silence.** If the first post-settle fingerprint shows nothing, wait until 1.2s after the action and read again before reporting. The reported window is the real one (`no DOM change within 1200ms`). Cost lands only on actions that would otherwise be reported as inert.
- **Focused field value in the fingerprint.** Reported as `field value now "monday"` when it changes with focus unchanged. Counts as a change for the second-read decision.
- Press hint reworded: a silent key is normal for a modifier combo.

## Verified

- 79 tests across the effect, formatter and tool suites; `tsc --noEmit` and `eslint` clean.
- Replay of the absorbmore case on an image with this change is in progress; result will be posted here.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01792FWz3b1emZ8z1H1DyP3u
