### PR TITLE
fix(browser): browser_wait reports how long it waited; refuses syntax the CLI cannot take

### DIFF
--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -813,7 +813,10 @@ import { resolveRunCommandArgs } from './browser-command-args';
 import { validatePressKey } from './press-key';
 import { prepareEvalScript, finalizeEvalOutput, evalErrorHint } from './eval-script';
 import { judgeSelectCommit, parseSelectOptions, targetOptionMatches, SELECT_COMMIT_SETTLE_MS } from './select-verify';
-import { classifyWaitTarget } from './wait-target';
+import { classifyWaitTarget, WAIT_PAGE_PROBE_SCRIPT, parseWaitPageProbe } from './wait-target';
+
+/** Budget for the page probe around a wait — independent of the exec ceiling. */
+const WAIT_PAGE_PROBE_TIMEOUT_MS = 3000;
 import { resolveCommittedValue } from './field-value-readback';
 import { capBrowserOutput, redactCdpUrls, describeExecFailure, BROWSER_EXEC_TIMEOUT_MS, MAX_BROWSER_OUTPUT_CHARS, MAX_BROWSER_ERROR_CHARS } from './browser-output';
 import { capSnapshot, compactWithText, countRefs, formatIframePlaceholders, formatTextFooter, THIN_TREE_REFS } from './snapshot-format';
