### PR TITLE
fix(browser): browser_get_state is one observation — URL from its own snapshot, one line per failure cause

### DIFF
--- a/agent-container/src/tools/browser.test.ts
+++ b/agent-container/src/tools/browser.test.ts
@@ -315,3 +315,101 @@ describe('browser_wait result carries the page URL', () => {
     expect(result.content[0].text).toBe('Selector "#dash" matched after 900 ms. Page: https://a.com/dashboard')
   })
 })
+
+describe('browser_get_state coherence', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+
+  it('takes the URL from the snapshot it shows, and never calls get url', async () => {
+    const calls: string[] = []
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      calls.push(String(url))
+      if (String(url).endsWith('/browser/snapshot')) {
+        return json({
+          snapshot: '[page] https://b.com/results · "Results" · HTTP 200 · complete · 3 refs\n\n- button "Go" [ref=e1]',
+          page: { url: 'https://b.com/results', title: 'Results', readyState: 'complete', httpStatus: 200, contentType: 'text/html' },
+          tabCount: 1,
+        })
+      }
+      return json({ output: 'Screenshot saved to: /nonexistent/shot.png' })
+    }))
+    const tool = createBrowserTools(() => 's').find(t => t.name === 'browser_get_state') as any
+    const result = await tool.handler({})
+    const text = String(result.content.find((c: any) => c.type === 'text').text)
+    expect(text).toContain('**Current URL:** https://b.com/results')
+    expect(text).toContain('**Accessibility Snapshot:**')
+    expect(calls.some(u => u.endsWith('/browser/run'))).toBe(false)
+    expect(calls.indexOf(calls.find(u => u.endsWith('/browser/snapshot'))!)).toBeLessThan(calls.indexOf(calls.find(u => u.endsWith('/browser/screenshot'))!))
+    expect(result.isError).toBeUndefined()
+  })
+
+  it('collapses one cause that failed every leg into one error line and marks the result an error', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({ error: '✗ Auto-launch failed: CDP WebSocket connect failed: HTTP error: 410 Gone' }, 500)))
+    const tool = createBrowserTools(() => 's').find(t => t.name === 'browser_get_state') as any
+    const result = await tool.handler({})
+    const text = String(result.content[0].text)
+    expect(text.match(/410 Gone/g)).toHaveLength(1)
+    expect(text).toContain('**Error (snapshot and screenshot):**')
+    expect(text).not.toContain('Current URL')
+    expect(result.isError).toBe(true)
+  })
+
+  it('keeps a partial failure as a section error without marking the whole result an error', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (String(url).endsWith('/browser/snapshot')) {
+        return json({ snapshot: '[page] https://b.com/ · "B" · HTTP 200 · complete · 1 refs\n\n- link "x" [ref=e1]', page: { url: 'https://b.com/', title: 'B', readyState: 'complete', httpStatus: 200, contentType: 'text/html' }, tabCount: 1 })
+      }
+      return json({ error: 'screenshot timed out' }, 500)
+    }))
+    const tool = createBrowserTools(() => 's').find(t => t.name === 'browser_get_state') as any
+    const result = await tool.handler({})
+    const text = String(result.content[0].text)
+    expect(text).toContain('**Error (screenshot):** screenshot timed out')
+    expect(text).toContain('**Current URL:** https://b.com/')
+    expect(result.isError).toBeUndefined()
+  })
+
+  it('omits the screenshot leg entirely when screenshot=false, so a single failure is total', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json({ error: 'Browser is not active' }, 400)))
+    const tool = createBrowserTools(() => 's').find(t => t.name === 'browser_get_state') as any
+    const result = await tool.handler({ screenshot: false })
+    expect(String(result.content[0].text)).toBe('**Error (snapshot):** Browser is not active')
+    expect(result.isError).toBe(true)
+  })
+})
+
+describe('browser_get_state screenshot delivery', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+
+  it('counts an unreadable screenshot file as a failed leg, so snapshot failure + unreadable file is a total failure', async () => {
+    // review: snapshot failed and the screenshot file could not be read/resized — nothing delivered, isError absent
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (String(url).endsWith('/browser/snapshot')) return json({ error: 'Browser is not active' }, 400)
+      return json({ output: 'Screenshot saved to: /nonexistent/dir/shot.png' })
+    }))
+    const tool = createBrowserTools(() => 's').find(t => t.name === 'browser_get_state') as any
+    const result = await tool.handler({})
+    const text = String(result.content[0].text)
+    expect(result.content.some((c: any) => c.type === 'image')).toBe(false)
+    expect(text).toContain('**Error (snapshot):** Browser is not active')
+    expect(text).toContain('**Error (screenshot):** screenshot file could not be read: /nonexistent/dir/shot.png')
+    expect(text).not.toContain('**Screenshot:**')
+    expect(result.isError).toBe(true)
+  })
+
+  it('treats a missing screenshot path as a failed leg too', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (String(url).endsWith('/browser/snapshot')) return json({ snapshot: '[page] https://b.com/ · "B" · HTTP 200 · complete · 1 refs\n- link "x" [ref=e1]', page: { url: 'https://b.com/', title: 'B', readyState: 'complete', httpStatus: 200, contentType: 'text/html' }, tabCount: 1 })
+      return json({ output: '' })
+    }))
+    const tool = createBrowserTools(() => 's').find(t => t.name === 'browser_get_state') as any
+    const result = await tool.handler({})
+    expect(String(result.content[0].text)).toContain('**Error (screenshot):** no screenshot path returned')
+    expect(result.isError).toBeUndefined()
+  })
+})

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -732,21 +732,30 @@ const browserGetStateTool = tool(
       parts.push(`**Current URL:** ${page.url}`)
     }
 
