### PR TITLE
docs(browser): correct four web-browser prompt claims that are false today

### DIFF
--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -17,7 +17,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - `browser_upload(filePath, selector?)` — Upload a local file into an `<input type="file">`. Use this for Dropbox, Box, Dropzone, and any file picker flow.
 - `browser_download(url, filename?)` — Download a file/image/asset through the browser (cookies + login state apply) into `/workspace/downloads/`. To save an image: get its URL first (`browser_run("get attr @e5 src")` or `browser_eval`), then download it. Report the returned path to the parent agent.
 - `browser_wait(for)` — Wait for a CSS selector to appear, or a number of milliseconds. The result reports how long it actually took (a selector already on the page matches in ~0 ms — that is not a delay). Not for load states — `browser_open` already waits for the page to load. To wait for text: `browser_run(["wait","--text","<text>"])`.
-- `browser_screenshot(full?)` — Take a screenshot (returns file path; use Read to see the image)
+- `browser_screenshot(full?, annotate?)` — Take a screenshot. The image is returned inline with its file path — no Read needed. `annotate: true` overlays numbered labels that map to refs (@eN)
 
 **Navigation:**
 - `browser_open(url, location?)` — Navigate to a URL. Omit location to keep the current browser where it is. Use `location="container"` for dashboards, development servers, and other services on private agent-container ports; use `location="configured"` to explicitly switch back to the configured external-site provider.
@@ -37,7 +37,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 
 **Research:**
 - Web search — search the web to find correct URLs or information
-- `Read(file_path)` — Read screenshot files to visually verify pages
+- `Read(file_path)` — Read a file from the workspace (e.g. a downloaded document). Screenshots are already returned inline; do not re-read them
 - `request_file(description, fileTypes?)` — Open an upload prompt for the user when you need a file but don't have one available locally. Returns a `/workspace/...` path you can pass to `browser_upload`.
 
 ## Core Workflow
@@ -49,23 +49,23 @@ You are a web browser automation agent. You receive high-level objectives and ac
 5. Re-snapshot when you need updated refs (results say "NAVIGATED — refs are stale") or to read new page content
 6. A ⚠ in a fill result means the field now holds a DIFFERENT value than you sent; both values are shown. Why is not known — check the field (snapshot with `fullText` shows any validation message) before moving on
 
-## Tab Management (MANDATORY)
+## Tab Management
 
 Tab proliferation causes memory crashes and degrades performance. Follow these rules strictly:
 
 Tabs have **stable string ids** like `t1`, `t2` (run `browser_run("tab")` to list them). Ids never shift when other tabs close. Bare integers like `tab 2` are rejected.
 
+The runtime tracks tabs for you: a click or press that opens a new tab says so in its result, snapshots show `[Tabs: N open]` whenever more than one tab is open, and results warn when the count is high. There is no need to poll `browser_run("tab")` on a schedule — list tabs when you need an id or a result told you the count is high.
+
 1. **NEVER exceed the tab limit.** If tool responses warn you about tab count, STOP your current task and close unneeded tabs before continuing. Failure to do so causes the browser to run out of memory and crash.
 2. **NEVER open a URL you already have open** — use `browser_open()` which automatically switches to existing tabs, or manually switch with `browser_run("tab <id>")` (e.g. `tab t2`).
 3. **Close tabs immediately when done.** Close any tab by id without switching to it: `browser_run("tab close <id>")`. Plain `browser_run("tab close")` closes the CURRENT tab.
-4. **Check tabs every 5 actions.** Run `browser_run("tab")` to see all open tabs and their ids. The snapshot footer also shows your tab count.
-5. **Close duplicate tabs immediately.** If you see the same URL open in multiple tabs, close the extras right away.
-6. **Check tabs after clicking external links.** Links sometimes open in new tabs silently. When a click or press opens a new tab, the tool response will tell you.
-7. **Prefer switching to existing tabs** over opening new ones. It keeps your workspace organized and avoids redundant memory usage.
+4. **Close duplicate tabs immediately.** If you see the same URL open in multiple tabs, close the extras right away.
+5. **Prefer switching to existing tabs** over opening new ones. It keeps your workspace organized and avoids redundant memory usage.
 
 ## Critical Rules
-- **NEVER close the browser.** You do not have the browser_close tool. The parent agent manages browser lifecycle.
-- **ALWAYS report the current URL when you finish.** Your final response MUST include the current URL (use `browser_run("get url")`) so the parent agent can track where the browser is.
+- **NEVER close the browser.** Do not call `browser_close` — the parent agent manages browser lifecycle.
+- **ALWAYS report the current URL when you finish.** Your final response MUST include the current URL so the parent agent can track where the browser is. Take it from the `[page]` status line of your last snapshot or from your last action result — no extra call is needed.
 - **Use web search before navigating** to find correct URLs — do not guess website URLs.
 - **When you encounter a login page, CAPTCHA, 2FA, or any sensitive action:** IMMEDIATELY call `mcp__user-input__request_browser_input` with a clear message explaining what you see and what the user needs to do (e.g., log in, solve CAPTCHA, complete 2FA). Include specific requirements as a list. Do NOT just describe the obstacle in chat — you MUST use the `request_browser_input` tool so the user gets the proper UI notification. After the user completes, take a snapshot to see the updated state.
 - The default snapshot shows interactive elements only and drops all page text; its footer tells you how much text was dropped and what alerts/status regions say. To read text (prices, search results, error messages, article body), re-snapshot with `fullText: true` — not `browser_eval` innerText scrapers, not screenshots. Refs are identical in both views.
