### PR TITLE
fix(browser): show the browser-guide hint once per browser launch, not on every open

### DIFF
--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -1283,6 +1283,9 @@ app.post('/browser/open', async (c) => {
       }
     }
 
+    // A net-new browser (none active, or the location switch above closed the
+    // old one) is the one moment the browser-guide hint belongs on the result.
+    const launched = !browserState.active;
     const hostBrowser = await launchHostBrowserIfNeeded(location);
     const cdpUrl = hostBrowser?.cdpUrl;
     const profile = process.env.AGENT_BROWSER_PROFILE || '/workspace/.browser-profile';
@@ -1341,7 +1344,7 @@ app.post('/browser/open', async (c) => {
     }
     broadcastBrowserEvent(true);
 
-    return c.json({ success: true, location, switchedFrom, page });
+    return c.json({ success: true, location, switchedFrom, page, launched });
   } catch (error: any) {
     console.error('[Browser] Error opening browser:', error);
     return c.json({ error: error.message || 'Failed to open browser' }, 500);

--- a/agent-container/src/tools/browser.test.ts
+++ b/agent-container/src/tools/browser.test.ts
@@ -77,6 +77,7 @@ describe('browser_open location', () => {
       success: true,
       location: 'container',
       switchedFrom: 'host',
+      launched: true,
     }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
@@ -171,6 +172,7 @@ describe('browser_open location', () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
       success: true,
       location: 'container',
+      launched: true,
     }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
@@ -186,7 +188,7 @@ describe('browser_open location', () => {
     expect(result.content[0].text).toContain('/opt/gamut/docs/browser-use.md')
   })
 
-  it('returns the browser guide hint when switching to an existing tab', async () => {
+  it('omits the browser guide hint when switching to an existing tab', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
       success: true,
       location: 'container',
@@ -202,6 +204,32 @@ describe('browser_open location', () => {
       .find(candidate => candidate.name === 'browser_open') as any
     const result = await openTool.handler({ url: 'https://example.com' })
 
-    expect(result.content[0].text).toContain(BROWSER_USE_GUIDANCE_HINT)
+    expect(result.content[0].text).not.toContain(BROWSER_USE_GUIDANCE_HINT)
+  })
+})
+
+describe('browser guide hint frequency', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  const open = async (body: Record<string, unknown>) => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })))
+    const openTool = createBrowserTools(() => 'session-h').find(t => t.name === 'browser_open') as any
+    const result = await openTool.handler({ url: 'https://example.com/a' })
+    return String(result.content[0].text)
+  }
+  const page = { url: 'https://example.com/a', title: 'A', readyState: 'complete', httpStatus: 200, contentType: 'text/html' }
+
+  it('attaches the hint when the open launched a browser', async () => {
+    expect(await open({ success: true, location: 'host', page, launched: true })).toContain(BROWSER_USE_GUIDANCE_HINT)
+    expect(await open({ success: true, location: 'host', launched: true })).toContain(BROWSER_USE_GUIDANCE_HINT)
+  })
+
+  it('omits the hint for an open inside an already-running browser', async () => {
+    expect(await open({ success: true, location: 'host', page })).not.toContain(BROWSER_USE_GUIDANCE_HINT)
+    expect(await open({ success: true, location: 'host', page, launched: false })).not.toContain(BROWSER_USE_GUIDANCE_HINT)
+    expect(await open({ success: true, location: 'host' })).not.toContain(BROWSER_USE_GUIDANCE_HINT)
   })
 })

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -33,7 +33,10 @@ const CONTAINER_URL = `http://localhost:${process.env.PORT || '3000'}`
 // with a web-browser subagent to delegate rather than read. An unconditional
 // "required" here would either undo that saving or train the model to ignore
 // these hints — including in the no-subagent case where the read is the only
