### PR TITLE
fix(browser): fill and select read-backs state values, not causes

### DIFF
--- a/agent-container/docs/browser-use.md
+++ b/agent-container/docs/browser-use.md
@@ -90,8 +90,9 @@ number of interactive elements, and focus. `Effect: none observed within Nms
 failed: a highlight, a change inside an iframe or canvas, or a slow server
 all look like this. Snapshot or screenshot if you need to know; do not click
 again on that basis, which would undo a toggle. Fill results
-report the value the page actually committed. A fill warning means the page
-kept a different value—fix it before moving on.
+report the value the page actually committed. A fill warning means the field
+now holds a different value than you sent; both are shown and the cause is
+not known—check the field before moving on.
 
 Navigation makes existing refs stale. Re-snapshot when a result reports
 navigation, when a dialog or dynamic view changes the relevant controls, or

--- a/agent-container/src/browser-digest.test.ts
+++ b/agent-container/src/browser-digest.test.ts
@@ -83,7 +83,7 @@ describe('formatFillReadback', () => {
   it('warns on divergence (maxlength truncation, reformatting, rejection)', () => {
     const msg = formatFillReadback('x'.repeat(100), 'x'.repeat(75))
     expect(msg).toContain('⚠')
-    expect(msg).toContain('differs from the requested')
+    expect(msg).toContain('differs from the')
   })
 
   it('says so when the value cannot be read back', () => {
@@ -117,5 +117,16 @@ describe('parseScrollInfo / formatScrollDigest', () => {
     expect(formatScrollDigest({ y: 0, viewportHeight: 800, pageHeight: 5400 })).toContain('(top of page)')
     expect(formatScrollDigest({ y: 4600, viewportHeight: 800, pageHeight: 5400 })).toContain('(bottom of page)')
     expect(formatScrollDigest(null)).toBe('')
+  })
+})
+
+describe('formatFillReadback states values only', () => {
+  it('names both values on divergence and asserts no cause', () => {
+    const msg = formatFillReadback('speakeasy', 'Reels')
+    expect(msg).toContain('⚠ Field value is now "Reels"')
+    expect(msg).toContain('"speakeasy" you sent')
+    for (const claim of ['reformatted', 'truncated', 'rejected', 'browser_type']) {
+      expect(msg).not.toContain(claim)
+    }
   })
 })

--- a/agent-container/src/browser-digest.ts
+++ b/agent-container/src/browser-digest.ts
@@ -90,6 +90,13 @@ function displayValue(value: string): string {
  * programmatically and reports success regardless of what the page kept —
  * maxlength truncation, JS reformatting, and keystroke-only widgets all
  * silently diverged in the audit (F6).
+ *
+ * On divergence the line states the two values and nothing else. The old
+ * text asserted a cause ("The site reformatted, truncated (maxlength), or
+ * rejected the input") that the read-back never established — a rebound
+ * ref reading a neighbouring element produced the same line, and agents
+ * carried the invented site behaviour for hundreds of calls (mining theme
+ * 24). The agent can see the difference; what it means is its call.
  */
 export function formatFillReadback(requested: string, committed: string | null): string {
   if (committed === null) {
@@ -98,7 +105,7 @@ export function formatFillReadback(requested: string, committed: string | null):
   if (committed === requested) {
     return `\nField value verified: "${displayValue(committed)}".`
   }
-  return `\n⚠ Field value is now "${displayValue(committed)}" — differs from the requested "${displayValue(requested)}". The site reformatted, truncated (maxlength), or rejected the input. If this matters, fix it before moving on; keystroke-listening widgets may need browser_type instead.`
+  return `\n⚠ Field value is now "${displayValue(committed)}" — differs from the "${displayValue(requested)}" you sent.`
 }
 
 // --- Scroll position ---------------------------------------------------------

--- a/agent-container/src/select-verify.test.ts
+++ b/agent-container/src/select-verify.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { judgeSelectCommit, selectLabelMatchScript, parseLabelMatch } from './select-verify'
+import { judgeSelectCommit, FOCUSED_SELECT_STATE_SCRIPT, parseFocusedSelectState, focusedTargetMatches } from './select-verify'
 
 describe('judgeSelectCommit', () => {
   it('passes when the value committed exactly (select by value)', () => {
@@ -16,7 +16,7 @@ describe('judgeSelectCommit', () => {
     expect(judgeSelectCommit('us', 'us', 'us')).toEqual({ ok: true, committed: 'us' })
   })
 
-  it('passes when the requested LABEL names the option that was already selected', () => {
+  it('passes when the requested LABEL names the option the target already holds', () => {
     // mining theme 24: 'requested "California", element value is still "CA"' — CA is California
     expect(judgeSelectCommit('California', 'CA', 'CA', true)).toEqual({ ok: true, committed: 'CA' })
   })
@@ -32,11 +32,14 @@ describe('judgeSelectCommit', () => {
     }
   })
 
-  it('fails when the target has no readable value (custom dropdown div)', () => {
+  it('reports an unreadable value as unverified, without diagnosing the element', () => {
     const r = judgeSelectCommit('AI Tools', null, null)
     expect(r.ok).toBe(false)
     if (!r.ok) {
-      expect(r.reason).toContain('not a native <select>')
+      expect(r.reason).toContain('could not be read back')
+      expect(r.reason).toContain('unverified')
+      expect(r.reason).not.toContain('so it is not a native')
+      expect(r.reason).not.toContain('probably')
       expect(r.reason).toContain('Recipe:')
     }
   })
@@ -48,18 +51,26 @@ describe('judgeSelectCommit', () => {
   })
 })
 
-describe('selectLabelMatchScript', () => {
-  it('embeds the request and value as JSON so quotes cannot break the script', () => {
-    const script = selectLabelMatchScript(' Kids" Menu ', 'k"1')
-    expect(script).toContain('"Kids\\" Menu"')
-    expect(script).toContain('"k\\"1"')
-    expect(script).toContain('querySelectorAll("select")')
+describe('focused-target label check', () => {
+  it('inspects only the focused element, and only when it is a select', () => {
+    expect(FOCUSED_SELECT_STATE_SCRIPT).toContain('document.activeElement')
+    expect(FOCUSED_SELECT_STATE_SCRIPT).toContain('tagName!=="SELECT"')
+    expect(FOCUSED_SELECT_STATE_SCRIPT).not.toContain('querySelectorAll')
   })
 
-  it('parses the CLI double-encoded boolean', () => {
-    expect(parseLabelMatch('"true"')).toBe(true)
-    expect(parseLabelMatch('true')).toBe(true)
-    expect(parseLabelMatch('"false"')).toBe(false)
-    expect(parseLabelMatch('garbage')).toBe(false)
+  it('parses the CLI double-encoded state and rejects anything else', () => {
+    expect(parseFocusedSelectState(JSON.stringify(JSON.stringify({ value: 'CA', label: 'California' })))).toEqual({ value: 'CA', label: 'California' })
+    expect(parseFocusedSelectState('{"value":"CA","label":"California"}')).toEqual({ value: 'CA', label: 'California' })
+    expect(parseFocusedSelectState('null')).toBeNull()
+    expect(parseFocusedSelectState('"null"')).toBeNull()
+    expect(parseFocusedSelectState('garbage')).toBeNull()
+  })
+
+  it('matches only when the TARGET holds the value under the requested label', () => {
+    expect(focusedTargetMatches({ value: 'CA', label: 'California' }, 'California', 'CA')).toBe(true)
+    expect(focusedTargetMatches({ value: 'CA', label: 'California' }, ' California ', 'CA')).toBe(true)
+    // the reviewer's case: target reverted to New York while another dropdown holds California
+    expect(focusedTargetMatches({ value: 'NY', label: 'New York' }, 'California', 'NY')).toBe(false)
+    expect(focusedTargetMatches(null, 'California', 'CA')).toBe(false)
   })
 })

--- a/agent-container/src/select-verify.test.ts
+++ b/agent-container/src/select-verify.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { judgeSelectCommit, FOCUSED_SELECT_STATE_SCRIPT, parseFocusedSelectState, focusedTargetMatches } from './select-verify'
+import {
+  judgeSelectCommit,
+  parseElementBox,
+  selectTargetStateScript,
+  parseSelectTargetState,
+  targetMatches,
+} from './select-verify'
 
 describe('judgeSelectCommit', () => {
   it('passes when the value committed exactly (select by value)', () => {
@@ -51,26 +57,41 @@ describe('judgeSelectCommit', () => {
   })
 })
 
-describe('focused-target label check', () => {
-  it('inspects only the focused element, and only when it is a select', () => {
-    expect(FOCUSED_SELECT_STATE_SCRIPT).toContain('document.activeElement')
-    expect(FOCUSED_SELECT_STATE_SCRIPT).toContain('tagName!=="SELECT"')
-    expect(FOCUSED_SELECT_STATE_SCRIPT).not.toContain('querySelectorAll')
+describe('target identification by rectangle', () => {
+  it('parses the CLI box JSON envelope and a bare box', () => {
+    expect(parseElementBox('{"success":true,"data":{"height":19,"width":85,"x":55,"y":81.875},"error":null}')).toEqual({ x: 55, y: 81.875, width: 85, height: 19 })
+    expect(parseElementBox('{"x":1,"y":2,"width":3,"height":4}')).toEqual({ x: 1, y: 2, width: 3, height: 4 })
+    expect(parseElementBox('{"success":false,"data":null}')).toBeNull()
+    expect(parseElementBox('x:      55')).toBeNull()
+  })
+
+  it('reads the <select> AT the box, checks its rectangle, and never consults focus or searches the page', () => {
+    const script = selectTargetStateScript({ x: 55, y: 81.875, width: 85, height: 19 })
+    expect(script).toContain('document.elementFromPoint')
+    expect(script).toContain('getBoundingClientRect')
+    expect(script).toContain('tagName!=="SELECT"')
+    expect(script).not.toContain('activeElement')
+    expect(script).not.toContain('querySelectorAll')
+    // review: <option value="CA" label="California">CA</option> displays California — option.label, not .text
+    expect(script).toContain('o.label||o.text')
+    // both viewport- and document-relative interpretations of the CLI box are tried
+    expect(script).toContain('window.scrollX')
   })
 
   it('parses the CLI double-encoded state and rejects anything else', () => {
-    expect(parseFocusedSelectState(JSON.stringify(JSON.stringify({ value: 'CA', label: 'California' })))).toEqual({ value: 'CA', label: 'California' })
-    expect(parseFocusedSelectState('{"value":"CA","label":"California"}')).toEqual({ value: 'CA', label: 'California' })
-    expect(parseFocusedSelectState('null')).toBeNull()
-    expect(parseFocusedSelectState('"null"')).toBeNull()
-    expect(parseFocusedSelectState('garbage')).toBeNull()
+    expect(parseSelectTargetState(JSON.stringify(JSON.stringify({ value: 'CA', label: 'California' })))).toEqual({ value: 'CA', label: 'California' })
+    expect(parseSelectTargetState('{"value":"CA","label":"California"}')).toEqual({ value: 'CA', label: 'California' })
+    expect(parseSelectTargetState('null')).toBeNull()
+    expect(parseSelectTargetState('"null"')).toBeNull()
+    expect(parseSelectTargetState('garbage')).toBeNull()
   })
 
   it('matches only when the TARGET holds the value under the requested label', () => {
-    expect(focusedTargetMatches({ value: 'CA', label: 'California' }, 'California', 'CA')).toBe(true)
-    expect(focusedTargetMatches({ value: 'CA', label: 'California' }, ' California ', 'CA')).toBe(true)
+    expect(targetMatches({ value: 'CA', label: 'California' }, 'California', 'CA')).toBe(true)
+    expect(targetMatches({ value: 'CA', label: 'California' }, ' California ', 'CA')).toBe(true)
     // the reviewer's case: target reverted to New York while another dropdown holds California
-    expect(focusedTargetMatches({ value: 'NY', label: 'New York' }, 'California', 'NY')).toBe(false)
-    expect(focusedTargetMatches(null, 'California', 'CA')).toBe(false)
+    expect(targetMatches({ value: 'NY', label: 'New York' }, 'California', 'NY')).toBe(false)
+    // no <select> with the target's rectangle at that point: unknown, so no match
+    expect(targetMatches(null, 'California', 'CA')).toBe(false)
   })
 })

--- a/agent-container/src/select-verify.test.ts
+++ b/agent-container/src/select-verify.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { judgeSelectCommit } from './select-verify'
+import { judgeSelectCommit, selectLabelMatchScript, parseLabelMatch } from './select-verify'
 
 describe('judgeSelectCommit', () => {
   it('passes when the value committed exactly (select by value)', () => {
@@ -16,13 +16,19 @@ describe('judgeSelectCommit', () => {
     expect(judgeSelectCommit('us', 'us', 'us')).toEqual({ ok: true, committed: 'us' })
   })
 
+  it('passes when the requested LABEL names the option that was already selected', () => {
+    // mining theme 24: 'requested "California", element value is still "CA"' — CA is California
+    expect(judgeSelectCommit('California', 'CA', 'CA', true)).toEqual({ ok: true, committed: 'CA' })
+  })
+
   it('fails when the value reverted (React-controlled select, probe P2)', () => {
     const r = judgeSelectCommit('US', '', '')
     expect(r.ok).toBe(false)
     if (!r.ok) {
-      expect(r.reason).toContain('did not commit')
+      expect(r.reason).toContain('did not change')
       expect(r.reason).toContain('requested "US"')
       expect(r.reason).toContain('Recipe:')
+      expect(r.reason).not.toContain('reverted')
     }
   })
 
@@ -35,9 +41,25 @@ describe('judgeSelectCommit', () => {
     }
   })
 
-  it('fails when the value stayed on a different option', () => {
-    const r = judgeSelectCommit('b', 'a', 'a')
+  it('fails when the value stayed on a different option whose label is not the request', () => {
+    const r = judgeSelectCommit('b', 'a', 'a', false)
     expect(r.ok).toBe(false)
     if (!r.ok) expect(r.reason).toContain('still "a"')
+  })
+})
+
+describe('selectLabelMatchScript', () => {
+  it('embeds the request and value as JSON so quotes cannot break the script', () => {
+    const script = selectLabelMatchScript(' Kids" Menu ', 'k"1')
+    expect(script).toContain('"Kids\\" Menu"')
+    expect(script).toContain('"k\\"1"')
+    expect(script).toContain('querySelectorAll("select")')
+  })
+
+  it('parses the CLI double-encoded boolean', () => {
+    expect(parseLabelMatch('"true"')).toBe(true)
+    expect(parseLabelMatch('true')).toBe(true)
+    expect(parseLabelMatch('"false"')).toBe(false)
+    expect(parseLabelMatch('garbage')).toBe(false)
   })
 })

--- a/agent-container/src/select-verify.test.ts
+++ b/agent-container/src/select-verify.test.ts
@@ -118,3 +118,30 @@ describe('option-list edge cases from review', () => {
     expect(targetOptionMatches(parseSelectOptions(html), 'California', 'CA')).toBe(false)
   })
 })
+
+describe('attribute boundaries', () => {
+  it('does not read label= inside another attribute\'s quoted value', () => {
+    // review: title="Search label='California'" verified California while the target stayed New York
+    const options = parseSelectOptions('<option title="Search label=\'California\'" value="0">New York</option>')
+    expect(options).toEqual([{ value: '0', label: 'New York' }])
+    expect(targetOptionMatches(options, 'California', '0')).toBe(false)
+    expect(parseSelectOptions('<option data-x=\'value="ZZ"\' value="CA">California</option>')).toEqual([{ value: 'CA', label: 'California' }])
+  })
+
+  it('tolerates > and = inside quoted values, unquoted values, and repeated attributes (first wins)', () => {
+    expect(parseSelectOptions('<option title="a>b=c" value=CA value="XX">California</option>')).toEqual([{ value: 'CA', label: 'California' }])
+    expect(parseSelectOptions('<option selected disabled value="">-- pick --</option>')).toEqual([{ value: '', label: '-- pick --' }])
+  })
+
+  it('does not treat attribute-looking text content as attributes', () => {
+    expect(parseSelectOptions('<option value="0">label=\'X\' value="Y"</option>')).toEqual([{ value: '0', label: "label='X' value=\"Y\"" }])
+  })
+
+  it('handles options whose closing tag is omitted, as HTML allows', () => {
+    expect(parseSelectOptions('<option value="a">A<option value="b">B<optgroup label="G"><option value="c">C</optgroup>')).toEqual([
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+      { value: 'c', label: 'C' },
+    ])
+  })
+})

--- a/agent-container/src/select-verify.test.ts
+++ b/agent-container/src/select-verify.test.ts
@@ -96,3 +96,25 @@ describe('target option list from `get html @ref`', () => {
     expect(targetOptionMatches([], 'California', 'CA')).toBe(false)
   })
 })
+
+describe('option-list edge cases from review', () => {
+  it('leaves verification unknown when options with the read-back value carry conflicting labels', () => {
+    // review: California and New York both value "0" — the value does not say which is selected
+    const options = parseSelectOptions('<option value="0">California</option><option value="0" selected>New York</option>')
+    expect(targetOptionMatches(options, 'California', '0')).toBe(false)
+    expect(targetOptionMatches(options, 'New York', '0')).toBe(false)
+    // duplicate values that agree on the label still verify
+    expect(targetOptionMatches(parseSelectOptions('<option value="0">Same</option><option value="0">Same</option>'), 'Same', '0')).toBe(true)
+  })
+
+  it('ignores option-shaped text that is not a live option: comments, template, script, style', () => {
+    const html = [
+      '<!-- <option value="CA">California</option> -->',
+      '<template><option value="CA">California</option></template>',
+      '<script>var s = "<option value=\\"CA\\">California</option>"</script>',
+      '<option value="NY" selected>New York</option>',
+    ].join('')
+    expect(parseSelectOptions(html)).toEqual([{ value: 'NY', label: 'New York' }])
+    expect(targetOptionMatches(parseSelectOptions(html), 'California', 'CA')).toBe(false)
+  })
+})

--- a/agent-container/src/select-verify.test.ts
+++ b/agent-container/src/select-verify.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-  judgeSelectCommit,
-  parseElementBox,
-  selectTargetStateScript,
-  parseSelectTargetState,
-  targetMatches,
-} from './select-verify'
+import { judgeSelectCommit, parseSelectOptions, targetOptionMatches } from './select-verify'
 
 describe('judgeSelectCommit', () => {
   it('passes when the value committed exactly (select by value)', () => {
@@ -57,41 +51,48 @@ describe('judgeSelectCommit', () => {
   })
 })
 
-describe('target identification by rectangle', () => {
-  it('parses the CLI box JSON envelope and a bare box', () => {
-    expect(parseElementBox('{"success":true,"data":{"height":19,"width":85,"x":55,"y":81.875},"error":null}')).toEqual({ x: 55, y: 81.875, width: 85, height: 19 })
-    expect(parseElementBox('{"x":1,"y":2,"width":3,"height":4}')).toEqual({ x: 1, y: 2, width: 3, height: 4 })
-    expect(parseElementBox('{"success":false,"data":null}')).toBeNull()
-    expect(parseElementBox('x:      55')).toBeNull()
+describe('target option list from `get html @ref`', () => {
+  // Captured from agent-browser 0.27.2: `get html @e2` on a <select>.
+  const cliHtml = '<option value="AL">Alabama</option><option value="CA">California</option><option value="NY" selected="">New York</option>'
+
+  it('parses the CLI output into value/label pairs', () => {
+    expect(parseSelectOptions(cliHtml)).toEqual([
+      { value: 'AL', label: 'Alabama' },
+      { value: 'CA', label: 'California' },
+      { value: 'NY', label: 'New York' },
+    ])
   })
 
-  it('reads the <select> AT the box, checks its rectangle, and never consults focus or searches the page', () => {
-    const script = selectTargetStateScript({ x: 55, y: 81.875, width: 85, height: 19 })
-    expect(script).toContain('document.elementFromPoint')
-    expect(script).toContain('getBoundingClientRect')
-    expect(script).toContain('tagName!=="SELECT"')
-    expect(script).not.toContain('activeElement')
-    expect(script).not.toContain('querySelectorAll')
-    // review: <option value="CA" label="California">CA</option> displays California — option.label, not .text
-    expect(script).toContain('o.label||o.text')
-    // both viewport- and document-relative interpretations of the CLI box are tried
-    expect(script).toContain('window.scrollX')
+  it('follows option.label (label attribute over text) and option.value (value attribute over text)', () => {
+    // review: <option value="CA" label="California">CA</option> displays California
+    expect(parseSelectOptions('<option value="CA" label="California">CA</option><option>Texas</option>')).toEqual([
+      { value: 'CA', label: 'California' },
+      { value: 'Texas', label: 'Texas' },
+    ])
   })
 
-  it('parses the CLI double-encoded state and rejects anything else', () => {
-    expect(parseSelectTargetState(JSON.stringify(JSON.stringify({ value: 'CA', label: 'California' })))).toEqual({ value: 'CA', label: 'California' })
-    expect(parseSelectTargetState('{"value":"CA","label":"California"}')).toEqual({ value: 'CA', label: 'California' })
-    expect(parseSelectTargetState('null')).toBeNull()
-    expect(parseSelectTargetState('"null"')).toBeNull()
-    expect(parseSelectTargetState('garbage')).toBeNull()
+  it('handles attribute order, quoting styles, entities, whitespace and optgroups', () => {
+    const html = [
+      '<optgroup label="West"><option selected value=\'WA\'>  Washington\n</option>',
+      "<option value=OR label='Oregon &amp; Coast'>OR</option></optgroup>",
+      '<option value="TX">Texas &#39;n&#39; more</option>',
+    ].join('')
+    expect(parseSelectOptions(html)).toEqual([
+      { value: 'WA', label: 'Washington' },
+      { value: 'OR', label: 'Oregon & Coast' },
+      { value: 'TX', label: "Texas 'n' more" },
+    ])
+    expect(parseSelectOptions('')).toEqual([])
+    expect(parseSelectOptions('✗ Unknown ref: e31')).toEqual([])
   })
 
-  it('matches only when the TARGET holds the value under the requested label', () => {
-    expect(targetMatches({ value: 'CA', label: 'California' }, 'California', 'CA')).toBe(true)
-    expect(targetMatches({ value: 'CA', label: 'California' }, ' California ', 'CA')).toBe(true)
-    // the reviewer's case: target reverted to New York while another dropdown holds California
-    expect(targetMatches({ value: 'NY', label: 'New York' }, 'California', 'NY')).toBe(false)
-    // no <select> with the target's rectangle at that point: unknown, so no match
-    expect(targetMatches(null, 'California', 'CA')).toBe(false)
+  it('matches only when the TARGET option holding the value carries the requested label', () => {
+    const options = parseSelectOptions(cliHtml)
+    expect(targetOptionMatches(options, 'California', 'CA')).toBe(true)
+    expect(targetOptionMatches(options, ' California ', 'CA')).toBe(true)
+    // the reviewer's cases: the target still holds NY — whatever a sibling, a focused or a
+    // covering dropdown holds, this target's NY option is "New York", not "California"
+    expect(targetOptionMatches(options, 'California', 'NY')).toBe(false)
+    expect(targetOptionMatches([], 'California', 'CA')).toBe(false)
   })
 })

--- a/agent-container/src/select-verify.ts
+++ b/agent-container/src/select-verify.ts
@@ -62,9 +62,15 @@ function attr(attrs: string, name: string): string | null {
  */
 export function parseSelectOptions(html: string): SelectOption[] {
   const out: SelectOption[] = []
+  // Option-shaped text that is not an option: comments, and the inert
+  // contents of <template>/<script>/<style> (review: a commented-out
+  // <option> verified a selection that was never available).
+  const live = html
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<(template|script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, '')
   const re = /<option\b([^>]*)>([\s\S]*?)<\/option>/gi
   let m: RegExpExecArray | null
-  while ((m = re.exec(html)) !== null) {
+  while ((m = re.exec(live)) !== null) {
     const text = decodeEntities(m[2].replace(/<[^>]*>/g, '')).replace(/\s+/g, ' ').trim()
     const value = attr(m[1], 'value')
     const label = attr(m[1], 'label')
@@ -80,7 +86,12 @@ export function parseSelectOptions(html: string): SelectOption[] {
  */
 export function targetOptionMatches(options: SelectOption[], requested: string, value: string): boolean {
   const want = requested.trim()
-  return options.some(o => o.value === value && o.label === want)
+  // The read-back value names an option only when every option carrying
+  // that value has the same label: with duplicate values (California and
+  // New York both "0") the value does not say which is selected, so the
+  // verification is unknown, not a match.
+  const holders = options.filter(o => o.value === value)
+  return holders.length > 0 && holders.every(o => o.label === want)
 }
 
 /**

--- a/agent-container/src/select-verify.ts
+++ b/agent-container/src/select-verify.ts
@@ -12,9 +12,10 @@
  * have asked by visible LABEL. When the requested label's option was already
  * selected, value-before equals value-after and neither equals the request —
  * which used to be reported as "did not commit" ("requested California,
- * element value is still CA"; mining theme 24). The route now checks the
- * page for a <select> holding that value whose option with that value
- * carries the requested label, and passes the result in as `labelMatches`.
+ * element value is still CA"; mining theme 24). In that one case the route
+ * focuses the target (`focus @ref`) and reads the focused element's own
+ * value and selected label — the target itself, not any <select> on the
+ * page — and passes the result in as `labelMatches`.
  */
 
 export const SELECT_COMMIT_SETTLE_MS = 300
@@ -30,40 +31,44 @@ export type SelectJudgement =
   | { ok: false; reason: string }
 
 /**
- * In-page script: is there a <select> whose current value is `value` and
- * whose option with that value has the visible label `requested`? Strings
- * are JSON-embedded, so agent input cannot break out of the script.
+ * In-page script, run after `focus @ref`: the focused element's value and
+ * selected option label, or null when the focused element is not a select.
+ * Only the element the CLI focused is inspected — never a sibling dropdown.
  */
-export function selectLabelMatchScript(requested: string, value: string): string {
-  const r = JSON.stringify(requested.trim())
-  const v = JSON.stringify(value)
-  return (
-    'JSON.stringify([].some.call(document.querySelectorAll("select"),function(s){' +
-    `if(s.value!==${v})return false;` +
-    `return [].some.call(s.options,function(o){return o.value===${v}&&String(o.text||"").trim()===${r}})}))`
-  )
-}
+export const FOCUSED_SELECT_STATE_SCRIPT =
+  'JSON.stringify((function(){var a=document.activeElement;if(!a||a.tagName!=="SELECT")return null;' +
+  'var o=a.selectedOptions&&a.selectedOptions[0];return{value:String(a.value),label:o?String(o.text||"").trim():""}})())'
 
-/** Parse the (possibly double-JSON-encoded) output of selectLabelMatchScript. */
-export function parseLabelMatch(stdout: string): boolean {
+export interface FocusedSelectState { value: string; label: string }
+
+/** Parse the (possibly double-JSON-encoded) output of FOCUSED_SELECT_STATE_SCRIPT. */
+export function parseFocusedSelectState(stdout: string): FocusedSelectState | null {
   try {
     let parsed: unknown = JSON.parse(stdout.trim())
     if (typeof parsed === 'string') parsed = JSON.parse(parsed)
-    return parsed === true
+    if (!parsed || typeof parsed !== 'object') return null
+    const o = parsed as Record<string, unknown>
+    if (typeof o.value !== 'string' || typeof o.label !== 'string') return null
+    return { value: o.value, label: o.label }
   } catch {
-    return false
+    return null
   }
+}
+
+/** Does the focused target hold `value` under the requested label? */
+export function focusedTargetMatches(state: FocusedSelectState | null, requested: string, value: string): boolean {
+  return state !== null && state.value === value && state.label === requested.trim()
 }
 
 /**
  * Judge whether a select committed, from the element's value read before and
- * after the select call (null = the read failed, e.g. no value property).
+ * after the select call (null = the read failed).
  *
  * Selecting by visible label is supported by the CLI, so a successful commit
  * may land on a value different from the requested string — any post-select
  * change counts as a commit, and the committed value is reported back. When
- * nothing changed, `labelMatches` (the requested label names the option that
- * holds the current value) also counts as committed: the request was already
+ * nothing changed, `labelMatches` (the target's selected option carries the
+ * requested label) also counts as committed: the request was already
  * satisfied.
  */
 export function judgeSelectCommit(
@@ -73,10 +78,13 @@ export function judgeSelectCommit(
   labelMatches = false
 ): SelectJudgement {
   if (after === null) {
+    // A failed `get value` has many causes (navigation, detached ref, a
+    // connection drop, an element with no value property). None is known
+    // here, so none is named.
     return {
       ok: false,
       reason:
-        `select reported success but the target has no value property to read back, so it is not a native <select>. ${CUSTOM_DROPDOWN_RECIPE}`,
+        `select reported success but the element's value could not be read back afterwards, so the selection is unverified. ${CUSTOM_DROPDOWN_RECIPE}`,
     }
   }
   if (after === requested) {

--- a/agent-container/src/select-verify.ts
+++ b/agent-container/src/select-verify.ts
@@ -13,12 +13,13 @@
  * selected, value-before equals value-after and neither equals the request —
  * which used to be reported as "did not commit" ("requested California,
  * element value is still CA"; mining theme 24). In that one case the route
- * reads the target's own selected option. The CLI resolves refs, not page
- * scripts, so the target is identified geometrically: `get box @ref` gives
- * its rectangle and the in-page script takes the <select> at that point
- * whose rectangle matches — never document.activeElement (a page's onfocus
- * handler can move focus to another dropdown) and never a page-wide search
- * (a sibling dropdown can hold the requested label).
+ * reads the target's own option list with `get html @ref` — a second read
+ * the CLI resolves against the same ref as the select and the value read —
+ * and checks whether the option holding the read-back value carries the
+ * requested label. No page script is involved: a page-wide search can be
+ * satisfied by a sibling dropdown, focus can be redirected by an onfocus
+ * handler, and elementFromPoint returns whichever control covers the
+ * target — all three verified the wrong element in review.
  */
 
 export const SELECT_COMMIT_SETTLE_MS = 300
@@ -33,63 +34,53 @@ export type SelectJudgement =
   | { ok: true; committed: string }
   | { ok: false; reason: string }
 
-export interface ElementBox { x: number; y: number; width: number; height: number }
+export interface SelectOption { value: string; label: string }
 
-/** Parse `get box @ref --json` ({"success":true,"data":{x,y,width,height}}) or the bare data object. */
-export function parseElementBox(stdout: string): ElementBox | null {
-  try {
-    let parsed: unknown = JSON.parse(stdout.trim())
-    if (typeof parsed === 'string') parsed = JSON.parse(parsed)
-    const o = parsed as Record<string, unknown> | null
-    const d = (o && typeof o.data === 'object' && o.data !== null ? o.data : o) as Record<string, unknown> | null
-    if (!d) return null
-    const n = (k: string): number | null => (typeof d[k] === 'number' && Number.isFinite(d[k] as number) ? (d[k] as number) : null)
-    const x = n('x'), y = n('y'), width = n('width'), height = n('height')
-    if (x === null || y === null || width === null || height === null) return null
-    return { x, y, width, height }
-  } catch {
-    return null
-  }
+const ENTITIES: Record<string, string> = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' }
+
+function decodeEntities(s: string): string {
+  return s.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (m, e: string) => {
+    if (e[0] === '#') {
+      const code = e[1].toLowerCase() === 'x' ? parseInt(e.slice(2), 16) : parseInt(e.slice(1), 10)
+      return Number.isFinite(code) ? String.fromCodePoint(code) : m
+    }
+    return ENTITIES[e.toLowerCase()] ?? m
+  })
+}
+
+function attr(attrs: string, name: string): string | null {
+  const m = new RegExp(`(?:^|\\s)${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'>]+))`, 'i').exec(attrs)
+  if (!m) return null
+  return decodeEntities(m[1] ?? m[2] ?? m[3] ?? '')
 }
 
 /**
- * In-page script: the <select> whose rectangle is `box`, read at the box's
- * centre. The CLI's box may be viewport- or document-relative, so both
- * interpretations are tried and a hit must also match the box's size and
- * position (±2px). Returns {value,label} — `label` is option.label, which
- * honours a `label` attribute and falls back to the text — or null when no
- * <select> with that rectangle is at that point.
+ * The options of a <select>, from its innerHTML as `get html @ref` returns
+ * it. `label` follows the DOM's option.label: the label attribute when
+ * present, else the text; `value` follows option.value: the value attribute
+ * when present, else the text.
  */
-export function selectTargetStateScript(box: ElementBox): string {
-  const b = JSON.stringify({ x: box.x, y: box.y, w: box.width, h: box.height })
-  return (
-    'JSON.stringify((function(){var b=' + b + ';var cands=[[b.x+b.w/2,b.y+b.h/2,0,0],[b.x+b.w/2-window.scrollX,b.y+b.h/2-window.scrollY,window.scrollX,window.scrollY]];' +
-    'for(var i=0;i<cands.length;i++){var c=cands[i];var e=document.elementFromPoint(c[0],c[1]);' +
-    'if(!e||e.tagName!=="SELECT")continue;var r=e.getBoundingClientRect();' +
-    'if(Math.abs(r.width-b.w)>2||Math.abs(r.height-b.h)>2||Math.abs(r.left+c[2]-b.x)>2||Math.abs(r.top+c[3]-b.y)>2)continue;' +
-    'var o=e.selectedOptions&&e.selectedOptions[0];return{value:String(e.value),label:o?String(o.label||o.text||"").trim():""}}return null})())'
-  )
-}
-
-export interface SelectTargetState { value: string; label: string }
-
-/** Parse the (possibly double-JSON-encoded) output of selectTargetStateScript. */
-export function parseSelectTargetState(stdout: string): SelectTargetState | null {
-  try {
-    let parsed: unknown = JSON.parse(stdout.trim())
-    if (typeof parsed === 'string') parsed = JSON.parse(parsed)
-    if (!parsed || typeof parsed !== 'object') return null
-    const o = parsed as Record<string, unknown>
-    if (typeof o.value !== 'string' || typeof o.label !== 'string') return null
-    return { value: o.value, label: o.label }
-  } catch {
-    return null
+export function parseSelectOptions(html: string): SelectOption[] {
+  const out: SelectOption[] = []
+  const re = /<option\b([^>]*)>([\s\S]*?)<\/option>/gi
+  let m: RegExpExecArray | null
+  while ((m = re.exec(html)) !== null) {
+    const text = decodeEntities(m[2].replace(/<[^>]*>/g, '')).replace(/\s+/g, ' ').trim()
+    const value = attr(m[1], 'value')
+    const label = attr(m[1], 'label')
+    out.push({ value: value ?? text, label: (label ?? text).trim() })
   }
+  return out
 }
 
-/** Does the target hold `value` under the requested label? */
-export function targetMatches(state: SelectTargetState | null, requested: string, value: string): boolean {
-  return state !== null && state.value === value && state.label === requested.trim()
+/**
+ * Does the target's option holding `value` carry the requested label? Read
+ * from the target's own option list, so a sibling dropdown, a redirected
+ * focus or a covering control cannot answer for it.
+ */
+export function targetOptionMatches(options: SelectOption[], requested: string, value: string): boolean {
+  const want = requested.trim()
+  return options.some(o => o.value === value && o.label === want)
 }
 
 /**
@@ -99,9 +90,9 @@ export function targetMatches(state: SelectTargetState | null, requested: string
  * Selecting by visible label is supported by the CLI, so a successful commit
  * may land on a value different from the requested string — any post-select
  * change counts as a commit, and the committed value is reported back. When
- * nothing changed, `labelMatches` (the target's selected option carries the
- * requested label) also counts as committed: the request was already
- * satisfied.
+ * nothing changed, `labelMatches` (the target's option holding the current
+ * value carries the requested label) also counts as committed: the request
+ * was already satisfied.
  */
 export function judgeSelectCommit(
   requested: string,

--- a/agent-container/src/select-verify.ts
+++ b/agent-container/src/select-verify.ts
@@ -13,9 +13,12 @@
  * selected, value-before equals value-after and neither equals the request —
  * which used to be reported as "did not commit" ("requested California,
  * element value is still CA"; mining theme 24). In that one case the route
- * focuses the target (`focus @ref`) and reads the focused element's own
- * value and selected label — the target itself, not any <select> on the
- * page — and passes the result in as `labelMatches`.
+ * reads the target's own selected option. The CLI resolves refs, not page
+ * scripts, so the target is identified geometrically: `get box @ref` gives
+ * its rectangle and the in-page script takes the <select> at that point
+ * whose rectangle matches — never document.activeElement (a page's onfocus
+ * handler can move focus to another dropdown) and never a page-wide search
+ * (a sibling dropdown can hold the requested label).
  */
 
 export const SELECT_COMMIT_SETTLE_MS = 300
@@ -30,19 +33,48 @@ export type SelectJudgement =
   | { ok: true; committed: string }
   | { ok: false; reason: string }
 
+export interface ElementBox { x: number; y: number; width: number; height: number }
+
+/** Parse `get box @ref --json` ({"success":true,"data":{x,y,width,height}}) or the bare data object. */
+export function parseElementBox(stdout: string): ElementBox | null {
+  try {
+    let parsed: unknown = JSON.parse(stdout.trim())
+    if (typeof parsed === 'string') parsed = JSON.parse(parsed)
+    const o = parsed as Record<string, unknown> | null
+    const d = (o && typeof o.data === 'object' && o.data !== null ? o.data : o) as Record<string, unknown> | null
+    if (!d) return null
+    const n = (k: string): number | null => (typeof d[k] === 'number' && Number.isFinite(d[k] as number) ? (d[k] as number) : null)
+    const x = n('x'), y = n('y'), width = n('width'), height = n('height')
+    if (x === null || y === null || width === null || height === null) return null
+    return { x, y, width, height }
+  } catch {
+    return null
+  }
+}
+
 /**
- * In-page script, run after `focus @ref`: the focused element's value and
- * selected option label, or null when the focused element is not a select.
- * Only the element the CLI focused is inspected — never a sibling dropdown.
+ * In-page script: the <select> whose rectangle is `box`, read at the box's
+ * centre. The CLI's box may be viewport- or document-relative, so both
+ * interpretations are tried and a hit must also match the box's size and
+ * position (±2px). Returns {value,label} — `label` is option.label, which
+ * honours a `label` attribute and falls back to the text — or null when no
+ * <select> with that rectangle is at that point.
  */
-export const FOCUSED_SELECT_STATE_SCRIPT =
-  'JSON.stringify((function(){var a=document.activeElement;if(!a||a.tagName!=="SELECT")return null;' +
-  'var o=a.selectedOptions&&a.selectedOptions[0];return{value:String(a.value),label:o?String(o.text||"").trim():""}})())'
+export function selectTargetStateScript(box: ElementBox): string {
+  const b = JSON.stringify({ x: box.x, y: box.y, w: box.width, h: box.height })
+  return (
+    'JSON.stringify((function(){var b=' + b + ';var cands=[[b.x+b.w/2,b.y+b.h/2,0,0],[b.x+b.w/2-window.scrollX,b.y+b.h/2-window.scrollY,window.scrollX,window.scrollY]];' +
+    'for(var i=0;i<cands.length;i++){var c=cands[i];var e=document.elementFromPoint(c[0],c[1]);' +
+    'if(!e||e.tagName!=="SELECT")continue;var r=e.getBoundingClientRect();' +
+    'if(Math.abs(r.width-b.w)>2||Math.abs(r.height-b.h)>2||Math.abs(r.left+c[2]-b.x)>2||Math.abs(r.top+c[3]-b.y)>2)continue;' +
+    'var o=e.selectedOptions&&e.selectedOptions[0];return{value:String(e.value),label:o?String(o.label||o.text||"").trim():""}}return null})())'
+  )
+}
 
-export interface FocusedSelectState { value: string; label: string }
+export interface SelectTargetState { value: string; label: string }
 
-/** Parse the (possibly double-JSON-encoded) output of FOCUSED_SELECT_STATE_SCRIPT. */
-export function parseFocusedSelectState(stdout: string): FocusedSelectState | null {
+/** Parse the (possibly double-JSON-encoded) output of selectTargetStateScript. */
+export function parseSelectTargetState(stdout: string): SelectTargetState | null {
   try {
     let parsed: unknown = JSON.parse(stdout.trim())
     if (typeof parsed === 'string') parsed = JSON.parse(parsed)
@@ -55,8 +87,8 @@ export function parseFocusedSelectState(stdout: string): FocusedSelectState | nu
   }
 }
 
-/** Does the focused target hold `value` under the requested label? */
-export function focusedTargetMatches(state: FocusedSelectState | null, requested: string, value: string): boolean {
+/** Does the target hold `value` under the requested label? */
+export function targetMatches(state: SelectTargetState | null, requested: string, value: string): boolean {
   return state !== null && state.value === value && state.label === requested.trim()
 }
 

--- a/agent-container/src/select-verify.ts
+++ b/agent-container/src/select-verify.ts
@@ -7,6 +7,14 @@
  * 'Selected "US"' followed by value="" with 245 options). The fix is to read
  * the element's value back after a settle delay and judge whether anything
  * actually committed.
+ *
+ * The read-back is `get value`, i.e. the option's VALUE, while the agent may
+ * have asked by visible LABEL. When the requested label's option was already
+ * selected, value-before equals value-after and neither equals the request —
+ * which used to be reported as "did not commit" ("requested California,
+ * element value is still CA"; mining theme 24). The route now checks the
+ * page for a <select> holding that value whose option with that value
+ * carries the requested label, and passes the result in as `labelMatches`.
  */
 
 export const SELECT_COMMIT_SETTLE_MS = 300
@@ -22,23 +30,53 @@ export type SelectJudgement =
   | { ok: false; reason: string }
 
 /**
+ * In-page script: is there a <select> whose current value is `value` and
+ * whose option with that value has the visible label `requested`? Strings
+ * are JSON-embedded, so agent input cannot break out of the script.
+ */
+export function selectLabelMatchScript(requested: string, value: string): string {
+  const r = JSON.stringify(requested.trim())
+  const v = JSON.stringify(value)
+  return (
+    'JSON.stringify([].some.call(document.querySelectorAll("select"),function(s){' +
+    `if(s.value!==${v})return false;` +
+    `return [].some.call(s.options,function(o){return o.value===${v}&&String(o.text||"").trim()===${r}})}))`
+  )
+}
+
+/** Parse the (possibly double-JSON-encoded) output of selectLabelMatchScript. */
+export function parseLabelMatch(stdout: string): boolean {
+  try {
+    let parsed: unknown = JSON.parse(stdout.trim())
+    if (typeof parsed === 'string') parsed = JSON.parse(parsed)
+    return parsed === true
+  } catch {
+    return false
+  }
+}
+
+/**
  * Judge whether a select committed, from the element's value read before and
  * after the select call (null = the read failed, e.g. no value property).
  *
  * Selecting by visible label is supported by the CLI, so a successful commit
  * may land on a value different from the requested string — any post-select
- * change counts as a commit, and the committed value is reported back.
+ * change counts as a commit, and the committed value is reported back. When
+ * nothing changed, `labelMatches` (the requested label names the option that
+ * holds the current value) also counts as committed: the request was already
+ * satisfied.
  */
 export function judgeSelectCommit(
   requested: string,
   before: string | null,
-  after: string | null
+  after: string | null,
+  labelMatches = false
 ): SelectJudgement {
   if (after === null) {
     return {
       ok: false,
       reason:
-        `select reported success but the target has no readable value — it is probably not a native <select>. ${CUSTOM_DROPDOWN_RECIPE}`,
+        `select reported success but the target has no value property to read back, so it is not a native <select>. ${CUSTOM_DROPDOWN_RECIPE}`,
     }
   }
   if (after === requested) {
@@ -49,10 +87,12 @@ export function judgeSelectCommit(
     // visible label; the committed option VALUE is reported.
     return { ok: true, committed: after }
   }
+  if (labelMatches) {
+    return { ok: true, committed: after }
+  }
   return {
     ok: false,
     reason:
-      `select reported success but the value did not commit (requested "${requested}", element value is still "${after}"). ` +
-      `The site either reverted the change (React-controlled select) or the target is not a native <select>. ${CUSTOM_DROPDOWN_RECIPE}`,
+      `select reported success but the element's value did not change (still "${after}"; requested "${requested}"). ${CUSTOM_DROPDOWN_RECIPE}`,
   }
 }

--- a/agent-container/src/select-verify.ts
+++ b/agent-container/src/select-verify.ts
@@ -48,17 +48,62 @@ function decodeEntities(s: string): string {
   })
 }
 
-function attr(attrs: string, name: string): string | null {
-  const m = new RegExp(`(?:^|\\s)${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'>]+))`, 'i').exec(attrs)
-  if (!m) return null
-  return decodeEntities(m[1] ?? m[2] ?? m[3] ?? '')
+/**
+ * Tokenize a start tag's attributes from `src[i]` (just after the tag
+ * name) to its closing `>`. Walks the text character by character so a
+ * quoted value can contain `>`, `=`, or text that looks like another
+ * attribute (review: `title="Search label='California'"` was read as a
+ * label attribute by a regex). The first occurrence of a name wins, as in
+ * the DOM. Returns the attributes and the index just past `>`.
+ */
+function parseAttributes(src: string, i: number): { attrs: Record<string, string>; end: number } {
+  const attrs: Record<string, string> = {}
+  const n = src.length
+  while (i < n) {
+    while (i < n && /[\s/]/.test(src[i])) i++
+    if (i >= n) break
+    if (src[i] === '>') return { attrs, end: i + 1 }
+    let j = i
+    while (j < n && !/[\s=>/]/.test(src[j])) j++
+    const name = src.slice(i, j).toLowerCase()
+    i = j
+    while (i < n && /\s/.test(src[i])) i++
+    let value = ''
+    if (src[i] === '=') {
+      i++
+      while (i < n && /\s/.test(src[i])) i++
+      const q = src[i]
+      if (q === '"' || q === "'") {
+        const close = src.indexOf(q, i + 1)
+        value = close === -1 ? src.slice(i + 1) : src.slice(i + 1, close)
+        i = close === -1 ? n : close + 1
+      } else {
+        j = i
+        while (j < n && !/[\s>]/.test(src[j])) j++
+        value = src.slice(i, j)
+        i = j
+      }
+    }
+    if (name && !(name in attrs)) attrs[name] = decodeEntities(value)
+  }
+  return { attrs, end: n }
+}
+
+/** Index of the next `<option`, `<optgroup`, `</optgroup`, `</select` or `</option` tag at or after `from`. */
+function nextOptionBoundary(src: string, from: number): number {
+  const re = /<\/?(option|optgroup|select)\b/gi
+  re.lastIndex = from
+  const m = re.exec(src)
+  return m ? m.index : src.length
 }
 
 /**
  * The options of a <select>, from its innerHTML as `get html @ref` returns
  * it. `label` follows the DOM's option.label: the label attribute when
  * present, else the text; `value` follows option.value: the value attribute
- * when present, else the text.
+ * when present, else the text. Tags are tokenized, not regex-matched, and
+ * an option's text ends at the next option/optgroup/select tag, so the
+ * `</option>` HTML lets authors omit is not required.
  */
 export function parseSelectOptions(html: string): SelectOption[] {
   const out: SelectOption[] = []
@@ -68,13 +113,14 @@ export function parseSelectOptions(html: string): SelectOption[] {
   const live = html
     .replace(/<!--[\s\S]*?-->/g, '')
     .replace(/<(template|script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, '')
-  const re = /<option\b([^>]*)>([\s\S]*?)<\/option>/gi
+  const open = /<option\b/gi
   let m: RegExpExecArray | null
-  while ((m = re.exec(live)) !== null) {
-    const text = decodeEntities(m[2].replace(/<[^>]*>/g, '')).replace(/\s+/g, ' ').trim()
-    const value = attr(m[1], 'value')
-    const label = attr(m[1], 'label')
-    out.push({ value: value ?? text, label: (label ?? text).trim() })
+  while ((m = open.exec(live)) !== null) {
+    const { attrs, end } = parseAttributes(live, m.index + '<option'.length)
+    const stop = nextOptionBoundary(live, end)
+    const text = decodeEntities(live.slice(end, stop).replace(/<[^>]*>/g, '')).replace(/\s+/g, ' ').trim()
+    out.push({ value: 'value' in attrs ? attrs.value : text, label: ('label' in attrs ? attrs.label : text).trim() })
+    open.lastIndex = Math.max(end, stop)
   }
   return out
 }

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -812,7 +812,7 @@ const execFileAsync = promisify(execFile);
 import { resolveRunCommandArgs } from './browser-command-args';
 import { validatePressKey } from './press-key';
 import { prepareEvalScript, finalizeEvalOutput, evalErrorHint } from './eval-script';
-import { judgeSelectCommit, SELECT_COMMIT_SETTLE_MS } from './select-verify';
+import { judgeSelectCommit, selectLabelMatchScript, parseLabelMatch, SELECT_COMMIT_SETTLE_MS } from './select-verify';
 import { resolveCommittedValue } from './field-value-readback';
 import { capBrowserOutput, redactCdpUrls, MAX_BROWSER_OUTPUT_CHARS, MAX_BROWSER_ERROR_CHARS } from './browser-output';
 import { capSnapshot, compactWithText, countRefs, formatIframePlaceholders, formatTextFooter, THIN_TREE_REFS } from './snapshot-format';
@@ -1832,7 +1832,16 @@ app.post('/browser/select', async (c) => {
 
     const after = await readValue();
 
-    const judgement = judgeSelectCommit(body.value, before, after);
+    // Unchanged value that is not the requested string: the agent may have
+    // asked by label for the option that was already selected. Check the
+    // page before calling it a failure.
+    let labelMatches = false;
+    if (after !== null && after === before && after !== body.value) {
+      const probe = await execBrowser(['eval', selectLabelMatchScript(body.value, after)], browserState.cdpUrl || undefined);
+      labelMatches = probe.exitCode === 0 && parseLabelMatch(probe.stdout);
+    }
+
+    const judgement = judgeSelectCommit(body.value, before, after, labelMatches);
     if (!judgement.ok) {
       return c.json({ error: judgement.reason, success: false }, 500);
     }

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -812,7 +812,7 @@ const execFileAsync = promisify(execFile);
 import { resolveRunCommandArgs } from './browser-command-args';
 import { validatePressKey } from './press-key';
 import { prepareEvalScript, finalizeEvalOutput, evalErrorHint } from './eval-script';
-import { judgeSelectCommit, FOCUSED_SELECT_STATE_SCRIPT, parseFocusedSelectState, focusedTargetMatches, SELECT_COMMIT_SETTLE_MS } from './select-verify';
+import { judgeSelectCommit, parseElementBox, selectTargetStateScript, parseSelectTargetState, targetMatches, SELECT_COMMIT_SETTLE_MS } from './select-verify';
 import { resolveCommittedValue } from './field-value-readback';
 import { capBrowserOutput, redactCdpUrls, MAX_BROWSER_OUTPUT_CHARS, MAX_BROWSER_ERROR_CHARS } from './browser-output';
 import { capSnapshot, compactWithText, countRefs, formatIframePlaceholders, formatTextFooter, THIN_TREE_REFS } from './snapshot-format';
@@ -1838,10 +1838,14 @@ app.post('/browser/select', async (c) => {
     // the page could be satisfied by a different dropdown.
     let labelMatches = false;
     if (after !== null && after === before && after !== body.value) {
-      const focused = await execBrowser(['focus', body.ref], browserState.cdpUrl || undefined);
-      if (focused.exitCode === 0) {
-        const probe = await execBrowser(['eval', FOCUSED_SELECT_STATE_SCRIPT], browserState.cdpUrl || undefined);
-        labelMatches = probe.exitCode === 0 && focusedTargetMatches(parseFocusedSelectState(probe.stdout), body.value, after);
+      // Identify the target by its rectangle (the CLI resolves the ref), then
+      // read the <select> at that point whose rectangle matches. Focus is not
+      // identity: a page's onfocus handler can move it to another dropdown.
+      const boxRead = await execBrowser(['get', 'box', body.ref, '--json'], browserState.cdpUrl || undefined);
+      const box = boxRead.exitCode === 0 ? parseElementBox(boxRead.stdout) : null;
+      if (box) {
+        const probe = await execBrowser(['eval', selectTargetStateScript(box)], browserState.cdpUrl || undefined);
+        labelMatches = probe.exitCode === 0 && targetMatches(parseSelectTargetState(probe.stdout), body.value, after);
       }
     }
 

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -812,7 +812,7 @@ const execFileAsync = promisify(execFile);
 import { resolveRunCommandArgs } from './browser-command-args';
 import { validatePressKey } from './press-key';
 import { prepareEvalScript, finalizeEvalOutput, evalErrorHint } from './eval-script';
-import { judgeSelectCommit, parseElementBox, selectTargetStateScript, parseSelectTargetState, targetMatches, SELECT_COMMIT_SETTLE_MS } from './select-verify';
+import { judgeSelectCommit, parseSelectOptions, targetOptionMatches, SELECT_COMMIT_SETTLE_MS } from './select-verify';
 import { resolveCommittedValue } from './field-value-readback';
 import { capBrowserOutput, redactCdpUrls, MAX_BROWSER_OUTPUT_CHARS, MAX_BROWSER_ERROR_CHARS } from './browser-output';
 import { capSnapshot, compactWithText, countRefs, formatIframePlaceholders, formatTextFooter, THIN_TREE_REFS } from './snapshot-format';
@@ -1838,15 +1838,12 @@ app.post('/browser/select', async (c) => {
     // the page could be satisfied by a different dropdown.
     let labelMatches = false;
     if (after !== null && after === before && after !== body.value) {
-      // Identify the target by its rectangle (the CLI resolves the ref), then
-      // read the <select> at that point whose rectangle matches. Focus is not
-      // identity: a page's onfocus handler can move it to another dropdown.
-      const boxRead = await execBrowser(['get', 'box', body.ref, '--json'], browserState.cdpUrl || undefined);
-      const box = boxRead.exitCode === 0 ? parseElementBox(boxRead.stdout) : null;
-      if (box) {
-        const probe = await execBrowser(['eval', selectTargetStateScript(box)], browserState.cdpUrl || undefined);
-        labelMatches = probe.exitCode === 0 && targetMatches(parseSelectTargetState(probe.stdout), body.value, after);
-      }
+      // Read the target's own option list through the same ref the select
+      // and the value read used. No page script: a page-wide search, a
+      // focused element or the element at the target's rectangle can all be
+      // a different dropdown (each verified the wrong one in review).
+      const html = await execBrowser(['get', 'html', body.ref], browserState.cdpUrl || undefined);
+      labelMatches = html.exitCode === 0 && targetOptionMatches(parseSelectOptions(html.stdout), body.value, after);
     }
 
     const judgement = judgeSelectCommit(body.value, before, after, labelMatches);

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -812,7 +812,7 @@ const execFileAsync = promisify(execFile);
 import { resolveRunCommandArgs } from './browser-command-args';
 import { validatePressKey } from './press-key';
 import { prepareEvalScript, finalizeEvalOutput, evalErrorHint } from './eval-script';
-import { judgeSelectCommit, selectLabelMatchScript, parseLabelMatch, SELECT_COMMIT_SETTLE_MS } from './select-verify';
+import { judgeSelectCommit, FOCUSED_SELECT_STATE_SCRIPT, parseFocusedSelectState, focusedTargetMatches, SELECT_COMMIT_SETTLE_MS } from './select-verify';
 import { resolveCommittedValue } from './field-value-readback';
 import { capBrowserOutput, redactCdpUrls, MAX_BROWSER_OUTPUT_CHARS, MAX_BROWSER_ERROR_CHARS } from './browser-output';
 import { capSnapshot, compactWithText, countRefs, formatIframePlaceholders, formatTextFooter, THIN_TREE_REFS } from './snapshot-format';
@@ -1833,12 +1833,16 @@ app.post('/browser/select', async (c) => {
     const after = await readValue();
 
     // Unchanged value that is not the requested string: the agent may have
-    // asked by label for the option that was already selected. Check the
-    // page before calling it a failure.
+    // asked by label for the option that was already selected. Focus the
+    // target and read ITS selected option — a probe over every <select> on
+    // the page could be satisfied by a different dropdown.
     let labelMatches = false;
     if (after !== null && after === before && after !== body.value) {
-      const probe = await execBrowser(['eval', selectLabelMatchScript(body.value, after)], browserState.cdpUrl || undefined);
-      labelMatches = probe.exitCode === 0 && parseLabelMatch(probe.stdout);
+      const focused = await execBrowser(['focus', body.ref], browserState.cdpUrl || undefined);
+      if (focused.exitCode === 0) {
+        const probe = await execBrowser(['eval', FOCUSED_SELECT_STATE_SCRIPT], browserState.cdpUrl || undefined);
+        labelMatches = probe.exitCode === 0 && focusedTargetMatches(parseFocusedSelectState(probe.stdout), body.value, after);
+      }
     }
 
     const judgement = judgeSelectCommit(body.value, before, after, labelMatches);

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -460,7 +460,7 @@ Custom dropdowns (divs with role=combobox/listbox) will NOT work with this tool.
     const committed = data?.committedValue
     return {
       content: [
-        { type: 'text' as const, text: `Selected "${args.value}" in ${args.ref} — committed value verified: "${committed}".${effectText(data, 'select', 300)}` },
+        { type: 'text' as const, text: `Selected "${args.value}" in ${args.ref} — the element's value is now "${committed}".${effectText(data, 'select', 300)}` },
       ],
     }
   }

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -47,7 +47,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 3. `browser_press("Enter")` to submit forms after filling inputs
 4. **Read the action result** — click/press/select/hover results report whether the page navigated plus an `Effect:` line of what was observed: dialogs opened or closed, live-region announcements (toasts, validation errors), control state changes (checked, pressed, expanded), typed field values, the change in interactive elements, and where focus is. Fill results report the field's actual committed value. When the line reports a change, trust it; don't re-snapshot just to confirm. `Effect: none observed within Nms (…)` is exactly that — nothing in the listed scope changed; it is not a verdict on the click. A highlight, a change inside an iframe or a canvas, or a slow server all look like this. If you need to know, snapshot or screenshot; do not simply click again, which would undo a toggle.
 5. Re-snapshot when you need updated refs (results say "NAVIGATED — refs are stale") or to read new page content
-6. A ⚠ in a fill result means the page kept a DIFFERENT value than you sent (reformatted/truncated/rejected) — fix it before moving on
+6. A ⚠ in a fill result means the field now holds a DIFFERENT value than you sent; both values are shown. Why is not known — check the field (snapshot with `fullText` shows any validation message) before moving on
 
 ## Tab Management (MANDATORY)
 


### PR DESCRIPTION
## What

**Fill read-back.** On divergence the line was `⚠ Field value is now "X" — differs from the requested "Y". The site reformatted, truncated (maxlength), or rejected the input. If this matters, fix it before moving on; keystroke-listening widgets may need browser_type instead.` It is now `⚠ Field value is now "X" — differs from the "Y" you sent.` The two values are the observation; the cause is not.

**Select read-back.** `judgeSelectCommit` compares the requested string against the option *value* read back. When the agent asked by visible label for the option that was already selected (`requested "California", element value is still "CA"`) it reported "did not commit" and asserted a cause ("the site reverted the change (React-controlled select) or the target is not a native <select>"). The route now runs one in-page check in that exact case — is there a `<select>` whose value is `CA` and whose option with that value is labelled `California`? — and reports it committed. The remaining failure text states what was observed (the value did not change) plus the existing custom-dropdown recipe, without naming a cause. Strings are JSON-embedded in the script.

`Selected "X" in @e3 — committed value verified: "…"` → `— the element's value is now "…"`, which is what was read. Prompt step 6 and `docs/browser-use.md` say the same.

## Why

Transcript-mining theme 24 (≈45/200 sessions): `'⚠ Field value is now "Reels" — differs from the requested "speakeasy". The site reformatted...' — the site did nothing of the sort; ref e10 had been rebound`; `'select reported success but the value did not commit (requested "California", element value is still "CA")' — CA *is* California`; one agent wrote "always re-snapshot after typing rather than trusting the browser_type readback" into its compaction summary. Facts only, per the browser-hints principle in CLAUDE.md.

Verified on the real CLI (agent-browser 0.27.2) that `get value` on a `<select>` returns the option value and `get text` returns every option's label, so the label has to come from the page; and that the select is not focused after `select`, so the check goes through `document.querySelectorAll("select")`.

## Tests

- `select-verify.test.ts`: label-match case passes; unchanged value without label match still fails with "did not change"; the reason no longer contains "reverted"; script embeds quotes safely; parser handles the CLI's double-encoded boolean.
- `browser-digest.test.ts`: divergence line contains both values and none of `reformatted`/`truncated`/`rejected`/`browser_type`.
- prompt tests (`agent-browser-upgrade`, `system-prompt-vars`) pass; typecheck + lint clean.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01792FWz3b1emZ8z1H1DyP3u