@@ -876,12 +879,16 @@ function cleanupAgentBrowserDaemon(): void {
 
 // Execute an agent-browser CLI command and return the result.
 // Uses execFile (no shell) to prevent command injection.
-async function execBrowser(args: string[], cdpUrl?: string): Promise<{ stdout: string; exitCode: number }> {
+async function execBrowser(
+  args: string[],
+  cdpUrl?: string,
+  opts: { timeoutMs?: number } = {},
+): Promise<{ stdout: string; exitCode: number }> {
   const started = Date.now();
   try {
     const fullArgs = cdpUrl ? ['--cdp', cdpUrl, ...args] : args;
     const { stdout } = await execFileAsync('agent-browser', fullArgs, {
-      timeout: BROWSER_EXEC_TIMEOUT_MS,
+      timeout: opts.timeoutMs ?? BROWSER_EXEC_TIMEOUT_MS,
       // Large-but-legitimate outputs must not THROW (the throw path used to
       // stuff up to 1 MiB of partial output into an error string);
       // capBrowserOutput below bounds what the model actually sees.
@@ -1701,6 +1708,15 @@ app.post('/browser/wait', async (c) => {
     const result = await execBrowser(target.args, browserState.cdpUrl || undefined);
     const elapsedMs = Date.now() - started;
 
+    // Where the page is now, read through a short budget of its own: a wait
+    // that hung the exec ceiling must not be followed by a probe that hangs
+    // it again (review: one hang could cost ~60 s). A browser that does not
+    // answer in time simply yields no page line.
+    const probePage = async (): Promise<{ url: string; readyState: string } | null> => {
+      const probe = await execBrowser(['eval', WAIT_PAGE_PROBE_SCRIPT], browserState.cdpUrl || undefined, { timeoutMs: WAIT_PAGE_PROBE_TIMEOUT_MS });
+      return probe.exitCode === 0 ? parseWaitPageProbe(probe.stdout) : null;
+    };
+
     if (result.exitCode !== 0) {
       // Load state waits (especially networkidle) often time out on real-world
       // pages with continuous ad/analytics traffic. browser_open already waited
@@ -1709,14 +1725,17 @@ app.post('/browser/wait', async (c) => {
       if (target.kind === 'load') {
         return c.json({ success: true, elapsedMs, timedOut: true });
       }
-      // A timeout is a fact about this page at this moment: say where the
-      // browser was and whether the document had finished loading.
-      const page = await observeNow({ previewChars: 0 });
-      const where = page.url ? `\nPage: ${page.url} · readyState ${page.readyState || 'unknown'}` : '';
+      // Only when the CLI itself reported the timeout (so the browser was
+      // answering) is it worth asking where the page is and whether the
+      // document had finished loading — a fact about this page at this moment.
+      const cliTimedOut = /wait timed out/i.test(result.stdout);
+      const page = cliTimedOut ? await probePage() : null;
+      const where = page?.url ? `\nPage: ${page.url} · readyState ${page.readyState || 'unknown'}` : '';
       return c.json({ error: `${result.stdout}${where}`, success: false }, 500);
     }
 
-    return c.json({ success: true, elapsedMs });
+    const page = await probePage();
+    return c.json({ success: true, elapsedMs, ...(page?.url && { url: page.url }) });
   } catch (error: any) {
     console.error('[Browser] Error waiting:', error);
     return c.json({ error: error.message || 'Failed to wait' }, 500);

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -813,6 +813,7 @@ import { resolveRunCommandArgs } from './browser-command-args';
 import { validatePressKey } from './press-key';
 import { prepareEvalScript, finalizeEvalOutput, evalErrorHint } from './eval-script';
 import { judgeSelectCommit, parseSelectOptions, targetOptionMatches, SELECT_COMMIT_SETTLE_MS } from './select-verify';
+import { classifyWaitTarget } from './wait-target';
 import { resolveCommittedValue } from './field-value-readback';
 import { capBrowserOutput, redactCdpUrls, describeExecFailure, BROWSER_EXEC_TIMEOUT_MS, MAX_BROWSER_OUTPUT_CHARS, MAX_BROWSER_ERROR_CHARS } from './browser-output';
 import { capSnapshot, compactWithText, countRefs, formatIframePlaceholders, formatTextFooter, THIN_TREE_REFS } from './snapshot-format';
@@ -1691,24 +1692,31 @@ app.post('/browser/wait', async (c) => {
       return c.json({ error: 'Browser is not active' }, 400);
     }
 
-    const loadStates = ['networkidle', 'load', 'domcontentloaded'];
-    const isLoadState = loadStates.includes(body.for);
-    const waitArgs = isLoadState
-      ? ['wait', '--load', body.for]
-      : ['wait', body.for];
-    const result = await execBrowser(waitArgs, browserState.cdpUrl || undefined);
-
-    if (result.exitCode !== 0) {
-      // Load state waits (especially networkidle) often time out on real-world pages
-      // with continuous ad/analytics traffic. Since browser_open already waits for the
-      // 'load' event, the page is usable — treat load state timeouts as success.
-      if (isLoadState) {
-        return c.json({ success: true });
-      }
-      return c.json({ error: result.stdout, success: false }, 500);
+    const target = classifyWaitTarget(body.for);
+    if (target.kind === 'rejected') {
+      return c.json({ error: target.reason, success: false }, 400);
     }
 
-    return c.json({ success: true });
+    const started = Date.now();
+    const result = await execBrowser(target.args, browserState.cdpUrl || undefined);
+    const elapsedMs = Date.now() - started;
+
+    if (result.exitCode !== 0) {
+      // Load state waits (especially networkidle) often time out on real-world
+      // pages with continuous ad/analytics traffic. browser_open already waited
+      // for 'load', so the page is usable — not an error, but the result says
+      // the state was not reached rather than pretending it was.
+      if (target.kind === 'load') {
+        return c.json({ success: true, elapsedMs, timedOut: true });
+      }
+      // A timeout is a fact about this page at this moment: say where the
+      // browser was and whether the document had finished loading.
+      const page = await observeNow({ previewChars: 0 });
+      const where = page.url ? `\nPage: ${page.url} · readyState ${page.readyState || 'unknown'}` : '';
+      return c.json({ error: `${result.stdout}${where}`, success: false }, 500);
+    }
+
+    return c.json({ success: true, elapsedMs });
   } catch (error: any) {
     console.error('[Browser] Error waiting:', error);
     return c.json({ error: error.message || 'Failed to wait' }, 500);

--- a/agent-container/src/tools/browser.test.ts
+++ b/agent-container/src/tools/browser.test.ts
@@ -266,3 +266,52 @@ describe('browser_run empty output', () => {
     expect(String(result.content[0].text)).toMatch(/^\[error\] TypeError/)
   })
 })
+
+describe('browser_wait result', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('reports the measured elapsed time, not a constant "satisfied"', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ success: true, elapsedMs: 4 }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })))
+    const waitTool = createBrowserTools(() => 'session-w').find(t => t.name === 'browser_wait') as any
+    const result = await waitTool.handler({ for: 'body' })
+    expect(result.content[0].text).toBe('Selector "body" matched after 4 ms.')
+  })
+
+  it('refuses Playwright syntax before calling the server', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const waitTool = createBrowserTools(() => 'session-w').find(t => t.name === 'browser_wait') as any
+    const result = await waitTool.handler({ for: 'text=Trigger' })
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('--text')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('says a load state was not reached instead of reporting success silently', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ success: true, elapsedMs: 25010, timedOut: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })))
+    const waitTool = createBrowserTools(() => 'session-w').find(t => t.name === 'browser_wait') as any
+    const result = await waitTool.handler({ for: 'networkidle' })
+    expect(result.isError).toBeUndefined()
+    expect(result.content[0].text).toBe('Load state "networkidle" was not reached within 25010 ms.')
+  })
+})
+
+describe('browser_wait result carries the page URL', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('shows where the page is after the wait, so a navigation that finished meanwhile is visible', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ success: true, elapsedMs: 900, url: 'https://a.com/dashboard' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })))
+    const waitTool = createBrowserTools(() => 'session-w').find(t => t.name === 'browser_wait') as any
+    const result = await waitTool.handler({ for: '#dash' })
+    expect(result.content[0].text).toBe('Selector "#dash" matched after 900 ms. Page: https://a.com/dashboard')
+  })
+})

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -20,6 +20,7 @@ import { formatUrlDigest, formatUrlDigestBrief, formatFillReadback, formatScroll
 import { parseObservation, EMPTY_OBSERVATION } from '../page-observer'
 import { landedElsewhere, pageWarnings } from '../page-status'
 import { formatActionEffect, type ActionEffect, type ActionVerb } from '../action-settle'
+import { classifyWaitTarget, formatWaitResult } from '../wait-target'
 
 /** The effect line for a mutating action's result, from the server's settle-and-diff. */
 function effectText(data: Record<string, unknown> | undefined, verb: ActionVerb, fallbackSettleMs: number): string {
@@ -353,20 +354,26 @@ const browserScrollTool = tool(
 
 const browserWaitTool = tool(
   'browser_wait',
-  `Wait for a CSS selector to appear on the page. Only use this when you need to wait for a specific element to render (e.g. after triggering dynamic content). Do NOT use for "networkidle", "load", or "domcontentloaded" — browser_open already waits for the page to load.`,
+  `Wait for a CSS selector to appear on the page, or for a number of milliseconds. The result says how long it actually took — a selector that is already present matches in ~0 ms, which is not a delay.
+
+Playwright locator syntax (text=…, role=…, :has-text(…)) is not CSS and is refused. To wait for text use browser_run(["wait","--text","<text>"]); for a URL, browser_run(["wait","--url","<pattern>"]). "networkidle"/"load"/"domcontentloaded" are accepted but rarely useful — browser_open already waits for the page to load.`,
   {
     for: z
       .string()
       .describe(
-        'CSS selector to wait for (e.g. "#results", ".loaded"). Avoid "networkidle"/"load"/"domcontentloaded" — browser_open already handles page load.'
+        'CSS selector to wait for (e.g. "#results", ".loaded"), or a number of milliseconds to sleep (e.g. "1500").'
       ),
   },
   async (args) => {
+    const target = classifyWaitTarget(args.for)
+    if (target.kind === 'rejected') return errorResult(target.reason)
     const result = await browserFetch('wait', { for: args.for })
     if (!result.success) return errorResult(result.error!)
+    const data = result.data as Record<string, unknown> | undefined
+    const elapsedMs = typeof data?.elapsedMs === 'number' ? data.elapsedMs : 0
     return {
       content: [
-        { type: 'text' as const, text: `Wait condition "${args.for}" satisfied.` },
+        { type: 'text' as const, text: formatWaitResult(target, elapsedMs, data?.timedOut === true) },
       ],
     }
   }

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -373,7 +373,7 @@ Playwright locator syntax (text=…, role=…, :has-text(…)) is not CSS and is
     const elapsedMs = typeof data?.elapsedMs === 'number' ? data.elapsedMs : 0
     return {
       content: [
-        { type: 'text' as const, text: formatWaitResult(target, elapsedMs, data?.timedOut === true) },
+        { type: 'text' as const, text: formatWaitResult(target, elapsedMs, data?.timedOut === true, typeof data?.url === 'string' ? data.url : undefined) },
       ],
     }
   }

--- a/agent-container/src/wait-target.test.ts
+++ b/agent-container/src/wait-target.test.ts
@@ -51,3 +51,25 @@ describe('formatWaitResult', () => {
     expect(formatWaitResult(classifyWaitTarget('load'), 120, false)).toBe('Load state "load" reached after 120 ms.')
   })
 })
+
+describe('classifyWaitTarget respects quoted strings', () => {
+  it('accepts valid CSS whose quoted value contains Playwright-looking text', () => {
+    // review: button[data-note="a>>b"] works in the pinned CLI
+    expect(classifyWaitTarget('button[data-note="a>>b"]').kind).toBe('selector')
+    expect(classifyWaitTarget("[title=':has-text(x)']").kind).toBe('selector')
+    expect(classifyWaitTarget('[data-x="say \\"hi\\" >> there"]').kind).toBe('selector')
+  })
+
+  it('still refuses Playwright syntax outside quotes', () => {
+    expect(classifyWaitTarget('div >> text=Hi').kind).toBe('rejected')
+    expect(classifyWaitTarget('button:has-text("Save")').kind).toBe('rejected')
+    expect(classifyWaitTarget('[data-x="ok"] >> span').kind).toBe('rejected')
+  })
+})
+
+describe('formatWaitResult page line', () => {
+  it('appends the page URL when the route supplied one', () => {
+    expect(formatWaitResult(classifyWaitTarget('.loaded'), 1840, false, 'https://a.com/done')).toBe('Selector ".loaded" matched after 1840 ms. Page: https://a.com/done')
+    expect(formatWaitResult(classifyWaitTarget('.loaded'), 1840, false)).toBe('Selector ".loaded" matched after 1840 ms.')
+  })
+})

--- a/agent-container/src/wait-target.test.ts
+++ b/agent-container/src/wait-target.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { classifyWaitTarget, formatWaitResult } from './wait-target'
+
+describe('classifyWaitTarget', () => {
+  it('passes a CSS selector to the CLI unchanged', () => {
+    expect(classifyWaitTarget('#results .row')).toEqual({ kind: 'selector', args: ['wait', '#results .row'] })
+  })
+
+  it('treats a bare number as milliseconds (the CLI sleeps)', () => {
+    expect(classifyWaitTarget('2000')).toEqual({ kind: 'ms', ms: 2000, args: ['wait', '2000'] })
+  })
+
+  it('maps load states to --load', () => {
+    expect(classifyWaitTarget('networkidle')).toEqual({ kind: 'load', state: 'networkidle', args: ['wait', '--load', 'networkidle'] })
+  })
+
+  it('refuses Playwright locator prefixes and names the --text / --url modes', () => {
+    const r = classifyWaitTarget('text=Trigger')
+    expect(r.kind).toBe('rejected')
+    if (r.kind === 'rejected') {
+      expect(r.reason).toContain('not a CSS selector')
+      expect(r.reason).toContain('["wait","--text","<text>"]')
+      expect(r.reason).toContain('["wait","--url","<pattern>"]')
+    }
+    expect(classifyWaitTarget('role=button').kind).toBe('rejected')
+  })
+
+  it('refuses Playwright-only pseudo selectors', () => {
+    expect(classifyWaitTarget('button:has-text("Save")').kind).toBe('rejected')
+    expect(classifyWaitTarget('div >> text=Hi').kind).toBe('rejected')
+  })
+
+  it('does not refuse valid CSS that merely contains an equals sign', () => {
+    expect(classifyWaitTarget('input[name=email]').kind).toBe('selector')
+    expect(classifyWaitTarget('[data-testid="save"]').kind).toBe('selector')
+  })
+})
+
+describe('formatWaitResult', () => {
+  it('states the elapsed time for a selector, so a 0 ms match is visible as one', () => {
+    expect(formatWaitResult(classifyWaitTarget('body'), 3, false)).toBe('Selector "body" matched after 3 ms.')
+    expect(formatWaitResult(classifyWaitTarget('.loaded'), 1840, false)).toBe('Selector ".loaded" matched after 1840 ms.')
+  })
+
+  it('reports a sleep as a sleep', () => {
+    expect(formatWaitResult(classifyWaitTarget('1500'), 1503, false)).toBe('Waited 1503 ms.')
+  })
+
+  it('never reports a timed-out load state as reached', () => {
+    expect(formatWaitResult(classifyWaitTarget('networkidle'), 25010, true)).toBe('Load state "networkidle" was not reached within 25010 ms.')
+    expect(formatWaitResult(classifyWaitTarget('load'), 120, false)).toBe('Load state "load" reached after 120 ms.')
+  })
+})

--- a/agent-container/src/wait-target.ts
+++ b/agent-container/src/wait-target.ts
@@ -1,0 +1,71 @@
+/**
+ * browser_wait target classification and result wording.
+ *
+ * The tool exposes one string, `for`, and the route used to pass it to the
+ * CLI untouched and print a constant `Wait condition "X" satisfied.` with no
+ * elapsed time. So `body`/`img`/`h1` resolved at t≈0 and read as a real wait
+ * — agents used the tool as a sleep 19×, 102× in single sessions believing
+ * they were throttling — and Playwright locator syntax (`text=Trigger`,
+ * `:has-text(...)`) burned the full 25s timeout on every call, sixteen of
+ * sixteen in one session (transcript-mining theme 10).
+ *
+ * The result now states what was waited for and how long it took; syntax
+ * the CLI cannot take is refused up front, naming the mode that does the
+ * job. Neither is a judgement about the page.
+ */
+
+export const WAIT_LOAD_STATES = ['networkidle', 'load', 'domcontentloaded'] as const
+
+export type WaitTarget =
+  | { kind: 'selector'; args: string[] }
+  | { kind: 'ms'; ms: number; args: string[] }
+  | { kind: 'load'; state: string; args: string[] }
+  | { kind: 'rejected'; reason: string }
+
+const PLAYWRIGHT_PREFIX = /^\s*(text|role|id|xpath|css|data-testid)\s*=/i
+const PLAYWRIGHT_PSEUDO = /:has-text\(|:text\(|:text-is\(|:nth-match\(|>>/
+
+/** Map the tool's `for` argument to CLI args, or refuse it with the alternative named. */
+export function classifyWaitTarget(raw: string): WaitTarget {
+  const s = raw.trim()
+  if (/^\d+$/.test(s)) {
+    return { kind: 'ms', ms: Number(s), args: ['wait', s] }
+  }
+  if ((WAIT_LOAD_STATES as readonly string[]).includes(s)) {
+    return { kind: 'load', state: s, args: ['wait', '--load', s] }
+  }
+  if (PLAYWRIGHT_PREFIX.test(s)) {
+    return {
+      kind: 'rejected',
+      reason:
+        `"${s}" is Playwright locator syntax, not a CSS selector, and the CLI would wait the full timeout without matching. ` +
+        'To wait for text on the page use browser_run(["wait","--text","<text>"]); for a URL, browser_run(["wait","--url","<pattern>"]); otherwise pass a CSS selector.',
+    }
+  }
+  if (PLAYWRIGHT_PSEUDO.test(s)) {
+    return {
+      kind: 'rejected',
+      reason:
+        `"${s}" uses Playwright-only selector syntax (:has-text, :text, >>), which the CLI does not accept. ` +
+        'Use plain CSS, or browser_run(["wait","--text","<text>"]) to wait for text.',
+    }
+  }
+  return { kind: 'selector', args: ['wait', s] }
+}
+
+/** The result line: what was waited for, and how long it actually took. */
+export function formatWaitResult(target: WaitTarget, elapsedMs: number, timedOut: boolean): string {
+  const ms = Math.max(0, Math.round(elapsedMs))
+  switch (target.kind) {
+    case 'ms':
+      return `Waited ${ms} ms.`
+    case 'load':
+      return timedOut
+        ? `Load state "${target.state}" was not reached within ${ms} ms.`
+        : `Load state "${target.state}" reached after ${ms} ms.`
+    case 'selector':
+      return `Selector ${JSON.stringify(target.args[1])} matched after ${ms} ms.`
+    case 'rejected':
+      return target.reason
+  }
+}

--- a/agent-container/src/wait-target.ts
+++ b/agent-container/src/wait-target.ts
@@ -25,6 +25,43 @@ export type WaitTarget =
 const PLAYWRIGHT_PREFIX = /^\s*(text|role|id|xpath|css|data-testid)\s*=/i
 const PLAYWRIGHT_PSEUDO = /:has-text\(|:text\(|:text-is\(|:nth-match\(|>>/
 
+/**
+ * The selector with its quoted strings blanked out, so `>>` or `:has-text(`
+ * inside an attribute value (`button[data-note="a>>b"]`, valid CSS the CLI
+ * accepts) is not mistaken for Playwright syntax. Escapes inside quotes are
+ * honoured; an unterminated quote blanks to the end.
+ */
+export function stripQuotedStrings(s: string): string {
+  let out = ''
+  let quote: string | null = null
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]
+    if (quote) {
+      if (ch === '\\') { i++; continue }
+      if (ch === quote) { quote = null; out += ch }
+      continue
+    }
+    if (ch === '"' || ch === "'") { quote = ch; out += ch; continue }
+    out += ch
+  }
+  return out
+}
+
+/** In-page probe used around waits: where the page is and whether it finished loading. */
+export const WAIT_PAGE_PROBE_SCRIPT = 'JSON.stringify({u:String(location.href||""),r:String(document.readyState||"")})'
+
+export function parseWaitPageProbe(stdout: string): { url: string; readyState: string } | null {
+  try {
+    let parsed: unknown = JSON.parse(stdout.trim())
+    if (typeof parsed === 'string') parsed = JSON.parse(parsed)
+    const o = parsed as Record<string, unknown> | null
+    if (!o || typeof o.u !== 'string') return null
+    return { url: o.u, readyState: typeof o.r === 'string' ? o.r : '' }
+  } catch {
+    return null
+  }
+}
+
 /** Map the tool's `for` argument to CLI args, or refuse it with the alternative named. */
 export function classifyWaitTarget(raw: string): WaitTarget {
   const s = raw.trim()
@@ -34,6 +71,7 @@ export function classifyWaitTarget(raw: string): WaitTarget {
   if ((WAIT_LOAD_STATES as readonly string[]).includes(s)) {
     return { kind: 'load', state: s, args: ['wait', '--load', s] }
   }
+  // The prefix test runs on the raw start: no CSS selector begins `text=`.
   if (PLAYWRIGHT_PREFIX.test(s)) {
     return {
       kind: 'rejected',
@@ -42,7 +80,7 @@ export function classifyWaitTarget(raw: string): WaitTarget {
         'To wait for text on the page use browser_run(["wait","--text","<text>"]); for a URL, browser_run(["wait","--url","<pattern>"]); otherwise pass a CSS selector.',
     }
   }
-  if (PLAYWRIGHT_PSEUDO.test(s)) {
+  if (PLAYWRIGHT_PSEUDO.test(stripQuotedStrings(s))) {
     return {
       kind: 'rejected',
       reason:
@@ -53,18 +91,23 @@ export function classifyWaitTarget(raw: string): WaitTarget {
   return { kind: 'selector', args: ['wait', s] }
 }
 
-/** The result line: what was waited for, and how long it actually took. */
-export function formatWaitResult(target: WaitTarget, elapsedMs: number, timedOut: boolean): string {
+/**
+ * The result line: what was waited for, how long it actually took, and —
+ * when the route could read it — where the page is now, so a navigation
+ * that finished during the wait is visible on the result itself.
+ */
+export function formatWaitResult(target: WaitTarget, elapsedMs: number, timedOut: boolean, url?: string): string {
   const ms = Math.max(0, Math.round(elapsedMs))
+  const page = url ? ` Page: ${url}` : ''
   switch (target.kind) {
     case 'ms':
-      return `Waited ${ms} ms.`
+      return `Waited ${ms} ms.${page}`
     case 'load':
-      return timedOut
+      return (timedOut
         ? `Load state "${target.state}" was not reached within ${ms} ms.`
-        : `Load state "${target.state}" reached after ${ms} ms.`
+        : `Load state "${target.state}" reached after ${ms} ms.`) + page
     case 'selector':
-      return `Selector ${JSON.stringify(target.args[1])} matched after ${ms} ms.`
+      return `Selector ${JSON.stringify(target.args[1])} matched after ${ms} ms.${page}`
     case 'rejected':
       return target.reason
   }

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -16,7 +16,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - `browser_select(ref, value)` — Select an option in a NATIVE `<select>` (by value or visible label; commit is verified). Custom dropdowns (role=combobox/listbox divs): click the trigger, re-snapshot, type into the filter input, click the option's FRESH ref — refs renumber after each committed selection, so re-snapshot between selections
 - `browser_upload(filePath, selector?)` — Upload a local file into an `<input type="file">`. Use this for Dropbox, Box, Dropzone, and any file picker flow.
 - `browser_download(url, filename?)` — Download a file/image/asset through the browser (cookies + login state apply) into `/workspace/downloads/`. To save an image: get its URL first (`browser_run("get attr @e5 src")` or `browser_eval`), then download it. Report the returned path to the parent agent.
-- `browser_wait(for)` — Wait for a CSS selector to appear on the page. Do NOT use for load states — `browser_open` already waits for the page to load.
+- `browser_wait(for)` — Wait for a CSS selector to appear, or a number of milliseconds. The result reports how long it actually took (a selector already on the page matches in ~0 ms — that is not a delay). Not for load states — `browser_open` already waits for the page to load. To wait for text: `browser_run(["wait","--text","<text>"])`.
 - `browser_screenshot(full?)` — Take a screenshot (returns file path; use Read to see the image)
 
 **Navigation:**


### PR DESCRIPTION
## What

New `wait-target.ts` classifies `browser_wait`'s `for` argument and words the result:

| input | result |
|---|---|
| `.loaded` | `Selector ".loaded" matched after 1840 ms.` |
| `body` (already present) | `Selector "body" matched after 3 ms.` |
| `1500` | `Waited 1503 ms.` |
| `networkidle` reached | `Load state "networkidle" reached after 120 ms.` |
| `networkidle` timed out | `Load state "networkidle" was not reached within 25010 ms.` (not an error, as before — but no longer a silent success) |
| `text=Trigger`, `role=button`, `button:has-text("Save")`, `div >> x` | refused before the CLI runs: not CSS; names `browser_run(["wait","--text","<text>"])` / `["wait","--url","<pattern>"]` |
| selector timeout | the CLI's `✗ Wait timed out after 25000ms` plus `Page: <url> · readyState <state>` |

The route measures wall-clock around the exec; the tool renders from the same classifier. Tool description and prompt line updated (the CLI's `wait --help` confirms the `<ms>`, `--text`, `--url`, `--load` modes).

## Why

Transcript-mining theme 10 (≈74/200 sessions, ~380 wasted calls): *"used a tool that does nothing 102 times, saying 'let me wait longer' after each one … The harness never once said 'this didn't wait'"*; *"'Wait condition "body" satisfied.' — technically true, functionally a lie; it resolved in 0ms and the agent believed its rate-limit mitigation was in effect"*; *"repeated `text=Trigger` nine times across three hours, treating the 25s failure as a sleep primitive"*.

Everything printed is a measurement or a syntax fact. No claim about the page beyond its URL and readyState at the moment of a timeout.

## Tests

- `wait-target.test.ts`: classification (CSS, ms, load states, Playwright prefixes and pseudo-selectors, CSS with `=` not refused) and wording (0 ms visible, sleep, load timeout never "reached").
- `tools/browser.test.ts`: measured elapsed rendered; Playwright syntax refused without a server call; load timeout reported as not reached.
- prompt tests pass; typecheck + lint clean.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01792FWz3b1emZ8z1H1DyP3u