-// source of browsing guidance.
+// source of browsing guidance. It is attached once per browser launch (the
+// open that started a browser), never on tab switches or navigations inside
+// a live browser: repeated on every open, it told the web-browser subagent
+// up to 50 times a session to consider delegating to itself (mining theme 31).
 export const BROWSER_USE_GUIDANCE_HINT =
   'Guidance: if you will drive the browser yourself rather than delegate to the web-browser agent, read `/opt/gamut/docs/browser-use.md` before interacting (unless you already read it in this conversation).'
 
@@ -138,13 +141,14 @@ Omit location to keep using the current browser where it is; when no browser is 
     const localhostWarning = isLoopbackBrowserUrl(args.url) && activeLocation === 'host'
       ? '\n\nWARNING: This URL points at the host browser\'s own loopback interface. If you meant a service inside the agent container, reopen it with location="container".'
       : ''
+    const guide = data?.launched === true ? `\n\n${BROWSER_USE_GUIDANCE_HINT}` : ''
 
     if (data?.switchedToExisting) {
       return {
         content: [
           {
             type: 'text' as const,
-            text: `Switched to existing tab ${data.tabId} in ${locationText}, which already has ${data.url} open. Use browser_snapshot to see the page content.${localhostWarning}\n\n${BROWSER_USE_GUIDANCE_HINT}`,
+            text: `Switched to existing tab ${data.tabId} in ${locationText}, which already has ${data.url} open. Use browser_snapshot to see the page content.${localhostWarning}`,
           },
         ],
       }
@@ -166,7 +170,7 @@ Omit location to keep using the current browser where it is; when no browser is 
         `Loaded ${title} at ${page.url}${redirect}${http} in ${locationText}.${switchText}` +
         warns.map(w => `\n⚠ ${w}`).join('') +
         (warns.length > 0 && page.preview ? `\nPage text: ${JSON.stringify(page.preview.slice(0, 400))}` : '') +
-        ` The user can see the browser live. Use browser_snapshot to see the page content.${localhostWarning}\n\n${BROWSER_USE_GUIDANCE_HINT}`
+        ` The user can see the browser live. Use browser_snapshot to see the page content.${localhostWarning}${guide}`
       return { content: [{ type: 'text' as const, text }], ...(unreachable ? { isError: true } : {}) }
     }
 
@@ -174,7 +178,7 @@ Omit location to keep using the current browser where it is; when no browser is 
       content: [
         {
           type: 'text' as const,
-          text: `Browser opened in ${locationText} and navigating to ${args.url}.${switchText} The landing page could not be read — take a browser_snapshot to see where you are; its status line shows the URL, title and HTTP status.${localhostWarning}\n\n${BROWSER_USE_GUIDANCE_HINT}`,
+          text: `Browser opened in ${locationText} and navigating to ${args.url}.${switchText} The landing page could not be read — take a browser_snapshot to see where you are; its status line shows the URL, title and HTTP status.${localhostWarning}${guide}`,
         },
       ],
     }


### PR DESCRIPTION
## What

`BROWSER_USE_GUIDANCE_HINT` ("if you will drive the browser yourself rather than delegate to the web-browser agent, read `/opt/gamut/docs/browser-use.md`…") was appended to all three `browser_open` return paths, unconditionally. It is now attached only when the call launched a browser:

- `/browser/open` returns `launched: true` when no browser was active before the launch (including after a location switch closed the previous one).
- The tool attaches the hint only on `launched === true`. "Switched to existing tab" and a navigation inside a live browser carry no hint.

The hint text itself is unchanged, so the prompt/hint agreement test still holds.

## Why

Transcript-mining theme 31 (33 sessions): the hint advised the web-browser subagent to consider delegating to the web-browser subagent, up to 50 times per session; the code comment above it described a conditionality that was never implemented. One hint per net-new browser is the guidance a parent needs and nothing the subagent can act on repeatedly.

## Tests

- `tools/browser.test.ts`: hint present on a launch (`launched: true`), absent when switching to an existing tab, absent on an open inside an already-running browser (no `launched`).
- `system-prompt-vars.test.ts` (hint/prompt agreement) passes; typecheck + lint clean.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01792FWz3b1emZ8z1H1DyP3u
