### PR TITLE
feat(paywall): let the subscribe CTA expand for the platform promo form

### DIFF
--- a/src/renderer/components/provider-error/billing-embed-frame.tsx
+++ b/src/renderer/components/provider-error/billing-embed-frame.tsx
@@ -17,6 +17,11 @@ export const LAUNCHER_MAX_HEIGHT = 'calc(100dvh - 160px)'
 const MAX_SEATS = 10_000
 const MAX_SEAT_PRICE_CENTS = 100_000_00
 export const FRAME_READY_TIMEOUT_MS = 15_000
+// Views whose CTA can swap its button for an in-frame panel (top-up form, promo code).
+const EXPANDABLE_VIEWS: ReadonlySet<BillingEmbedView> = new Set(['topup', 'subscribe'])
+// Mirrors the platform's promo line under the upgrade button (mt-1.5 + 16px), so the
+// CTA box is tall enough for it.
+export const PROMO_LINK_LABEL = 'Have a promo code?'
 
 /** The subscribe quote the platform CTA reports, so the host can draw the price block. */
 export interface SubscribePlan {
@@ -157,7 +162,7 @@ export function BillingEmbedFrame({
       const message = readEmbedMessage(event.data)
       if (!message || message.orgId !== orgId) return
       if (message.event === 'ready') { setFrameReady(true); sendTheme() }
-      else if (message.event === 'open-billing' && launcher && view === 'topup') onOpenBilling?.()
+      else if (message.event === 'open-billing' && launcher && EXPANDABLE_VIEWS.has(view)) onOpenBilling?.()
       else if (message.event === 'close' && launcher) onClose?.()
       else if (message.event === 'billing-updated') onBillingUpdated({ pending: message.pending })
       else if (message.event === 'session-expired') setFailure('expired')
@@ -199,6 +204,14 @@ export function BillingEmbedFrame({
           >
             {frameLabel}
           </Button>
+          {view === 'subscribe' && (
+            <p
+              className={cn('mt-1.5 h-4 text-center text-[11px] leading-4 text-muted-foreground', expanded ? 'hidden' : frameReady ? 'invisible' : '')}
+              aria-hidden="true" data-testid="billing-cta-promo-reference"
+            >
+              {PROMO_LINK_LABEL}
+            </p>
+          )}
           {src && <iframe key={attempt} ref={iframeRef} title="Open workspace billing" src={src} onLoad={sendTheme}
             className="absolute inset-0 block h-full w-full border-0 bg-transparent" style={{ visibility: frameReady ? 'visible' : 'hidden' }}
             referrerPolicy="strict-origin" data-testid="billing-cta-frame" />}

--- a/src/renderer/components/provider-error/platform-paywall-card.test.tsx
+++ b/src/renderer/components/provider-error/platform-paywall-card.test.tsx
@@ -498,7 +498,7 @@ describe('PlatformPaywallCard', () => {
       expect(screen.queryByTestId('billing-cta-hint')).not.toBeInTheDocument()
     })
 
-    it('draws the subscribe quote from the platform CTA and never expands the subscribe CTA', async () => {
+    it('draws the subscribe quote from the platform CTA and clears on billing-updated', async () => {
       renderCard('API Error: 402 {"error":"insufficient_balance","subscription_required":true}')
       await screen.findByTestId('billing-cta-frame')
       expect(screen.getByTestId('paywall-subscribe')).toHaveClass('flex-col', 'sm:flex-row')
@@ -514,12 +514,58 @@ describe('PlatformPaywallCard', () => {
       expect(screen.getByTestId('paywall-plan')).toHaveTextContent(/2 seats\s*×\s*\$200\/mo/)
       expect(screen.queryByTestId('billing-cta-hint')).not.toBeInTheDocument()
       expect(screen.getByTestId('billing-cta-size-reference')).toHaveClass('w-full')
-      postEmbedMessage(PLATFORM_ORIGIN, 'open-billing')
-      expect(screen.getByTestId('paywall-card')).toHaveAttribute('data-expanded', 'false')
       fetchBilling.mockResolvedValue(billing({ access: ALLOWED }))
       postEmbedMessage(PLATFORM_ORIGIN, 'billing-updated')
       await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith('Billing updated. You can continue.'))
       expect(screen.queryByTestId('paywall-card')).not.toBeInTheDocument()
+    })
+
+    it('sizes the subscribe CTA box for the promo line the platform draws under the button', async () => {
+      renderCard('API Error: 402 {"error":"insufficient_balance","subscription_required":true}')
+      await screen.findByTestId('billing-cta-frame')
+      const promoLine = screen.getByTestId('billing-cta-promo-reference')
+      expect(promoLine).toHaveTextContent('Have a promo code?')
+      expect(promoLine).toHaveClass('mt-1.5', 'h-4')
+      expect(promoLine).toHaveAttribute('aria-hidden', 'true')
+      postEmbedMessage(PLATFORM_ORIGIN, 'ready')
+      expect(promoLine).toHaveClass('invisible')
+      expect(screen.getByTestId('billing-cta-size-reference')).toHaveClass('invisible')
+    })
+
+    it('does not draw a promo line for the top-up or payment CTA', async () => {
+      renderCard()
+      await screen.findByTestId('billing-cta-frame')
+      expect(screen.queryByTestId('billing-cta-promo-reference')).not.toBeInTheDocument()
+    })
+
+    it('expands the subscribe CTA under both columns for the promo form and collapses on close, keeping the iframe', async () => {
+      renderCard('API Error: 402 {"error":"insufficient_balance","subscription_required":true}')
+      const frame = await screen.findByTestId('billing-cta-frame')
+      postEmbedMessage(PLATFORM_ORIGIN, 'cta-state', { label: 'Upgrade to Pro', hint: 'Promo HALF3 applied.', seats: 1, seatPriceCents: 20000 })
+      expect(screen.getByTestId('billing-cta-hint')).toHaveTextContent('Promo HALF3 applied.')
+
+      await expandCta()
+      const aside = screen.getByTestId('paywall-subscribe-aside')
+      expect(aside).toHaveAttribute('data-expanded', 'true')
+      expect(aside).toHaveClass('w-full', 'sm:basis-full', 'items-stretch')
+      expect(aside).not.toHaveClass('sm:border-l', 'sm:min-w-[200px]')
+      expect(screen.getByTestId('paywall-subscribe')).toHaveClass('sm:flex-wrap')
+      expect(screen.getByTestId('paywall-card')).not.toHaveClass('max-w-md')
+      expect(screen.getByTestId('paywall-plan')).toHaveTextContent('$200/mo')
+      expect(screen.getByTestId('billing-cta-size-reference')).toHaveClass('hidden')
+      expect(screen.getByTestId('billing-cta-promo-reference')).toHaveClass('hidden')
+      expect(screen.queryByTestId('billing-cta-hint')).not.toBeInTheDocument()
+      postEmbedMessage(PLATFORM_ORIGIN, 'resize', { height: 180 })
+      expect(screen.getByTestId('billing-cta-body').style.height).toBe('180px')
+      expect(screen.getByTestId('billing-cta-frame')).toBe(frame)
+
+      postEmbedMessage(PLATFORM_ORIGIN, 'cta-state', { label: 'Upgrade to Pro', hint: 'Promo HALF3 applied.', seats: 1, seatPriceCents: 10000 })
+      postEmbedMessage(PLATFORM_ORIGIN, 'close')
+      expect(screen.getByTestId('paywall-card')).toHaveAttribute('data-expanded', 'false')
+      expect(aside).toHaveClass('sm:border-l', 'sm:min-w-[200px]')
+      expect(screen.getByTestId('paywall-plan')).toHaveTextContent('$100/mo')
+      expect(screen.getByTestId('billing-cta-hint')).toHaveTextContent('Promo HALF3 applied.')
+      expect(screen.getByTestId('billing-cta-frame')).toBe(frame)
     })
 
     it('widens only the subscribe card past the gutter at full column width', async () => {
@@ -899,8 +945,6 @@ describe('PlatformPaywallCard', () => {
       expect(screen.queryByRole('button', { name: 'Upgrade to Pro' })).not.toBeInTheDocument()
       expect(screen.getByTestId('billing-cta-size-reference')).toHaveTextContent('Upgrade to Pro')
       expect(screen.getByTestId('billing-cta-size-reference')).toHaveClass('bg-brand')
-      postEmbedMessage(PLATFORM_ORIGIN, 'open-billing')
-      expect(screen.getByTestId('paywall-card')).toHaveAttribute('data-expanded', 'false')
     })
 
     it('embeds the payment CTA when the payment is past due', async () => {

--- a/src/renderer/components/provider-error/platform-paywall-card.tsx
+++ b/src/renderer/components/provider-error/platform-paywall-card.tsx
@@ -168,9 +168,10 @@ function PaywallActions({
 // The subscribe card: why to upgrade on the left, the quote and the action on the right;
 // below `sm` the quote stacks under the benefits. The quote comes from the platform CTA
 // (seat count and per-seat price), so it is absent until that arrives and on Electron.
-function SubscribeBody({ plan, hint, actions }: { plan: SubscribePlan | null; hint: string; actions: ReactNode }) {
+// An expanded CTA panel (promo code) drops below both columns at full width.
+function SubscribeBody({ plan, hint, actions, expanded }: { plan: SubscribePlan | null; hint: string; actions: ReactNode; expanded: boolean }) {
   return (
-    <div className="flex flex-col gap-4 py-1.5 sm:flex-row sm:items-center sm:gap-6" data-testid="paywall-subscribe">
+    <div className="flex flex-col gap-4 py-1.5 sm:flex-row sm:flex-wrap sm:items-center sm:gap-6" data-testid="paywall-subscribe">
       <div className="min-w-0 flex-1">
         <p className="text-base font-medium leading-6 text-muted-foreground">Your trial has ended.</p>
         <p className="text-base font-medium leading-6 text-foreground">Upgrade to Pro to keep going.</p>
@@ -185,8 +186,16 @@ function SubscribeBody({ plan, hint, actions }: { plan: SubscribePlan | null; hi
         {hint && <p className="mt-3 text-[11px] leading-4 text-muted-foreground" data-testid="billing-cta-hint">{hint}</p>}
       </div>
       <div
-        className="flex flex-col items-start justify-center gap-3 border-t border-border/70 pt-4 sm:min-w-[200px] sm:shrink-0 sm:self-stretch sm:border-l sm:border-t-0 sm:py-1 sm:pl-10 sm:pr-3"
+        className={cn(
+          'flex flex-col justify-center gap-3 border-t border-border/70 pt-4',
+          // Same element either way so the CTA iframe keeps its document; the aside just
+          // wraps under the benefits and takes the full row while the panel is open.
+          expanded
+            ? 'w-full items-stretch sm:basis-full'
+            : 'items-start sm:min-w-[200px] sm:shrink-0 sm:self-stretch sm:border-l sm:border-t-0 sm:py-1 sm:pl-10 sm:pr-3',
+        )}
         data-testid="paywall-subscribe-aside"
+        data-expanded={expanded}
       >
         {plan && (
           <div data-testid="paywall-plan">
@@ -250,10 +259,10 @@ export function PlatformPaywallCard({ message, presentation, children, live = tr
     setPanelHold(false)
   }, [])
   const holding = embedded && panelHold
-  // Only the top-up panel expands in place; a view change remounts the frame anyway.
+  // A view change remounts the frame, so any open panel (and its hold) is gone with it.
   useEffect(() => {
-    if (expanded && view !== 'topup') collapse()
-  }, [expanded, view, collapse])
+    collapse()
+  }, [view, collapse])
   useEffect(() => {
     if (!billing.cleared || holding || !inApp || !billingChanged.current || successShown.current) return
     successShown.current = true
@@ -352,11 +361,12 @@ export function PlatformPaywallCard({ message, presentation, children, live = tr
             PAYWALL_GLASS_CLASS,
             subscribeLayout ? 'px-4 py-4 sm:px-6 sm:py-5' : 'px-5 py-4',
             // West's purchase dialog was max-w-md; keep the collapsed banner full-width.
-            panelOpen && 'mx-auto w-full max-w-md',
+            // The subscribe card keeps its two-column width, the panel wraps under it.
+            panelOpen && !subscribeLayout && 'mx-auto w-full max-w-md',
           )}
         >
           {subscribeLayout ? (
-            <SubscribeBody plan={plan} hint={hint} actions={actions} />
+            <SubscribeBody plan={plan} hint={hint} actions={actions} expanded={panelOpen} />
           ) : (
             <div className={cn('flex flex-wrap items-center gap-x-6 gap-y-3', !showHeader && 'justify-end')}>
               {showHeader && (


### PR DESCRIPTION
Stacked on #994 (base: `feat/billing-embed-proxy`). Companion to platform [#431](https://github.com/SkillfulAgents/platform/pull/431).

## Bug

The subscribe paywall has no way to enter a promo code. Platform #429 added the input to the full `EmbedSubscribeView`, but since #408 the paywall loads `surface=cta`, where the iframe is only the "Upgrade to Pro" button and the host draws the price. Users had to redeem from the dashboard and come back.

## Repro (staging, `v0.5.21-pr994.10`)

1. Cloud workspace with an ended trial → paywall card shows `$200/mo · 1 seat × $200/mo`.
2. No promo entry anywhere on the card. Redeeming on `platform.gamutstaging.com/dashboard/organizations/<id>/billing` and reloading is the only path.

## Change

Platform #431 (second commit) draws a "Have a promo code?" line under the button and swaps in a promo form on click, reusing the top-up panel's `open-billing` / `close` handshake. This PR is the host side:

- `billing-embed-frame.tsx`: honor `open-billing` for the subscribe view (was topup-only). Draw a hidden `mt-1.5 h-4` "Have a promo code?" line under the size-reference button for subscribe so the CTA box is tall enough for the platform's line.
- `platform-paywall-card.tsx`: drop the "collapse unless topup" effect (a view change still collapses, since the frame remounts). While the panel is open the subscribe aside wraps under the benefits at full width (`sm:flex-wrap` + `sm:basis-full`) — same element, so the iframe keeps its document and storage-access grant. The subscribe card keeps its two-column width instead of shrinking to `max-w-md`.
- Mobile: below `sm` the aside already stacks under the benefits; the expanded panel just takes that same full-width slot. The platform form stacks input above Apply below `sm` inside the iframe.

No message-shape change. Topup/payment CTAs are untouched (no promo line, `open-billing` still topup-only for payment).

## Validation

- `vitest run src/renderer/components/provider-error` — 102 passed (3 new: promo line sizing, no line on topup/payment, expand → resize → re-quote → close keeping the iframe).
- `tsc --noEmit` — 0 errors under `src/` (pre-existing errors in untracked `tools/*.ts` only).
- eslint clean on changed files.
- Not verified: end-to-end in a browser against staging — needs this PR built into an image and the staging org moved to it, plus platform `staging` (already has #431).

## Rollout

Platform `staging` already has the CTA change; until this lands the extra line is clipped and nothing else changes. After merge into #994 → new image → `POST /orgs/set-version` on the staging org.
