### PR TITLE
fix(browser): iframe footer lists only frames the tree could not read; drop the coordinate-click recipe

### DIFF
--- a/agent-container/docs/browser-use.md
+++ b/agent-container/docs/browser-use.md
@@ -127,9 +127,10 @@ Do not ask the user to paste credentials into chat. The browser profile retains
 successful sessions. Follow the system prompt's confirmation rules for
 submissions with financial, legal, destructive, or externally visible impact.
 
-Cross-origin iframe content is unavailable to `browser_eval` and may not appear
-as actionable snapshot fields. For embedded payment fields, click the iframe
-field by the available mechanism and use `browser_type`.
+Cross-origin iframe content is unavailable to `browser_eval`, but the snapshot
+normally merges frames — payment frames included — with working refs. Use those
+refs; for keystroke-driven fields, click the ref and use `browser_type`. A frame
+the tree could not read is listed under the snapshot.
 
 ## Uploads and Downloads
 

--- a/agent-container/src/eval-script.test.ts
+++ b/agent-container/src/eval-script.test.ts
@@ -125,7 +125,8 @@ describe('evalErrorHint', () => {
   it('adds the top-frame hint for null-property errors', () => {
     const hinted = evalErrorHint("✗ Evaluation error: TypeError: Cannot read properties of null (reading 'click')")
     expect(hinted).toContain('TOP frame only')
-    expect(hinted).toContain('browser_type')
+    expect(hinted).toContain('refs from browser_snapshot')
+    expect(hinted).not.toContain('coordinate')
   })
 
   it('adds the quoting hint for invalid-selector errors', () => {

--- a/agent-container/src/eval-script.ts
+++ b/agent-container/src/eval-script.ts
@@ -124,7 +124,7 @@ export function finalizeEvalOutput(output: string): string {
 /** Append a hint to known-confusing eval error shapes. */
 export function evalErrorHint(error: string): string {
   if (/Cannot read propert(y|ies) of (null|undefined)/i.test(error)) {
-    return `${error}\nHint: a selector likely matched nothing. eval runs in the TOP frame only — elements inside cross-origin iframes (e.g. payment frames) are unreachable from JavaScript; use coordinate clicks + browser_type for those.`
+    return `${error}\nHint: something in the script was null — commonly a querySelector that matched nothing. eval runs in the TOP frame only — elements inside cross-origin iframes (e.g. payment frames) are unreachable from JavaScript; use their refs from browser_snapshot for those.`
   }
   if (/is not a valid selector/i.test(error)) {
     return `${error}\nHint: attribute values containing spaces must be quoted inside the selector string, e.g. querySelector('iframe[title="Payment frame"]').`

--- a/agent-container/src/page-observer.test.ts
+++ b/agent-container/src/page-observer.test.ts
@@ -57,6 +57,8 @@ type Page = {
   errorPage?: boolean
   /** Selectors that document.querySelector resolves (challenge-wall DOM markers). */
   markers?: string[]
+  /** Elements document.getElementById resolves (aria-labelledby targets). */
+  byId?: Record<string, unknown>
 }
 
 const LIVE = '[role="alert"],[role="status"],[aria-live]:not([aria-live="off"]),output'
@@ -71,7 +73,7 @@ function makePage(page: Page) {
     readyState: page.readyState ?? 'complete',
     contentType: page.contentType ?? 'text/html',
     activeElement: page.active ?? body,
-    getElementById: (id: string) => (id === 'main-frame-error' && page.errorPage ? {} : null),
+    getElementById: (id: string) => (id === 'main-frame-error' && page.errorPage ? {} : (page.byId?.[id] ?? null)),
     querySelector: (q: string) => (q === 'main,[role=main]' ? page.main ?? null : (page.markers ?? []).some(m => q.split(',').includes(m)) ? {} : null),
     querySelectorAll: (q: string) => page.sel?.[q] ?? [],
   }
@@ -178,9 +180,16 @@ describe('observerScript', () => {
     expect(run().iframes).toEqual([{ title: 'Secure payment', host: 'js.stripe.com', sameOrigin: false }, { title: '', host: 'app.com', sameOrigin: true }])
   })
 
-  it('reports the accessible name — aria-label over title — since that is what the tree prints', () => {
-    const { run } = makePage({ sel: { iframe: [el({ src: 'https://js.stripe.com/v3/elements', title: 'Secure payment input frame', label: 'Payment details' }), el({ src: 'https://js.stripe.com/x', title: 'Only title' })] } })
-    expect(run().iframes.map(f => f.title)).toEqual(['Payment details', 'Only title'])
+  it('reports the accessible name — aria-label, then aria-labelledby, then title — since that is what the tree prints', () => {
+    const { run } = makePage({
+      byId: { lbl: el({ text: 'Billing card' }) },
+      sel: { iframe: [
+        el({ src: 'https://js.stripe.com/v3/elements', title: 'Secure payment input frame', label: 'Payment details' }),
+        el({ src: 'https://js.stripe.com/y', title: 'Ignored title', labelledby: 'lbl' }),
+        el({ src: 'https://js.stripe.com/x', title: 'Only title' }),
+      ] },
+    })
+    expect(run().iframes.map(f => f.title)).toEqual(['Payment details', 'Billing card', 'Only title'])
   })
 
   it('treats a frame on the page\'s own origin as same-origin even when its document is not readable (sandboxed)', () => {

--- a/agent-container/src/page-observer.test.ts
+++ b/agent-container/src/page-observer.test.ts
@@ -178,6 +178,11 @@ describe('observerScript', () => {
     expect(run().iframes).toEqual([{ title: 'Secure payment', host: 'js.stripe.com', sameOrigin: false }, { title: '', host: 'app.com', sameOrigin: true }])
   })
 
+  it('reports the accessible name — aria-label over title — since that is what the tree prints', () => {
+    const { run } = makePage({ sel: { iframe: [el({ src: 'https://js.stripe.com/v3/elements', title: 'Secure payment input frame', label: 'Payment details' }), el({ src: 'https://js.stripe.com/x', title: 'Only title' })] } })
+    expect(run().iframes.map(f => f.title)).toEqual(['Payment details', 'Only title'])
+  })
+
   it('treats a frame on the page\'s own origin as same-origin even when its document is not readable (sandboxed)', () => {
     // contentDocument is null/throws for a sandboxed frame without allow-same-origin;
     // the URL still says it is the page's own host (mining theme 11: reported cross-origin).

--- a/agent-container/src/page-observer.test.ts
+++ b/agent-container/src/page-observer.test.ts
@@ -178,6 +178,13 @@ describe('observerScript', () => {
     expect(run().iframes).toEqual([{ title: 'Secure payment', host: 'js.stripe.com', sameOrigin: false }, { title: '', host: 'app.com', sameOrigin: true }])
   })
 
+  it('treats a frame on the page\'s own origin as same-origin even when its document is not readable (sandboxed)', () => {
+    // contentDocument is null/throws for a sandboxed frame without allow-same-origin;
+    // the URL still says it is the page's own host (mining theme 11: reported cross-origin).
+    const { run } = makePage({ href: 'https://app.com/checkout', sel: { iframe: [el({ src: 'https://app.com/widget', title: 'Widget' }), el({ src: '/relative', title: 'Rel' })] } })
+    expect(run().iframes).toEqual([{ title: 'Widget', host: 'app.com', sameOrigin: true }, { title: 'Rel', host: '', sameOrigin: true }])
+  })
+
   it('recognises a challenge wall by the vendor\'s own DOM or a challenge status with its wording — never by wording alone', () => {
     const form = [el({ tag: 'input' }), el({ tag: 'input', type: 'password' }), el({ tag: 'button' }), el({ tag: 'a' }), el({ tag: 'a' })]
     // The real thing: Cloudflare's interstitial (its DOM, or its 403/503 with its wording), Google's /sorry/, an Akamai 403.

--- a/agent-container/src/page-observer.ts
+++ b/agent-container/src/page-observer.ts
@@ -188,7 +188,11 @@ export function observerScript(opts: ObserverOptions = {}): string {
     'for(var i=0;i<ls.length&&o.liveRegions.length<' + LIVE_REGION_MAX + ';i++){if(!vis(ls[i]))continue;var s=ws(ls[i].innerText);if(!s||seenL[s])continue;seenL[s]=1;o.liveRegions.push(s.slice(0,' + LIVE_REGION_CHARS + '))}}catch(e){}' +
     // Iframes (offsetParent is fine here: frames are never position:fixed toasts).
     'try{o.iframes=[].slice.call(document.querySelectorAll("iframe")).filter(function(f){return f.offsetParent!==null})' +
-    '.map(function(f){var host="";try{host=new URL(f.src).host}catch(e){}var same=false;try{same=!!f.contentDocument}catch(e){}return{title:f.title||"",host:host,sameOrigin:same}})}catch(e){}' +
+    // sameOrigin: a readable contentDocument, or the same origin by URL. The
+    // document check alone is null for a sandboxed frame on the page's own
+    // host, which used to be reported as cross-origin (mining theme 11).
+    '.map(function(f){var host="";try{host=new URL(f.src).host}catch(e){}var same=false;try{same=!!f.contentDocument}catch(e){}' +
+    'if(!same){try{same=new URL(f.src||"",location.href).origin===new URL(location.href).origin}catch(e){}}return{title:f.title||"",host:host,sameOrigin:same}})}catch(e){}' +
     // Interactive census, and the state of every visible control.
     'var act=null;try{act=document.activeElement}catch(e){}var actIx=-1;' +
     'try{var els=document.querySelectorAll(' + JSON.stringify(INTERACTIVE_SELECTOR) + ');var sa=' + JSON.stringify(STATE_ATTRS) + ';var st="";' +

--- a/agent-container/src/page-observer.ts
+++ b/agent-container/src/page-observer.ts
@@ -192,7 +192,8 @@ export function observerScript(opts: ObserverOptions = {}): string {
     // document check alone is null for a sandboxed frame on the page's own
     // host, which used to be reported as cross-origin (mining theme 11).
     '.map(function(f){var host="";try{host=new URL(f.src).host}catch(e){}var same=false;try{same=!!f.contentDocument}catch(e){}' +
-    'if(!same){try{same=new URL(f.src||"",location.href).origin===new URL(location.href).origin}catch(e){}}return{title:f.title||"",host:host,sameOrigin:same}})}catch(e){}' +
+    // title: the frame's accessible name as the tree prints it (aria-label wins over title).
+    'if(!same){try{same=new URL(f.src||"",location.href).origin===new URL(location.href).origin}catch(e){}}return{title:String(f.getAttribute("aria-label")||f.title||""),host:host,sameOrigin:same}})}catch(e){}' +
     // Interactive census, and the state of every visible control.
     'var act=null;try{act=document.activeElement}catch(e){}var actIx=-1;' +
     'try{var els=document.querySelectorAll(' + JSON.stringify(INTERACTIVE_SELECTOR) + ');var sa=' + JSON.stringify(STATE_ATTRS) + ';var st="";' +

--- a/agent-container/src/page-observer.ts
+++ b/agent-container/src/page-observer.ts
@@ -192,8 +192,10 @@ export function observerScript(opts: ObserverOptions = {}): string {
     // document check alone is null for a sandboxed frame on the page's own
     // host, which used to be reported as cross-origin (mining theme 11).
     '.map(function(f){var host="";try{host=new URL(f.src).host}catch(e){}var same=false;try{same=!!f.contentDocument}catch(e){}' +
-    // title: the frame's accessible name as the tree prints it (aria-label wins over title).
-    'if(!same){try{same=new URL(f.src||"",location.href).origin===new URL(location.href).origin}catch(e){}}return{title:String(f.getAttribute("aria-label")||f.title||""),host:host,sameOrigin:same}})}catch(e){}' +
+    // title: the frame's accessible name as the tree prints it — aria-label, then aria-labelledby, then title.
+    'if(!same){try{same=new URL(f.src||"",location.href).origin===new URL(location.href).origin}catch(e){}}' +
+    'var nm=String(f.getAttribute("aria-label")||"");if(!nm){var lb=f.getAttribute("aria-labelledby");if(lb){nm=String(lb).split(/\\s+/).map(function(id){var le=document.getElementById(id);return le?String(le.innerText||le.textContent||""):""}).join(" ").replace(/\\s+/g," ").trim()}}' +
+    'if(!nm)nm=String(f.title||"");return{title:nm,host:host,sameOrigin:same}})}catch(e){}' +
     // Interactive census, and the state of every visible control.
     'var act=null;try{act=document.activeElement}catch(e){}var actIx=-1;' +
     'try{var els=document.querySelectorAll(' + JSON.stringify(INTERACTIVE_SELECTOR) + ');var sa=' + JSON.stringify(STATE_ATTRS) + ';var st="";' +

--- a/agent-container/src/server.ts
+++ b/agent-container/src/server.ts
@@ -1547,7 +1547,7 @@ app.post('/browser/snapshot', async (c) => {
         (header ? `${header}\n\n` : '') +
         capSnapshot(tree, Boolean(body.scope)) +
         formatTextFooter(probe, { fullText, scoped: Boolean(body.scope), previewChars }) +
-        formatIframePlaceholders(iframes),
+        formatIframePlaceholders(iframes, tree),
       iframes,
       page: { ...probe, preview: probe.preview.slice(0, previewChars) },
       tabCount: tabManager.getTabCount(),

--- a/agent-container/src/snapshot-format.test.ts
+++ b/agent-container/src/snapshot-format.test.ts
@@ -69,10 +69,35 @@ describe('formatIframePlaceholders', () => {
     expect(out).not.toContain('cross-origin')
   })
 
-  it('takes an untitled DOM frame as merged when the tree has an untitled Iframe with children', () => {
+  it('never claims anything about an unnamed frame', () => {
     const tree = '- Iframe [ref=e2]\n  - button "Go" [ref=e3]'
     expect(formatIframePlaceholders([{ title: '', host: 'ads.example', sameOrigin: false }], tree)).toBe('')
-    expect(formatIframePlaceholders([{ title: '', host: 'ads.example', sameOrigin: false }], '- Iframe [ref=e2]')).toContain('(ads.example)')
+    expect(formatIframePlaceholders([{ title: '', host: 'ads.example', sameOrigin: false }], '- Iframe [ref=e2]')).toBe('')
+    expect(formatIframePlaceholders([{ title: '', host: 'ads.example', sameOrigin: false }], '')).toBe('')
+  })
+
+  it('matches a name the tree escaped (quotes in the title)', () => {
+    // review: 'Card "main" frame' printed as Iframe "Card \"main\" frame"
+    const tree = '- Iframe "Card \\"main\\" frame" [ref=e2]\n  - textbox "Card number" [ref=e7]'
+    expect(formatIframePlaceholders([{ title: 'Card "main" frame', host: 'js.stripe.com', sameOrigin: false }], tree)).toBe('')
+  })
+
+  it('says nothing when every visible frame is accounted for by a merged node, even if the names do not match', () => {
+    // review: aria-label overrides title in the accessible name; the observer now reports aria-label, but
+    // any residual mismatch (aria-labelledby, whitespace) must not become a false "not in this tree".
+    const tree = '- Iframe "Payment details" [ref=e2]\n  - textbox "Card number" [ref=e7]'
+    expect(formatIframePlaceholders([{ title: 'Secure payment input frame', host: 'js.stripe.com', sameOrigin: false }], tree)).toBe('')
+  })
+
+  it('lists a named frame only when the tree holds fewer merged frames than the page has', () => {
+    const tree = '- Iframe "Chat" [ref=e2]\n  - button "Open chat" [ref=e3]'
+    const frames: IframeInfo[] = [
+      { title: 'Chat', host: 'chat.example', sameOrigin: false },
+      { title: 'Secure payment input frame', host: 'js.stripe.com', sameOrigin: false },
+    ]
+    const out = formatIframePlaceholders(frames, tree)
+    expect(out).toContain('iframe "Secure payment input frame" (js.stripe.com) · cross-origin')
+    expect(out).not.toContain('"Chat"')
   })
 
   it('omits srcless/blank frames (no host)', () => {

--- a/agent-container/src/snapshot-format.test.ts
+++ b/agent-container/src/snapshot-format.test.ts
@@ -58,7 +58,7 @@ describe('formatIframePlaceholders', () => {
     }
   })
 
-  it('lists a frame that is in the tree but empty', () => {
+  it('lists a frame whose own node is in the tree but empty', () => {
     const emptyTree = '- Iframe "Secure payment input frame" [ref=e2]\n- button "Submit" [ref=e4]'
     expect(formatIframePlaceholders([stripe], emptyTree)).toContain('iframe "Secure payment input frame" (js.stripe.com)')
   })
@@ -82,14 +82,31 @@ describe('formatIframePlaceholders', () => {
     expect(formatIframePlaceholders([{ title: 'Card "main" frame', host: 'js.stripe.com', sameOrigin: false }], tree)).toBe('')
   })
 
-  it('says nothing when every visible frame is accounted for by a merged node, even if the names do not match', () => {
-    // review: aria-label overrides title in the accessible name; the observer now reports aria-label, but
-    // any residual mismatch (aria-labelledby, whitespace) must not become a false "not in this tree".
+  it('says nothing when any tree Iframe node is not accounted for by a visible frame name', () => {
+    // review: a name the observer could not compute (e.g. aria-labelledby) must not turn into
+    // "not in this tree" for a frame that has working refs right above the line.
     const tree = '- Iframe "Payment details" [ref=e2]\n  - textbox "Card number" [ref=e7]'
-    expect(formatIframePlaceholders([{ title: 'Secure payment input frame', host: 'js.stripe.com', sameOrigin: false }], tree)).toBe('')
+    expect(formatIframePlaceholders([stripe], tree)).toBe('')
+    // ...even when a genuinely empty frame is on the page too: which frame is missing is unknown.
+    const two = '- Iframe "Billing card" [ref=e2]\n  - textbox "Card number" [ref=e7]\n- Iframe "Empty one" [ref=e3]'
+    expect(formatIframePlaceholders([
+      { title: 'Different name', host: '127.0.0.1', sameOrigin: false },
+      { title: 'Empty one', host: '127.0.0.1', sameOrigin: false },
+    ], two)).toBe('')
   })
 
-  it('lists a named frame only when the tree holds fewer merged frames than the page has', () => {
+  it('lists exactly the empty frame when every tree node is matched by name', () => {
+    // the reviewer's scenario with the accessible name computed correctly
+    const two = '- Iframe "Billing card" [ref=e2]\n  - textbox "Card number" [ref=e7]\n- Iframe "Empty one" [ref=e3]'
+    const out = formatIframePlaceholders([
+      { title: 'Billing card', host: '127.0.0.1', sameOrigin: false },
+      { title: 'Empty one', host: '127.0.0.1', sameOrigin: false },
+    ], two)
+    expect(out).toContain('iframe "Empty one" (127.0.0.1)')
+    expect(out).not.toContain('Billing card')
+  })
+
+  it('lists a named frame with no node only when the tree holds nothing unmatched', () => {
     const tree = '- Iframe "Chat" [ref=e2]\n  - button "Open chat" [ref=e3]'
     const frames: IframeInfo[] = [
       { title: 'Chat', host: 'chat.example', sameOrigin: false },

--- a/agent-container/src/snapshot-format.test.ts
+++ b/agent-container/src/snapshot-format.test.ts
@@ -35,25 +35,52 @@ describe('parseIframeInfo', () => {
 })
 
 describe('formatIframePlaceholders', () => {
-  it('lists cross-origin frames with the payment recipe', () => {
-    const frames: IframeInfo[] = [{ title: 'Secure payment input frame', host: 'js.stripe.com', sameOrigin: false }]
-    const out = formatIframePlaceholders(frames)
-    expect(out).toContain('js.stripe.com')
-    expect(out).toContain('Secure payment input frame')
-    expect(out).toContain('browser_type')
+  const stripe: IframeInfo = { title: 'Secure payment input frame', host: 'js.stripe.com', sameOrigin: false }
+  // Real CLI tree (agent-browser 0.27.2): a cross-origin frame merged with refs.
+  const mergedTree = [
+    '- textbox "Name " [ref=e5]',
+    '- Iframe "Secure payment input frame" [ref=e2]',
+    '  - textbox "Card number " [ref=e7]',
+    '  - button "Pay" [ref=e6]',
+    '- button "Submit" [ref=e4]',
+  ].join('\n')
+
+  it('says nothing about a frame whose contents are in the tree, cross-origin or not', () => {
+    expect(formatIframePlaceholders([stripe], mergedTree)).toBe('')
   })
 
-  it('omits same-origin frames (already merged into the tree)', () => {
-    const frames: IframeInfo[] = [{ title: 'inner', host: 'self.com', sameOrigin: true }]
-    expect(formatIframePlaceholders(frames)).toBe('')
+  it('lists a frame the tree does not carry, as a fact and without a recipe', () => {
+    const out = formatIframePlaceholders([stripe], '- textbox "Name " [ref=e5]\n- button "Submit" [ref=e4]')
+    expect(out).toContain('whose contents are not in this tree')
+    expect(out).toContain('iframe "Secure payment input frame" (js.stripe.com) · cross-origin')
+    for (const claim of ['NOT in this snapshot', 'coordinates', 'browser_type', 'card number']) {
+      expect(out).not.toContain(claim)
+    }
+  })
+
+  it('lists a frame that is in the tree but empty', () => {
+    const emptyTree = '- Iframe "Secure payment input frame" [ref=e2]\n- button "Submit" [ref=e4]'
+    expect(formatIframePlaceholders([stripe], emptyTree)).toContain('iframe "Secure payment input frame" (js.stripe.com)')
+  })
+
+  it('marks a same-origin frame the tree could not read without the cross-origin label', () => {
+    const out = formatIframePlaceholders([{ title: 'inner', host: 'self.com', sameOrigin: true }], '')
+    expect(out).toContain('iframe "inner" (self.com)')
+    expect(out).not.toContain('cross-origin')
+  })
+
+  it('takes an untitled DOM frame as merged when the tree has an untitled Iframe with children', () => {
+    const tree = '- Iframe [ref=e2]\n  - button "Go" [ref=e3]'
+    expect(formatIframePlaceholders([{ title: '', host: 'ads.example', sameOrigin: false }], tree)).toBe('')
+    expect(formatIframePlaceholders([{ title: '', host: 'ads.example', sameOrigin: false }], '- Iframe [ref=e2]')).toContain('(ads.example)')
   })
 
   it('omits srcless/blank frames (no host)', () => {
-    expect(formatIframePlaceholders([{ title: '', host: '', sameOrigin: false }])).toBe('')
+    expect(formatIframePlaceholders([{ title: '', host: '', sameOrigin: false }], '')).toBe('')
   })
 
-  it('returns empty string when there are no opaque frames', () => {
-    expect(formatIframePlaceholders([])).toBe('')
+  it('returns empty string when there are no frames', () => {
+    expect(formatIframePlaceholders([], '')).toBe('')
   })
 })
 

--- a/agent-container/src/snapshot-format.ts
+++ b/agent-container/src/snapshot-format.ts
@@ -49,22 +49,57 @@ export function parseIframeInfo(stdout: string): IframeInfo[] {
   }
 }
 
+/** An `Iframe` node in the CLI's tree: its accessible name and whether it has children. */
+function treeIframes(tree: string): Array<{ title: string; hasChildren: boolean }> {
+  const lines = tree.split('\n')
+  const out: Array<{ title: string; hasChildren: boolean }> = []
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^(\s*)- iframe(?: "((?:[^"\\]|\\.)*)")?/i.exec(lines[i])
+    if (!m) continue
+    const indent = m[1].length
+    let hasChildren = false
+    for (let j = i + 1; j < lines.length; j++) {
+      if (lines[j].trim() === '') continue
+      const childIndent = (/^(\s*)/.exec(lines[j]) ?? ['', ''])[1].length
+      hasChildren = childIndent > indent
+      break
+    }
+    out.push({ title: (m[2] ?? '').trim(), hasChildren })
+  }
+  return out
+}
+
 /**
- * Render placeholders for cross-origin iframes (whose fields the a11y snapshot
- * cannot see). Same-origin frames are already merged into the tree, so they
- * are omitted. Returns '' when there is nothing the agent is blind to.
+ * List the visible iframes whose contents the tree does NOT carry.
+ *
+ * The CLI merges frames — cross-origin ones included — into the tree with
+ * working refs (verified on agent-browser 0.27.2: a card field inside a
+ * cross-origin frame fills and reads back by ref). The old footer listed
+ * every cross-origin frame as "contents NOT in this snapshot" directly under
+ * that frame's own refs, then prescribed a coordinate click that has no CLI
+ * command; agents believed the prose over the tree (mining theme 11). Now a
+ * frame is listed only when the tree has no `Iframe` node with that name
+ * carrying children — i.e. when the tree really could not read it — and the
+ * line states that and nothing else.
  */
-export function formatIframePlaceholders(iframes: IframeInfo[]): string {
-  const opaque = iframes.filter(f => !f.sameOrigin && f.host)
-  if (opaque.length === 0) return ''
-  const lines = opaque.map(f => {
-    const label = f.title ? `"${f.title}" ` : ''
-    return `  - iframe ${label}(${f.host}) — contents NOT in this snapshot (cross-origin)`
+export function formatIframePlaceholders(iframes: IframeInfo[], tree = ''): string {
+  const inTree = treeIframes(tree)
+  const unreadable = iframes.filter(f => {
+    if (!f.host) return false
+    const title = f.title.trim()
+    const matches = inTree.filter(t => t.title === title)
+    if (matches.length === 0) return true
+    // An untitled DOM frame with any untitled tree frame carrying children
+    // is taken as merged; a titled frame must match by name.
+    return !matches.some(t => t.hasChildren)
   })
-  return (
-    `\n\nFrames on this page whose fields are not captured above:\n${lines.join('\n')}\n` +
-    `If you need to fill a field inside one (e.g. card number in a payment frame), click into it by coordinates, then use browser_type.`
-  )
+  if (unreadable.length === 0) return ''
+  const lines = unreadable.map(f => {
+    const label = f.title ? `"${f.title}" ` : ''
+    const origin = f.sameOrigin ? '' : ' · cross-origin'
+    return `  - iframe ${label}(${f.host})${origin}`
+  })
+  return `\n\nFrames on this page whose contents are not in this tree:\n${lines.join('\n')}`
 }
 
 /**

--- a/agent-container/src/snapshot-format.ts
+++ b/agent-container/src/snapshot-format.ts
@@ -64,7 +64,8 @@ function treeIframes(tree: string): Array<{ title: string; hasChildren: boolean 
       hasChildren = childIndent > indent
       break
     }
-    out.push({ title: (m[2] ?? '').trim(), hasChildren })
+    // The tree escapes quotes and backslashes inside the quoted name.
+    out.push({ title: (m[2] ?? '').replace(/\\(.)/g, '$1').trim(), hasChildren })
   }
   return out
 }
@@ -78,20 +79,22 @@ function treeIframes(tree: string): Array<{ title: string; hasChildren: boolean 
  * every cross-origin frame as "contents NOT in this snapshot" directly under
  * that frame's own refs, then prescribed a coordinate click that has no CLI
  * command; agents believed the prose over the tree (mining theme 11). Now a
- * frame is listed only when the tree has no `Iframe` node with that name
- * carrying children — i.e. when the tree really could not read it — and the
- * line states that and nothing else.
+ * frame is listed only when the claim is unambiguous: it has a name (the
+ * accessible name, as the tree prints it), no `Iframe` node with that name
+ * carries children, and the tree holds fewer child-bearing `Iframe` nodes
+ * than the page has visible frames. If every visible frame is accounted for
+ * by a merged node, a name mismatch is a matching problem, not the tree's,
+ * and nothing is printed. Unnamed frames never produce a line.
  */
 export function formatIframePlaceholders(iframes: IframeInfo[], tree = ''): string {
   const inTree = treeIframes(tree)
-  const unreadable = iframes.filter(f => {
-    if (!f.host) return false
+  const visible = iframes.filter(f => f.host)
+  const mergedCount = inTree.filter(t => t.hasChildren).length
+  if (mergedCount >= visible.length) return ''
+  const unreadable = visible.filter(f => {
     const title = f.title.trim()
-    const matches = inTree.filter(t => t.title === title)
-    if (matches.length === 0) return true
-    // An untitled DOM frame with any untitled tree frame carrying children
-    // is taken as merged; a titled frame must match by name.
-    return !matches.some(t => t.hasChildren)
+    if (!title) return false
+    return !inTree.some(t => t.title === title && t.hasChildren)
   })
   if (unreadable.length === 0) return ''
   const lines = unreadable.map(f => {

--- a/agent-container/src/snapshot-format.ts
+++ b/agent-container/src/snapshot-format.ts
@@ -79,18 +79,20 @@ function treeIframes(tree: string): Array<{ title: string; hasChildren: boolean 
  * every cross-origin frame as "contents NOT in this snapshot" directly under
  * that frame's own refs, then prescribed a coordinate click that has no CLI
  * command; agents believed the prose over the tree (mining theme 11). Now a
- * frame is listed only when the claim is unambiguous: it has a name (the
- * accessible name, as the tree prints it), no `Iframe` node with that name
- * carries children, and the tree holds fewer child-bearing `Iframe` nodes
- * than the page has visible frames. If every visible frame is accounted for
- * by a merged node, a name mismatch is a matching problem, not the tree's,
- * and nothing is printed. Unnamed frames never produce a line.
+ * frame is listed only when the identification is complete: it has a name
+ * (the accessible name, as the tree prints it), no `Iframe` node carries
+ * that name with children, AND every `Iframe` node in the tree is matched
+ * by name to some visible frame — so no unmatched tree node could be this
+ * frame under a name the observer failed to compute. One unaccounted-for
+ * tree node suppresses every claim (a count of child-bearing nodes says
+ * some frame lacks children, not which). Unnamed frames never produce a
+ * line.
  */
 export function formatIframePlaceholders(iframes: IframeInfo[], tree = ''): string {
   const inTree = treeIframes(tree)
   const visible = iframes.filter(f => f.host)
-  const mergedCount = inTree.filter(t => t.hasChildren).length
-  if (mergedCount >= visible.length) return ''
+  const names = new Set(visible.map(f => f.title.trim()).filter(Boolean))
+  if (inTree.some(t => !names.has(t.title))) return ''
   const unreadable = visible.filter(f => {
     const title = f.title.trim()
     if (!title) return false

--- a/agent-container/src/tools/browser.ts
+++ b/agent-container/src/tools/browser.ts
@@ -204,7 +204,7 @@ The default view shows interactive elements only — it drops ALL static text (p
 - fullText=true: THE way to read a page. Adds the static text to the same compact tree; refs are identical in both views. Use it to extract data, read results or errors, or check on-page copy — not browser_eval innerText scrapers, not screenshots.
 - scope: limit the snapshot to a CSS-selected region (e.g. "form", "#main", ".modal", a dialog selector). Combine with fullText on large pages — it slashes output and avoids truncation. Refs stay valid for the rest of the page.
 
-Cross-origin iframes (e.g. Stripe payment frames) are listed as placeholders below the tree — their fields are NOT in the snapshot; fill them via coordinate click + browser_type.
+Frames — cross-origin ones such as Stripe payment frames included — are normally merged into the tree with working refs; use those refs like any other. A frame whose contents the tree could not read is listed below the tree.
 Very large snapshots are truncated with a note rather than failing — scope to recover the rest.`,
   {
     interactive: z
@@ -558,7 +558,7 @@ const browserTypeTool = tool(
   `Type text with REAL keystrokes into the currently focused element — or pass a ref to focus that element first.
 
 Use this when browser_fill cannot work:
-- Fields inside cross-origin payment iframes (Stripe card number/expiry/CVC): click into the field first (by ref if available, else by coordinates via browser_run mouse), then call browser_type WITHOUT a ref. Verify with a screenshot — the field is not readable from outside the iframe.
+- Fields inside payment iframes (Stripe card number/expiry/CVC) normally have refs in the snapshot: pass the ref, or browser_click it first and type without a ref. If the snapshot lists the frame as unreadable, focus the field with browser_run mouse (move x y, down, up) and type without a ref; verify with a screenshot.
 - Keystroke-listening widgets that ignore programmatic fill: OTP digit boxes, typeaheads, autocomplete inputs.
 
 Notes: this APPENDS to existing content (it does not clear first — use browser_fill to replace, or browser_press "Control+a" then type). When a ref is provided, the field's value is read back and returned.`,
@@ -589,7 +589,7 @@ const browserEvalTool = tool(
 
 - A single expression returns its value (e.g. document.title). A multi-line/statement body runs in a fresh scope — use \`return\` to produce a value (top-level return and await are supported; const/let won't collide across calls). Bare function expressions are auto-invoked.
 - Return JSON-serializable data — for structured results, end with JSON.stringify(...).
-- TOP FRAME ONLY: elements inside cross-origin iframes (e.g. Stripe payment frames) are unreachable from JavaScript. For those, click the field by coordinates and type with browser_type.
+- TOP FRAME ONLY: elements inside cross-origin iframes (e.g. Stripe payment frames) are unreachable from JavaScript. Use their refs from browser_snapshot (browser_click / browser_fill / browser_type) instead.
 - Output is capped at ~8000 chars — query only the fields you need instead of dumping HTML.`,
   {
     script: z.string().describe('JavaScript to evaluate. An expression (document.title) returns its value; a statement body should use return, e.g. "const n = document.querySelectorAll(\'a\').length; return n;"'),

--- a/agent-container/src/web-browser-agent-prompt.md
+++ b/agent-container/src/web-browser-agent-prompt.md
@@ -23,7 +23,7 @@ You are a web browser automation agent. You receive high-level objectives and ac
 - `browser_open(url, location?)` — Navigate to a URL. Omit location to keep the current browser where it is. Use `location="container"` for dashboards, development servers, and other services on private agent-container ports; use `location="configured"` to explicitly switch back to the configured external-site provider.
 
 **JavaScript:**
-- `browser_eval(script)` — Run JavaScript in the page and get the result. A single expression returns its value; a statement body runs in a fresh scope — use `return` to get a value (top-level `return`/`await` work, `const`/`let` won't collide across calls). Return `JSON.stringify(...)` for structured data. TOP FRAME ONLY — cross-origin iframes (payment frames) are unreachable from JS.
+- `browser_eval(script)` — Run JavaScript in the page and get the result. A single expression returns its value; a statement body runs in a fresh scope — use `return` to get a value (top-level `return`/`await` work, `const`/`let` won't collide across calls). Return `JSON.stringify(...)` for structured data. TOP FRAME ONLY — cross-origin iframes (payment frames) are unreachable from JS; their fields normally have refs in the snapshot, so use those.
 
 **Catch-all for advanced commands:**
 - `browser_run(command)` / `browser_run(args)` — Run any agent-browser CLI command. Use the `command` string for simple commands; whenever ANY argument contains spaces or quotes, pass the pre-tokenized `args` array instead — each element reaches the CLI verbatim, no escaping needed: `browser_run(args: ["type", "@e1", "chat isn't enough"])`, `browser_run(args: ["frame", "iframe[title=\"Payment frame\"]"])`. Examples:


### PR DESCRIPTION
## What

**The footer under the tree.** It listed every cross-origin frame as `contents NOT in this snapshot (cross-origin)` and appended "click into it by coordinates, then use browser_type". Now `formatIframePlaceholders(iframes, tree)` checks the tree itself: a visible DOM iframe is listed only when the tree has no `Iframe` node with that accessible name carrying children. The line is `  - iframe "Secure payment input frame" (js.stripe.com) · cross-origin` under "Frames on this page whose contents are not in this tree:", with no recipe. A frame that is in the tree with refs gets no footer at all.

**The origin check.** `sameOrigin` was `!!f.contentDocument`, which is null for a sandboxed frame on the page's own host. It is now that OR `new URL(f.src, location.href).origin === location.origin`.

**The advice.** Three tool descriptions and the eval error hint prescribed a coordinate click. The CLI has no such command (`mouse` is move/down/up; the mined sessions got `Unknown subcommand: click`). They now say what is true: frame fields normally have refs in the snapshot — use them; if a frame is listed as unreadable, `browser_run mouse move/down/up` then `browser_type`. `docs/browser-use.md` and the prompt line agree.

## Why

Verified on the real CLI (agent-browser 0.27.2) with a page embedding a cross-origin frame (`localhost` page, `127.0.0.1` frame): `snapshot -i -c` prints `- Iframe "Secure card frame" [ref=e2]` with `textbox "Card number" [ref=e7]` under it; `fill @e7 4242…` then `get value @e7` returns the number; `click @e6` on the inner button works. The same probe shows `contentDocument` false for a sandboxed same-host frame while the URL origin matches. (`frame <selector>` returned "Frame not found" for both `iframe` and `iframe[title=…]`, so it is deliberately not recommended.)

Transcript-mining theme 11 (≈70/200 sessions): *"The snapshot listed the iframe's buttons with usable refs (e50, e51, e52) and then said 'iframe … contents NOT in this snapshot (cross-origin)'" → tried JS, then raw mouse coordinates, then finally @e50, which worked*; *"the agent's single wrongest belief ('the iframe is cross-origin') was harness-induced"*; ~60 lines of credit-card advice on a Gmail read task.

## Tests

- `snapshot-format.test.ts`: merged frame → no footer; unreadable frame → fact line with host and `cross-origin`, none of the old claims; frame in tree but empty → listed; same-origin unreadable frame without the label; untitled frames; blank frames; empty input.
- `page-observer.test.ts`: sandboxed same-host and relative-src frames report `sameOrigin: true`; Stripe stays `false`.
- `eval-script.test.ts`: hint names refs, not coordinates. Prompt tests pass; typecheck + lint clean.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01792FWz3b1emZ8z1H1DyP3u