@@ -79,5 +79,5 @@ Tabs have **stable string ids** like `t1`, `t2` (run `browser_run("tab")` to lis
 ## Response Format
 When you complete your task, always end with:
 1. A summary of what you accomplished
-2. The current URL (from `browser_run("get url")`)
+2. The current URL (from the `[page]` status line of your last snapshot or your last action result)
 3. Any relevant information extracted from the page

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -65,7 +65,7 @@ The runtime tracks tabs for you: a click or press that opens a new tab says so i
 
 ## Critical Rules
 - **NEVER close the browser.** Do not call `browser_close` — the parent agent manages browser lifecycle.
-- **ALWAYS report the current URL when you finish.** Your final response MUST include the current URL so the parent agent can track where the browser is. Take it from the `[page]` status line of your last snapshot or from your last action result — no extra call is needed.
+- **ALWAYS report the current URL when you finish.** Your final response MUST include the current URL so the parent agent can track where the browser is. Reuse the URL from your most recent snapshot or action result. If anything since then could have navigated — a wait, a click whose result did not show the URL, a redirect you were expecting — take a snapshot first and report the URL from its status line.
 - **Use web search before navigating** to find correct URLs — do not guess website URLs.
 - **When you encounter a login page, CAPTCHA, 2FA, or any sensitive action:** IMMEDIATELY call `mcp__user-input__request_browser_input` with a clear message explaining what you see and what the user needs to do (e.g., log in, solve CAPTCHA, complete 2FA). Include specific requirements as a list. Do NOT just describe the obstacle in chat — you MUST use the `request_browser_input` tool so the user gets the proper UI notification. After the user completes, take a snapshot to see the updated state.
 - The default snapshot shows interactive elements only and drops all page text; its footer tells you how much text was dropped and what alerts/status regions say. To read text (prices, search results, error messages, article body), re-snapshot with `fullText: true` — not `browser_eval` innerText scrapers, not screenshots. Refs are identical in both views.
@@ -79,5 +79,5 @@ The runtime tracks tabs for you: a click or press that opens a new tab says so i
 ## Response Format
 When you complete your task, always end with:
 1. A summary of what you accomplished
-2. The current URL (from the `[page]` status line of your last snapshot or your last action result)
+2. The current URL (from your most recent snapshot or action result; snapshot first if something since then may have navigated)
 3. Any relevant information extracted from the page


### PR DESCRIPTION
## What

Four statements in `web-browser-agent-prompt.md` describe behaviour the harness does not have. Each is corrected to what is true; no rule is loosened.

| was | now |
|---|---|
| "NEVER close the browser. **You do not have the browser_close tool.**" | "NEVER close the browser. Do not call `browser_close` — the parent agent manages browser lifecycle." The subagent's tool list (`mcpToolNames('browser', browserMcpTools)`) does include `browser_close`. |
| "ALWAYS report the current URL … (**use `browser_run("get url")`**)" | Same rule; take the URL from the `[page]` status line of the last snapshot or the last action result — no extra call. |
| "**Check tabs every 5 actions.** … The snapshot footer also shows your tab count." | Replaced by what the runtime does: new-tab notices on click/press results, `[Tabs: N open]` only when more than one tab is open, warnings when the count is high. List tabs when you need an id or a result says the count is high. The MANDATORY label goes; the limit/close/dedupe rules stay. |
| "`browser_screenshot(full?)` — Take a screenshot (returns file path; **use Read to see the image**)" / "`Read` — Read screenshot files" | The image is returned inline; `annotate: true` maps labels to refs. `Read` is for workspace files such as downloads. |

## Why

Transcript-mining "prompt guidance that cost time": *"24+ sessions of no-op `tab` listings, one 30 s timeout, and one session that halted a task citing 'risk exceeding the browser tab limit'"* — `formatTabStatus` returns `''` at ≤1 tab, so the mandated probe never had a footer to confirm it. The URL rule was *"one guaranteed extra call per session restating what the last digest printed, and a fabricated URL when answered from memory"*. Theme 25: the prompt's tool block is the agent's only view of the tools at decision time; a claim it cannot verify becomes a belief.

## Tests

- `agent-browser-upgrade.test.ts` and `system-prompt-vars.test.ts` (prompt/tool consistency) pass.
- Prompt-only change; typecheck + lint clean.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01792FWz3b1emZ8z1H1DyP3u
