### PR TITLE
fix(browser): cap CLI output below the SDK result limit so a capped result cannot still hard-error

### DIFF
--- a/agent-container/src/browser-output.test.ts
+++ b/agent-container/src/browser-output.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { capBrowserOutput, redactCdpUrls, describeExecFailure, MAX_BROWSER_ERROR_CHARS } from './browser-output'
+import { capBrowserOutput, redactCdpUrls, describeExecFailure, MAX_BROWSER_ERROR_CHARS, MAX_BROWSER_OUTPUT_CHARS, MAX_SNAPSHOT_RAW_CHARS } from './browser-output'
+import { SNAPSHOT_SOFT_CAP_CHARS } from './snapshot-format'
 
 describe('capBrowserOutput', () => {
   it('passes short output through unchanged', () => {
@@ -83,5 +84,15 @@ describe('describeExecFailure', () => {
     expect(text).toContain('exceeded the buffer limit')
     expect(text).toContain('after 1200 ms')
     expect(text).not.toContain('within')
+  })
+})
+
+describe('output caps', () => {
+  it('keeps every browser result under the SDK tool-result limit, and above the snapshot soft cap', () => {
+    // ~25k tokens fires around 62k chars of token-dense CLI text; the exec cap
+    // must stay below that or a capped result still hard-errors at the SDK.
+    expect(MAX_BROWSER_OUTPUT_CHARS).toBeLessThanOrEqual(60_000)
+    expect(MAX_BROWSER_OUTPUT_CHARS).toBeGreaterThan(SNAPSHOT_SOFT_CAP_CHARS)
+    expect(MAX_SNAPSHOT_RAW_CHARS).toBeGreaterThan(MAX_BROWSER_OUTPUT_CHARS)
   })
 })

--- a/agent-container/src/browser-output.ts
+++ b/agent-container/src/browser-output.ts
@@ -11,9 +11,25 @@
  *   leaked connection internals into agent-visible errors.
  */
 
-/** Generous backstop for successful output (~25k tokens). Tool-level caps
- * (e.g. browser_eval's 8k) apply on top of this. */
-export const MAX_BROWSER_OUTPUT_CHARS = 100_000
+/**
+ * Backstop for successful output. The SDK's tool-result limit is ~25k
+ * tokens, which token-dense CLI text (a11y trees, request logs, URLs) hits
+ * around 62–74k chars — nondeterministically at the edge. The old 100k cap
+ * sat above that, so a busy `network requests` or `console` dump was capped
+ * to 100k and then hard-errored anyway, leaving the agent nothing
+ * (transcript-mining theme 22). 50k stays under the limit even for the
+ * densest output. Tool-level caps (browser_eval's 8k, the snapshot soft
+ * cap) apply on top of this.
+ */
+export const MAX_BROWSER_OUTPUT_CHARS = 50_000
+
+/**
+ * Raw ceiling for the snapshot route only. Its own capSnapshot truncates to
+ * SNAPSHOT_SOFT_CAP_CHARS and reports the true total; capping earlier would
+ * make that total the exec cap's, not the tree's. fullText also fetches the
+ * unfiltered tree and compacts it here, which needs the whole thing.
+ */
+export const MAX_SNAPSHOT_RAW_CHARS = 2_000_000
 
 /** Errors are for reading, not dumping — keep them tight. */
 export const MAX_BROWSER_ERROR_CHARS = 4_000

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -818,7 +818,7 @@ import { classifyWaitTarget, WAIT_PAGE_PROBE_SCRIPT, parseWaitPageProbe } from '
 /** Budget for the page probe around a wait — independent of the exec ceiling. */
 const WAIT_PAGE_PROBE_TIMEOUT_MS = 3000;
 import { resolveCommittedValue } from './field-value-readback';
-import { capBrowserOutput, redactCdpUrls, describeExecFailure, BROWSER_EXEC_TIMEOUT_MS, MAX_BROWSER_OUTPUT_CHARS, MAX_BROWSER_ERROR_CHARS } from './browser-output';
+import { capBrowserOutput, redactCdpUrls, describeExecFailure, BROWSER_EXEC_TIMEOUT_MS, MAX_BROWSER_OUTPUT_CHARS, MAX_SNAPSHOT_RAW_CHARS, MAX_BROWSER_ERROR_CHARS } from './browser-output';
 import { capSnapshot, compactWithText, countRefs, formatIframePlaceholders, formatTextFooter, THIN_TREE_REFS } from './snapshot-format';
 import { observerScript, parseObservation, EMPTY_OBSERVATION, PREVIEW_CHARS, THIN_TREE_PREVIEW_CHARS, type PageObservation } from './page-observer';
 import { formatStatusLine, waitForLoaded } from './page-status';
@@ -882,9 +882,10 @@ function cleanupAgentBrowserDaemon(): void {
 async function execBrowser(
   args: string[],
   cdpUrl?: string,
-  opts: { timeoutMs?: number } = {},
+  opts: { timeoutMs?: number; outputCap?: number } = {},
 ): Promise<{ stdout: string; exitCode: number }> {
   const started = Date.now();
+  const outputCap = opts.outputCap ?? MAX_BROWSER_OUTPUT_CHARS;
   try {
     const fullArgs = cdpUrl ? ['--cdp', cdpUrl, ...args] : args;
     const { stdout } = await execFileAsync('agent-browser', fullArgs, {
@@ -899,7 +900,7 @@ async function execBrowser(
         AGENT_BROWSER_ARGS: process.env.AGENT_BROWSER_ARGS || '--no-sandbox,--disable-blink-features=AutomationControlled',
       },
     });
-    return { stdout: capBrowserOutput(stdout.trim(), MAX_BROWSER_OUTPUT_CHARS), exitCode: 0 };
+    return { stdout: capBrowserOutput(stdout.trim(), outputCap), exitCode: 0 };
   } catch (error: any) {
     // Full, unsanitized detail (incl. the command line with the CDP URL) goes
     // to container logs for connectivity debugging — never to the model.
@@ -1524,7 +1525,9 @@ app.post('/browser/snapshot', async (c) => {
     });
     const probe = observed ?? EMPTY_OBSERVATION;
 
-    const result = await execBrowser(snapshotArgs, browserState.cdpUrl || undefined);
+    // The snapshot has its own cap (capSnapshot) that reports the true size;
+    // the exec-level cap must not truncate first.
+    const result = await execBrowser(snapshotArgs, browserState.cdpUrl || undefined, { outputCap: MAX_SNAPSHOT_RAW_CHARS });
 
     if (result.exitCode !== 0) {
       return c.json({ error: result.stdout, success: false }, 500);


### PR DESCRIPTION
## What

- `MAX_BROWSER_OUTPUT_CHARS` 100_000 → 50_000. Every `browser_run`/`eval`/read-verb result is now bounded below the SDK's tool-result limit, with the existing `…[output truncated — showing N of M chars]` notice.
- `execBrowser` takes an optional `outputCap`; the snapshot route passes a raw ceiling (`MAX_SNAPSHOT_RAW_CHARS`) so `capSnapshot` still sees the whole tree: it truncates to the 45k soft cap and reports the *true* total, and `fullText` compaction needs the unfiltered tree first.

## Why

Transcript-mining theme 22 (≈50/200 sessions): the three caps disagreed with each other and the SDK — *"'Error: result (60,127 characters across 1,274 lines) exceeds maximum allowed tokens' plus ~150 words of MCP boilerplate"*. A cap that sits above the hard limit is not a cap: the agent got neither the head nor a notice. The ~25k-token limit fires around 62–74k chars of token-dense text, nondeterministically at the edge; 50k stays under it for the densest output (URL lists).

## Tests

- `browser-output.test.ts`: invariant — exec cap ≤ 60k and above the snapshot soft cap; snapshot raw ceiling above the exec cap.
- typecheck + lint clean.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01792FWz3b1emZ8z1H1DyP3u
