### PR TITLE
fix(browser): say "(no output)" when a browser_run command returns nothing

### DIFF
--- a/agent-container/src/tools/browser.test.ts
+++ b/agent-container/src/tools/browser.test.ts
@@ -241,3 +241,28 @@ describe('browser_eval return note', () => {
     expect(await evalWith('', false)).toBe('(no output)')
   })
 })
+
+describe('browser_run empty output', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('reports "(no output)" instead of a success acknowledgment when the CLI printed nothing', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ success: true, output: '' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })))
+    const runTool = createBrowserTools(() => 'session-r').find(t => t.name === 'browser_run') as any
+    const result = await runTool.handler({ command: 'errors' })
+    expect(String(result.content[0].text)).toMatch(/^\(no output\)/)
+    expect(String(result.content[0].text)).not.toContain('Command executed')
+  })
+
+  it('passes real output through', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ success: true, output: '[error] TypeError: x is null' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })))
+    const runTool = createBrowserTools(() => 'session-r').find(t => t.name === 'browser_run') as any
+    const result = await runTool.handler({ command: 'errors' })
+    expect(String(result.content[0].text)).toMatch(/^\[error\] TypeError/)
+  })
+})

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -656,7 +656,11 @@ Available commands:
     const result = await browserFetch('run', { command: args.command, args: args.args })
     if (!result.success) return errorResult(result.error!)
     const data = result.data as Record<string, unknown>
-    let text = data.output ? String(data.output) : 'Command executed.'
+    // Read verbs (console, errors, cookies, get value/attr, network requests)
+    // legitimately return nothing. "Command executed." read as a clean
+    // result — three mined sessions laundered it into "no console errors"
+    // verdicts. Say what came back: nothing.
+    let text = data.output ? String(data.output) : '(no output)'
     const tabInfo = data.tabInfo as { activeId: string; activeUrl: string; tabCount: number } | undefined
     if (tabInfo) {
       text += tabManager.formatTabNotification(tabInfo)


### PR DESCRIPTION
## What

`browser_run` rendered an empty CLI result as `Command executed.` It now renders `(no output)`, matching `browser_eval`.

## Why

Transcript-mining theme 19 (≈55/200 sessions): `console`, `errors`, `cookies`, `get value`, `get attr` and `network requests` answer with the success acknowledgment when they return nothing — a string that cannot be distinguished from "no console errors", "capture was never armed", "unsupported subcommand" or "output swallowed". Three sessions laundered it into a QA verdict: *"the literal string "Command executed." six times; the final report claimed "No console errors were logged … browser_run("errors") returned clean at every check"*.

"(no output)" is the observation. What it means is for the agent to establish.

## Tests

- `tools/browser.test.ts`: empty output renders `(no output)` and never `Command executed`; real output passes through.
- typecheck + lint clean.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01792FWz3b1emZ8z1H1DyP3u
