### PR TITLE
fix(browser): attach the eval `return` note only when the body produced nothing

### DIFF
--- a/agent-container/src/tools/browser.test.ts
+++ b/agent-container/src/tools/browser.test.ts
@@ -205,3 +205,39 @@ describe('browser_open location', () => {
     expect(result.content[0].text).toContain(BROWSER_USE_GUIDANCE_HINT)
   })
 })
+
+describe('browser_eval return note', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  const evalWith = async (output: string, wrapped: boolean) => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ success: true, output, wrapped }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })))
+    const evalTool = createBrowserTools(() => 'session-e').find(t => t.name === 'browser_eval') as any
+    const result = await evalTool.handler({ script: 'ignored' })
+    return String(result.content[0].text)
+  }
+
+  it('does not attach the note when a wrapped script returned a value', async () => {
+    const text = await evalWith('{"rows":18}', true)
+    expect(text).toContain('{"rows":18}')
+    expect(text).not.toContain('add `return`')
+  })
+
+  it('does not attach the note to falsy-but-real values', async () => {
+    for (const out of ['0', 'false', '""', '{}', '[]']) {
+      expect(await evalWith(out, true)).not.toContain('add `return`')
+    }
+  })
+
+  it('attaches the note only when a wrapped body produced null or nothing', async () => {
+    expect(await evalWith('null', true)).toContain('add `return`')
+    expect(await evalWith('', true)).toContain('add `return`')
+  })
+
+  it('never attaches the note to an unwrapped expression', async () => {
+    expect(await evalWith('null', false)).not.toContain('add `return`')
+    expect(await evalWith('', false)).toBe('(no output)')
+  })
+})

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -598,9 +598,14 @@ const browserEvalTool = tool(
     const result = await browserFetch('eval', { script: args.script })
     if (!result.success) return errorResult(result.error!)
     const data = result.data as Record<string, unknown>
-    let text = data.output ? String(data.output) : '(no output)'
-    if (data.wrapped) {
-      text += '\n(note: ran in a fresh function scope — add `return` if you expected a value back)'
+    const output = data.output ? String(data.output) : ''
+    let text = output || '(no output)'
+    // A statement body runs inside an async IIFE, and the CLI prints `null`
+    // for a body that completes without `return` (undefined → JSON null).
+    // The note is only informative in that case; on any other output it was
+    // a 100% false positive in the mined sessions (theme 4).
+    if (data.wrapped && (output === '' || output === 'null')) {
+      text += '\n(note: a statement body that does not `return` also yields null — add `return` if you expected a value back)'
     }
     text += getTabWarning()
     return {


### PR DESCRIPTION
## What

`browser_eval` appended `(note: ran in a fresh function scope — add \`return\` if you expected a value back)` whenever the script was wrapped in the async IIFE — which is every statement-body eval, including the ones that returned a value. The note now appears only when the wrapped body produced `null` or nothing, and says what that means rather than guessing at the script.

## Why

Transcript-mining theme 4 (≈112/200 sessions): the note was a 100% false positive — "18 of 19 evals used return and got their value back; zero true positives". Agents either learned to ignore it or re-ran working scripts with an extra `return`.

Verified on the real CLI (agent-browser 0.27.2): a wrapped body that completes without `return` prints `null`; `return null` prints `null` too, so the note is phrased as a fact about statement bodies, not a claim about this script. `0`, `false`, `""`, `{}` and `[]` are real values and get no note.

## Tests

- `tools/browser.test.ts`: no note on a returned value, on falsy-but-real values, or on an unwrapped expression; note only on wrapped `null`/empty.
- typecheck + lint clean.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01792FWz3b1emZ8z1H1DyP3u