+    // The screenshot leg delivered something only when an image reached the
+    // result. A route success whose file cannot be read or resized is a
+    // failure like any other (review: it used to leave isError unset with
+    // nothing delivered).
+    let screenshotFailure: string | null = null
     if (screenshotResult === null) {
       // screenshot=false: nothing to report
     } else if (screenshotResult.success) {
       const data = screenshotResult.data as Record<string, unknown>
       const rawOutput = data.output ? String(data.output) : ''
       const filePath = rawOutput ? extractScreenshotPath(rawOutput) : ''
-      if (filePath) {
+      if (!filePath) {
+        screenshotFailure = 'no screenshot path returned'
+      } else {
         const image = await readScreenshotAsBase64(filePath)
         if (image) {
           content.push({ type: 'image' as const, data: image.data, mimeType: image.mimeType })
+          parts.push(`**Screenshot:** ${filePath}`)
+        } else {
+          screenshotFailure = `screenshot file could not be read: ${filePath}`
         }
-        parts.push(`**Screenshot:** ${filePath}`)
-      } else {
-        parts.push(`**Screenshot:** No screenshot path returned`)
       }
+    } else {
+      screenshotFailure = screenshotResult.error ?? 'unknown error'
     }
 
     if (snapshotData) {
@@ -760,7 +769,7 @@ const browserGetStateTool = tool(
     }
 
     if (!snapshotData) failures.push(`snapshot: ${snapshotResult.error}`)
-    if (screenshotResult !== null && !screenshotResult.success) failures.push(`screenshot: ${screenshotResult.error}`)
+    if (screenshotFailure !== null) failures.push(`screenshot: ${screenshotFailure}`)
 
     // One line per distinct cause: a dead browser fails every leg with the
     // same message, which is one fact, not two.

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -707,26 +707,29 @@ const browserGetStateTool = tool(
       .describe('Capture and return a screenshot image (default: true). Set false when you only need URL + snapshot.'),
   },
   async (args) => {
-    const [urlResult, screenshotResult, snapshotResult] = await Promise.all([
-      browserFetch('run', { command: 'get url' }),
-      args.screenshot === false ? Promise.resolve(null) : browserFetch('screenshot', { full: false }),
-      browserFetch('snapshot', {
-        interactive: true,
-        compact: true,
-        scope: args.scope,
-        fullText: args.fullText,
-        includeUrls: args.includeUrls,
-      }),
-    ])
+    // One observation, in order: the snapshot first (its page probe carries
+    // the URL, so no separate `get url`), then the screenshot. The old version
+    // fired `get url`, screenshot and snapshot in parallel with no shared
+    // instant, so "Current URL" could name a different page than the snapshot
+    // beside it, and a dead browser printed the same CDP error three times
+    // inside a success-shaped result (transcript-mining theme 23).
+    const snapshotResult = await browserFetch('snapshot', {
+      interactive: true,
+      compact: true,
+      scope: args.scope,
+      fullText: args.fullText,
+      includeUrls: args.includeUrls,
+    })
+    const screenshotResult = args.screenshot === false ? null : await browserFetch('screenshot', { full: false })
 
     const content: Array<{ type: 'image'; data: string; mimeType: string } | { type: 'text'; text: string }> = []
     const parts: string[] = []
+    const failures: string[] = []
 
-    if (urlResult.success) {
-      const data = urlResult.data as Record<string, unknown>
-      parts.push(`**Current URL:** ${data.output || 'unknown'}`)
-    } else {
-      parts.push(`**Current URL:** Error - ${urlResult.error}`)
+    const snapshotData = snapshotResult.success ? (snapshotResult.data as Record<string, unknown>) : null
+    const page = snapshotData?.page ? parseObservation(JSON.stringify(snapshotData.page)) : null
+    if (page?.url) {
+      parts.push(`**Current URL:** ${page.url}`)
     }
 
     if (screenshotResult === null) {
@@ -744,26 +747,40 @@ const browserGetStateTool = tool(
       } else {
         parts.push(`**Screenshot:** No screenshot path returned`)
       }
-    } else {
-      parts.push(`**Screenshot:** Error - ${screenshotResult.error}`)
     }
 
-    if (snapshotResult.success) {
-      const data = snapshotResult.data as Record<string, unknown>
-      const tabCount = typeof data.tabCount === 'number' ? data.tabCount : 0
-      const snapshot = data.snapshot
-        ? String(data.snapshot)
-        : JSON.stringify(data, null, 2)
+    if (snapshotData) {
+      const tabCount = typeof snapshotData.tabCount === 'number' ? snapshotData.tabCount : 0
+      const snapshot = snapshotData.snapshot
+        ? String(snapshotData.snapshot)
+        : JSON.stringify(snapshotData, null, 2)
       parts.push(`**Accessibility Snapshot:**\n${snapshot}`)
       const tabStatus = tabManager.formatTabStatus(tabCount)
       if (tabStatus) parts.push(tabStatus.trim())
-    } else {
-      parts.push(`**Accessibility Snapshot:** Error - ${snapshotResult.error}`)
+    }
+
+    if (!snapshotData) failures.push(`snapshot: ${snapshotResult.error}`)
+    if (screenshotResult !== null && !screenshotResult.success) failures.push(`screenshot: ${screenshotResult.error}`)
+
+    // One line per distinct cause: a dead browser fails every leg with the
+    // same message, which is one fact, not two.
+    const requested = screenshotResult === null ? 1 : 2
+    const allFailed = failures.length === requested
+    if (failures.length > 0) {
+      const causes = new Map<string, string[]>()
+      for (const f of failures) {
+        const [leg, ...rest] = f.split(': ')
+        const cause = rest.join(': ')
+        causes.set(cause, [...(causes.get(cause) ?? []), leg])
+      }
+      for (const [cause, legs] of causes) {
+        parts.push(`**Error (${legs.join(' and ')}):** ${cause}`)
+      }
     }
 
     content.push({ type: 'text' as const, text: parts.join('\n\n') })
 
-    return { content }
+    return allFailed ? { content, isError: true } : { content }
   }
 )
 


### PR DESCRIPTION
## What

`browser_get_state` ran `get url`, `screenshot` and `snapshot` in `Promise.all` and concatenated whatever came back, `isError` never set. Now:

- **Snapshot first, then screenshot**, sequentially. The URL comes from the snapshot's own page probe (the same one that prints the `[page]` status line), so the `**Current URL:**` line can no longer disagree with the tree under it. One fewer CLI round trip.
- **One line per distinct failure cause.** A dead browser fails every leg with the same message; that is one fact: `**Error (snapshot and screenshot):** ✗ Auto-launch failed: … 410 Gone`. A partial failure stays a section error (`**Error (screenshot):** …`) with the rest of the result intact.
- **`isError: true` when every requested leg failed** (with `screenshot: false`, that is the snapshot alone).

## Why

Transcript-mining theme 23 (≈48/200 sessions): *"'Current URL: …CorpSearchResults.aspx' next to a screenshot and snapshot that are unambiguously the Rhode Island … entity search"*; *"browser_get_state on a dead browser printed the same 'CDP WebSocket connect failed: HTTP error: 410 Gone' three times as three separate field errors, obscuring the one actionable fact"*; *"'Current URL: Error - ✗ Auto-launch failed…' alongside a complete, correct snapshot"*.

## Tests

- `tools/browser.test.ts`: URL taken from the snapshot's page and `get url` never called, snapshot before screenshot; one cause failing both legs → one error line + `isError`; partial failure → section error, no `isError`; `screenshot:false` single failure is total.
- typecheck + lint clean.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01792FWz3b1emZ8z1H1DyP3u
