### PR TITLE
fix: carry compaction state to late-joining session streams (SUP-822)

### DIFF
--- a/e2e/specs/message-queueing.spec.ts
+++ b/e2e/specs/message-queueing.spec.ts
@@ -78,11 +78,9 @@ test.describe('Message queueing while agent is working', () => {
     // "Compacting..." status must survive it, with the ghost below the line —
     // the queued message is picked up on the far side of the boundary.
 
-    // Settle a first turn before starting the one that compacts. compact_start
-    // is a one-shot broadcast and the connected frame carries no compaction
-    // snapshot, so a client that subscribes late never learns compaction began.
-    // The first message is what creates the session and navigates to it — under
-    // CI load that hand-off outran the mock's compacting status and the whole
+    // Settle a first turn before starting the one that compacts. The first
+    // message is what creates the session and navigates to it — under CI load
+    // that hand-off outran the mock's compacting status and the whole
     // compaction came and went before the stream was listening.
     await sessionPage.sendMessage('hello there')
     await expect(
@@ -118,6 +116,32 @@ test.describe('Message queueing while agent is working', () => {
     await expect(
       sessionPage.getAssistantMessages().filter({ hasText: 'Compacted the conversation.' })
     ).toBeVisible({ timeout: 15000 })
+  })
+
+  test('a stream opened mid-compaction learns the state from the connected snapshot', async ({ page }) => {
+    // The mock holds compaction open for 10s, long enough to reload inside it.
+    test.setTimeout(60000)
+    // SUP-822: compact_start is a one-shot broadcast. A page that opens its
+    // stream after it (a reload here, a fresh fork in the product) used to show
+    // "Working" until the summary landed; the connected frame now carries the
+    // state, so the indicator says "Compacting" from the first paint.
+    await sessionPage.sendMessage('hello there')
+    await expect(
+      sessionPage.getAssistantMessages().filter({ hasText: 'This is a mock response from the E2E test container.' })
+    ).toBeVisible({ timeout: 15000 })
+    await expect(sessionPage.getStopButton()).not.toBeVisible({ timeout: 15000 })
+
+    await sessionPage.sendMessage('please compact slowly for this test')
+    await expect(sessionPage.getActivityIndicator()).toContainText('Compacting', { timeout: 15000 })
+
+    await page.reload()
+    await expect(sessionPage.getActivityIndicator()).toContainText('Compacting', { timeout: 15000 })
+
+    // Compaction finishes on its own after the reload, and the boundary shows.
+    await expect(
+      sessionPage.getAssistantMessages().filter({ hasText: 'Compacted the conversation.' })
+    ).toBeVisible({ timeout: 25000 })
+    await expect(sessionPage.getStopButton()).not.toBeVisible({ timeout: 15000 })
   })
 
   test('a queued message can be cancelled before pickup', async ({ page }) => {

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -3228,11 +3228,15 @@ agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
       // A background task can run while the turn is still streaming, so the
       // task list alone does not say whether the turn's output has ended.
       const isWaitingBackground = messagePersister.isSessionWaitingBackground(agentSlug, sessionId)
+      // compact_start is a one-shot broadcast, so a stream that opens after it
+      // (a fresh fork, a reload) learns the state from the snapshot instead.
+      const isCompacting = messagePersister.isSessionCompacting(agentSlug, sessionId)
       await stream.writeSSE({
         data: JSON.stringify({
           type: 'connected',
           isActive,
           isWaitingBackground,
+          isCompacting,
           slashCommands: slashCommands.length > 0 ? slashCommands : undefined,
           backgroundTasks: backgroundTasks.length > 0 ? backgroundTasks : undefined,
         }),
@@ -3255,8 +3259,9 @@ agents.get('/:id/sessions/:sessionId/stream', AgentRead(), async (c) => {
       pingInterval = setInterval(async () => {
         try {
           const currentIsActive = messagePersister.isSessionActive(agentSlug, sessionId)
+          const currentIsCompacting = messagePersister.isSessionCompacting(agentSlug, sessionId)
           await stream.writeSSE({
-            data: JSON.stringify({ type: 'ping', isActive: currentIsActive }),
+            data: JSON.stringify({ type: 'ping', isActive: currentIsActive, isCompacting: currentIsCompacting }),
             event: 'message',
           })
         } catch {

--- a/src/renderer/components/messages/message-list.test.tsx
+++ b/src/renderer/components/messages/message-list.test.tsx
@@ -75,14 +75,12 @@ const mockStreamState = {
   errorPresentation: null as ProviderErrorPresentation | null,
 }
 
-const mockClearCompacting = vi.fn()
 const mockRemovePeerUserMessage = vi.fn()
 const mockClearPeerUserMessages = vi.fn()
 const mockConsumeDiscardedCommand = vi.fn()
 
 vi.mock('@renderer/hooks/use-message-stream', () => ({
   useMessageStream: () => mockStreamState,
-  clearCompacting: (...args: unknown[]) => mockClearCompacting(...args),
   removePeerUserMessage: (...args: unknown[]) => mockRemovePeerUserMessage(...args),
   clearPeerUserMessages: (...args: unknown[]) => mockClearPeerUserMessages(...args),
   consumeDiscardedCommand: (...args: unknown[]) => mockConsumeDiscardedCommand(...args),
@@ -954,44 +952,6 @@ describe('MessageList', () => {
     expect(screen.getByText('Delete me')).toBeInTheDocument()
     // The actual delete flow is tested via MessageItem's own test
     // Here we verify the message renders (the callback is passed as a prop)
-  })
-
-  // ---- Compaction boundary safety net ----
-
-  it('calls clearCompacting when new boundary appears during compaction', () => {
-    mockStreamState.isCompacting = true
-    // Start with no boundaries
-    mockMessagesData.data = []
-
-    const { rerender } = renderWithProviders(
-      <MessageList sessionId="s-1" agentSlug="agent-1" />
-    )
-
-    // Now a boundary appears (compaction finished, SSE event was missed)
-    mockMessagesData.data = [createCompactBoundary({ summary: 'New boundary' }) as any]
-    rerender(
-      <MessageList sessionId="s-1" agentSlug="agent-1" />
-    )
-
-    expect(mockClearCompacting).toHaveBeenCalledWith('s-1')
-  })
-
-  it('does not call clearCompacting when boundary count unchanged during compaction', () => {
-    // Pre-existing boundary before compaction started
-    mockMessagesData.data = [createCompactBoundary({ summary: 'Old boundary' }) as any]
-    mockStreamState.isCompacting = false
-
-    const { rerender } = renderWithProviders(
-      <MessageList sessionId="s-1" agentSlug="agent-1" />
-    )
-
-    // Now compaction starts (same boundary count)
-    mockStreamState.isCompacting = true
-    rerender(
-      <MessageList sessionId="s-1" agentSlug="agent-1" />
-    )
-
-    expect(mockClearCompacting).not.toHaveBeenCalled()
   })
 
   // ---- Pending message detection ----

--- a/src/renderer/components/messages/message-list.tsx
+++ b/src/renderer/components/messages/message-list.tsx
@@ -7,7 +7,6 @@ import { useIsVoiceReading } from '@renderer/hooks/use-read-aloud'
 import { VoiceAgentFeedbackDialog } from './voice-agent-feedback-dialog'
 import {
   useMessageStream,
-  clearCompacting,
   removePeerUserMessage,
   clearPeerUserMessages,
   consumeDiscardedCommand,
@@ -485,23 +484,6 @@ export function MessageList({ sessionId, agentSlug, pendingUserMessages, pending
       lastAssistantAt,
     }
   }, [visibleMessages, hasOlder])
-
-  // Safety net: if isCompacting is true but a NEW compact boundary appears in fetched
-  // messages, compaction is done and the SSE compact_complete event was missed.
-  // Track the boundary count baseline when not compacting, then detect increases.
-  const boundaryCountRef = useRef(0)
-  const boundaryCount = useMemo(
-    () => messages?.filter(m => m.type === 'compact_boundary').length ?? 0,
-    [messages]
-  )
-  useEffect(() => {
-    if (isCompacting && boundaryCount > boundaryCountRef.current) {
-      clearCompacting(sessionId)
-    }
-    if (!isCompacting) {
-      boundaryCountRef.current = boundaryCount
-    }
-  }, [isCompacting, boundaryCount, sessionId])
 
   // The one row (streaming or persisted) whose provider error a ProviderErrorPlacement shows right now.
   const currentRoutedError = useMemo(

--- a/src/renderer/hooks/use-message-stream.test.ts
+++ b/src/renderer/hooks/use-message-stream.test.ts
@@ -166,6 +166,133 @@ describe('useMessageStream', () => {
     expect(result.current.isWaitingBackground).toBe(true)
   })
 
+  it('takes isCompacting from the connected snapshot, keeping the local value when absent', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+
+    // A stream that opens after compact_start learns the state from the snapshot.
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true, isCompacting: true })
+    })
+    expect(result.current.isCompacting).toBe(true)
+
+    // A host that predates the field leaves the local value alone.
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+    })
+    expect(result.current.isCompacting).toBe(true)
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: false, isCompacting: false })
+    })
+    expect(result.current.isCompacting).toBe(false)
+  })
+
+  it('takes isCompacting from the ping, so a missed compact_start or compact_complete is corrected', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+    })
+    expect(result.current.isCompacting).toBe(false)
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'ping', isActive: true, isCompacting: true })
+    })
+    expect(result.current.isCompacting).toBe(true)
+
+    // An older host's ping carries no field and changes nothing.
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'ping', isActive: true })
+    })
+    expect(result.current.isCompacting).toBe(true)
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'ping', isActive: true, isCompacting: false })
+    })
+    expect(result.current.isCompacting).toBe(false)
+  })
+
+  it('an older host that omits isCompacting still clears it when its snapshot or ping says the session is idle', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      MockEventSource.instances[0].simulateMessage({ type: 'compact_start' })
+    })
+    expect(result.current.isCompacting).toBe(true)
+
+    // Reconnect after the compaction and the turn both ended unseen.
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: false })
+    })
+    expect(result.current.isCompacting).toBe(false)
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      MockEventSource.instances[0].simulateMessage({ type: 'compact_start' })
+    })
+    expect(result.current.isCompacting).toBe(true)
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'ping', isActive: false })
+    })
+    expect(result.current.isCompacting).toBe(false)
+  })
+
+  it('an older host snapshot that says the turn is waiting on background work ends a local compaction', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+    const backgroundTasks = [{ taskId: 'bg-1', startedAt: Date.now() }]
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
+      MockEventSource.instances[0].simulateMessage({ type: 'compact_start' })
+    })
+    expect(result.current.isCompacting).toBe(true)
+
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({
+        type: 'connected', isActive: true, isWaitingBackground: true, backgroundTasks,
+      })
+    })
+    expect(result.current.isCompacting).toBe(false)
+
+    // The live frame for the same transition clears it as well.
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'compact_start' })
+      MockEventSource.instances[0].simulateMessage({ type: 'session_waiting_background', backgroundTasks })
+    })
+    expect(result.current.isCompacting).toBe(false)
+  })
+
+  it('an idle ping from an older host clears a compaction even when the session was already thought idle', async () => {
+    const { useMessageStream } = await getHookModule()
+    const { result } = renderHook(
+      () => useMessageStream('session-1', 'agent-1'),
+      { wrapper: createWrapper() }
+    )
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: false })
+      MockEventSource.instances[0].simulateMessage({ type: 'compact_start' })
+    })
+    expect(result.current.isCompacting).toBe(true)
+    act(() => {
+      MockEventSource.instances[0].simulateMessage({ type: 'ping', isActive: false })
+    })
+    expect(result.current.isCompacting).toBe(false)
+  })
+
   it('handles session_active event', async () => {
     const { useMessageStream } = await getHookModule()
     const { result } = renderHook(
@@ -1706,28 +1833,6 @@ describe('useMessageStream', () => {
   })
 
   // ---- Remove helpers ----
-
-  it('handles clearCompacting helper', async () => {
-    const { useMessageStream, clearCompacting } = await getHookModule()
-    const { result } = renderHook(
-      () => useMessageStream('session-1', 'agent-1'),
-      { wrapper: createWrapper() }
-    )
-
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'connected', isActive: true })
-    })
-    act(() => {
-      MockEventSource.instances[0].simulateMessage({ type: 'compact_start' })
-    })
-    expect(result.current.isCompacting).toBe(true)
-
-    act(() => {
-      clearCompacting('session-1')
-    })
-
-    expect(result.current.isCompacting).toBe(false)
-  })
 
   it('handles clearBrowserActive helper', async () => {
     const { useMessageStream, clearBrowserActive } = await getHookModule()

--- a/src/renderer/hooks/use-message-stream.ts
+++ b/src/renderer/hooks/use-message-stream.ts
@@ -433,6 +433,8 @@ function getOrCreateEventSource(
           sessionSlashCommands.set(sessionId, data.slashCommands)
         }
         // Initial connection - get isActive from server
+        const snapshotWaitingBackground =
+          data.isWaitingBackground === true && Array.isArray(data.backgroundTasks) && data.backgroundTasks.length > 0
         streamStates.set(sessionId, {
           isActive: data.isActive ?? false,
           isStreaming: false,
@@ -445,7 +447,12 @@ function getOrCreateEventSource(
           computerUseApp: current?.computerUseApp ?? null,
           computerUseAppIcon: current?.computerUseAppIcon ?? null,
           activeStartTime: current?.activeStartTime ?? null,
-          isCompacting: current?.isCompacting ?? false,
+          // The snapshot carries it for a stream that opened after compact_start.
+          // An older host omits it: the local value stands in while the turn is
+          // still running, and a turn whose output ended cannot be compacting.
+          isCompacting: typeof data.isCompacting === 'boolean'
+            ? data.isCompacting
+            : ((data.isActive ?? false) && !snapshotWaitingBackground && (current?.isCompacting ?? false)),
           contextUsage: current?.contextUsage ?? null,
           activeSubagents: current?.activeSubagents ?? [],
           completedSubagents: current?.completedSubagents ?? null,
@@ -455,8 +462,7 @@ function getOrCreateEventSource(
           backgroundTasks: Array.isArray(data.backgroundTasks) ? data.backgroundTasks : (current?.backgroundTasks ?? []),
           // The snapshot says whether the turn's output has ended; a task in
           // the list can still belong to a turn that is streaming.
-          isWaitingBackground:
-            data.isWaitingBackground === true && Array.isArray(data.backgroundTasks) && data.backgroundTasks.length > 0,
+          isWaitingBackground: snapshotWaitingBackground,
           discardedCommandUuids: current?.discardedCommandUuids ?? [],
         })
         // Reconcile against the persisted transcript on every (re)connect. A client
@@ -615,7 +621,8 @@ function getOrCreateEventSource(
             })
             invalidateMessagesThrottled(queryClient, sessionId)
           } else {
-            streamStates.set(sessionId, { ...current, isWaitingBackground: true })
+            // The turn's output ended, so its compaction did too.
+            streamStates.set(sessionId, { ...current, isWaitingBackground: true, isCompacting: false })
           }
         }
       }
@@ -1340,6 +1347,18 @@ function getOrCreateEventSource(
           invalidateMessagesThrottled(queryClient, sessionId)
           queryClient.invalidateQueries({ queryKey: ['sessions'] })
         }
+        // Same for compaction: compact_start and compact_complete are one-shot
+        // frames, so the ping's word corrects a missed one. An older host omits
+        // the field, but an idle session cannot be compacting. Re-read the
+        // state: the block above may have replaced it.
+        const pingCompacting: boolean | undefined =
+          typeof data.isCompacting === 'boolean' ? data.isCompacting : (data.isActive === false ? false : undefined)
+        const latest = streamStates.get(sessionId)
+        if (latest && pingCompacting !== undefined && latest.isCompacting !== pingCompacting) {
+          streamStates.set(sessionId, { ...latest, isCompacting: pingCompacting })
+          // A finished compaction has a boundary in the transcript to show.
+          if (!pingCompacting) invalidateMessagesThrottled(queryClient, sessionId)
+        }
       }
       // Note: os_notification events are handled by GlobalNotificationHandler, not here
 
@@ -1437,15 +1456,6 @@ export function clearPeerUserMessages(sessionId: string): void {
   const current = streamStates.get(sessionId)
   if (current && current.peerUserMessages.length > 0) {
     streamStates.set(sessionId, { ...current, peerUserMessages: [] })
-    streamListeners.get(sessionId)?.forEach((listener) => listener())
-  }
-}
-
-// Helper to clear isCompacting state (used when persisted messages already show the boundary)
-export function clearCompacting(sessionId: string): void {
-  const current = streamStates.get(sessionId)
-  if (current && current.isCompacting) {
-    streamStates.set(sessionId, { ...current, isCompacting: false })
     streamListeners.get(sessionId)?.forEach((listener) => listener())
   }
 }

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -4400,12 +4400,26 @@ describe('MessagePersister', () => {
       expect(messagePersister.isSessionCompacting(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
-    it('a turn result clears the raw compaction flag, bounding a summary missed across a reattach', () => {
+    it('a turn result ends a compaction whose summary was missed, and does not re-announce one the summary ended', () => {
       messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
       const st = (messagePersister as any).streamingStates.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))
       st.isCompacting = true
+      sseEvents.length = 0
+      // The summary was lost across a reattach: the result is the last frame
+      // that can tell connected clients the spinner is over.
       mockClient._sendMessage({ type: 'result', subtype: 'success' })
       expect(st.isCompacting).toBe(false)
+      expect(sseEvents.filter(e => e.type === 'compact_complete')).toHaveLength(1)
+
+      // The ordinary turn: the summary ends the compaction, the result adds nothing.
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      st.isCompacting = true
+      sseEvents.length = 0
+      mockClient._sendMessage({
+        type: 'user', isCompactSummary: true, message: { role: 'user', content: [{ type: 'text', text: 'Summary.' }] },
+      })
+      mockClient._sendMessage({ type: 'result', subtype: 'success' })
+      expect(sseEvents.filter(e => e.type === 'compact_complete')).toHaveLength(1)
     })
 
     it('a stop clears the raw compaction flag, so a later wake does not resurrect it', async () => {
@@ -8513,6 +8527,40 @@ describe('MessagePersister', () => {
       expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
       expect(messagePersister.isSessionCompacting(AGENT_SLUG, SESSION_ID)).toBe(false)
       expect(sseEvents.filter(e => e.type === 'compact_complete')).toHaveLength(1)
+    })
+
+    it('a tool result that lands while a missed summary left the flag set still settles, and ends the compaction', () => {
+      // compact_start seen, transport dropped, summary missed, same process
+      // reattached with the flag kept: the next user frame is a tool result,
+      // not the summary, and it must reach the tool-result path.
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      // A deliver_file call is in flight; its result has to reach chat.
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'tool_use', id: 'deliver-1', name: 'mcp__user-input__deliver_file' },
+        },
+      })
+      mockClient._sendMessage({
+        type: 'stream_event',
+        event: { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: '{"filePath":"/workspace/out.txt"}' } },
+      })
+      mockClient._sendMessage({ type: 'stream_event', event: { type: 'content_block_stop' } })
+      const st = (messagePersister as any).streamingStates.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))
+      st.isCompacting = true
+      sseEvents.length = 0
+      mockClient._sendMessage({
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'deliver-1', content: 'delivered' }] },
+      })
+      expect(st.isCompacting).toBe(false)
+      expect(sseEvents.filter(e => e.type === 'compact_complete')).toHaveLength(1)
+      expect(sseEvents.filter(e => e.type === 'tool_result' && e.toolUseId === 'deliver-1')).toHaveLength(1)
+      const ready = sseEvents.filter(e => e.type === 'tool_result_ready')
+      expect(ready).toHaveLength(1)
+      expect(ready[0].filePath).toBe('/workspace/out.txt')
+      expect(sseEvents.filter(e => e.type === 'messages_updated')).toHaveLength(1)
     })
 
     it('a runtime-started turn resets a compaction left over from a turn that ended without its summary', () => {

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -4387,6 +4387,49 @@ describe('MessagePersister', () => {
       expect(messagePersister.getSessionActivity(AGENT_SLUG, SESSION_ID)).toBe('streaming')
     })
 
+    it('isSessionCompacting reads the flag while active, keeps it across an input request, and is false once idle', () => {
+      // The connected snapshot carries this to late-joining clients, which
+      // clear their own flag on session_idle and keep it across an input request.
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      const st = (messagePersister as any).streamingStates.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))
+      st.isCompacting = true
+      expect(messagePersister.isSessionCompacting(AGENT_SLUG, SESSION_ID)).toBe(true)
+      st.isAwaitingInput = true
+      expect(messagePersister.isSessionCompacting(AGENT_SLUG, SESSION_ID)).toBe(true)
+      st.isAwaitingInput = false; st.isActive = false
+      expect(messagePersister.isSessionCompacting(AGENT_SLUG, SESSION_ID)).toBe(false)
+    })
+
+    it('a turn result clears the raw compaction flag, bounding a summary missed across a reattach', () => {
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      const st = (messagePersister as any).streamingStates.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))
+      st.isCompacting = true
+      mockClient._sendMessage({ type: 'result', subtype: 'success' })
+      expect(st.isCompacting).toBe(false)
+    })
+
+    it('a stop clears the raw compaction flag, so a later wake does not resurrect it', async () => {
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      const st = (messagePersister as any).streamingStates.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))
+      st.isCompacting = true
+      await messagePersister.markSessionInterrupted(AGENT_SLUG, SESSION_ID, { processKept: true })
+      expect(st.isCompacting).toBe(false)
+    })
+
+    it('a transport reattach mid-turn keeps isCompacting; a reattach to an idle session starts clean', async () => {
+      await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      const key = sessionKeyOf(AGENT_SLUG, SESSION_ID)
+      ;(messagePersister as any).streamingStates.get(key).isCompacting = true
+
+      await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+      expect(messagePersister.isSessionCompacting(AGENT_SLUG, SESSION_ID)).toBe(true)
+
+      ;(messagePersister as any).streamingStates.get(key).isActive = false
+      await messagePersister.subscribeToSession(AGENT_SLUG, SESSION_ID, mockClient, SESSION_ID)
+      expect((messagePersister as any).streamingStates.get(key).isCompacting).toBe(false)
+    })
+
     it('a new turn (markSessionActive) clears a stale isCompacting/currentThinking from an abnormally-ended prior turn', () => {
       // The desktop app resets these on session_active/idle/error; chat must too, or a
       // turn that ended mid-compaction (error/interrupt before the compact summary)
@@ -8429,6 +8472,64 @@ describe('MessagePersister', () => {
       expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(false)
     })
 
+    it('a handshake from the same process keeps a compaction in flight; a new process instance drops it', () => {
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      mockClient._sendMessage({
+        type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'proc-1',
+      })
+      const st = (messagePersister as any).streamingStates.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))
+      st.isCompacting = true
+
+      // A transport reattach re-announces the same process mid-compaction.
+      mockClient._sendMessage({
+        type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'proc-1',
+      })
+      expect(messagePersister.isSessionCompacting(AGENT_SLUG, SESSION_ID)).toBe(true)
+
+      // The CLI was replaced: its compaction died with it and no summary will
+      // land, so connected clients are told to drop their indicator too.
+      sseEvents.length = 0
+      mockClient._sendMessage({
+        type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'proc-2',
+      })
+      expect(messagePersister.isSessionCompacting(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(sseEvents.filter(e => e.type === 'compact_complete')).toHaveLength(1)
+    })
+
+    it('a stopped turn that leaves background work running tells clients its compaction is over', () => {
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      mockClient._sendMessage({
+        type: 'system',
+        subtype: 'background_tasks_changed',
+        tasks: [{ task_id: 'bg-1', task_type: 'local_bash', description: 'Sleep' }],
+      })
+      const st = (messagePersister as any).streamingStates.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))
+      st.isCompacting = true
+      sseEvents.length = 0
+
+      // The interrupt result spares the task, so the session stays active and
+      // no idle frame follows to reset the client.
+      mockClient._sendMessage({ type: 'result', subtype: 'success', terminal_reason: 'aborted_tools' })
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionCompacting(AGENT_SLUG, SESSION_ID)).toBe(false)
+      expect(sseEvents.filter(e => e.type === 'compact_complete')).toHaveLength(1)
+    })
+
+    it('a runtime-started turn resets a compaction left over from a turn that ended without its summary', () => {
+      mockClient._sendMessage({
+        type: 'system', subtype: 'capabilities', session_state_events: true, process_instance: 'proc-1',
+      })
+      messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+      const st = (messagePersister as any).streamingStates.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))
+      st.isCompacting = true
+      st.isActive = false
+
+      // A background-task wake starts a turn the host never POSTed.
+      mockClient._sendMessage({ type: 'system', subtype: 'session_state_changed', state: 'running' })
+      expect(messagePersister.isSessionActive(AGENT_SLUG, SESSION_ID)).toBe(true)
+      expect(messagePersister.isSessionCompacting(AGENT_SLUG, SESSION_ID)).toBe(false)
+    })
+
     it('a capabilities handshake naming a new process instance drops the stale snapshot', () => {
       // The cold-resume path: the CLI is replaced while nothing is attached
       // (idle eviction + --resume, container restart), so the live
@@ -9097,6 +9198,27 @@ describe('MessagePersister mid-turn recovery snapshot', () => {
     expect(onDeath).toHaveBeenCalledWith(AGENT_SLUG)
     expect(messagePersister.consumeLastFatal(AGENT_SLUG)).toBe('oom_sigkill')
     messagePersister.setUnexpectedDeathCallback(null)
+  })
+
+  it('a deferred fatal SIGKILL ends the dead process\'s compaction before recovery starts', async () => {
+    const onDeath = vi.fn()
+    messagePersister.setUnexpectedDeathCallback(onDeath)
+    mockClient.onFatalResult = vi.fn(() => 'defer_for_recovery' as const)
+    messagePersister.markSessionActive(AGENT_SLUG, SESSION_ID)
+    const st = (messagePersister as any).streamingStates.get(sessionKeyOf(AGENT_SLUG, SESSION_ID))
+    st.isCompacting = true
+
+    mockClient._sendMessage({
+      type: 'result',
+      subtype: 'error',
+      fatal: true,
+      error: 'The agent process was killed due to running out of memory.',
+    })
+
+    expect(onDeath).toHaveBeenCalledWith(AGENT_SLUG)
+    expect(st.isCompacting).toBe(false)
+    messagePersister.setUnexpectedDeathCallback(null)
+    messagePersister.consumeLastFatal(AGENT_SLUG)
   })
 
   it('does not snapshot a fatal SIGKILL when no recovery callback is registered', async () => {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -623,7 +623,9 @@ class MessagePersister {
       waitingBackground: prior?.waitingBackground ?? false,
       isRecovering: prior?.isRecovering ?? false,
       coalescedUserMessages: prior?.coalescedUserMessages,
-      isCompacting: false,
+      // Turn-scoped like the assistant ids below: a transport reattach to the
+      // same live turn keeps it, a replaced process starts clean.
+      isCompacting: priorIsActive ? (prior?.isCompacting ?? false) : false,
       agentSlug,
       lastContextWindow: 200_000,
       lastAssistantUsage: null,
@@ -1025,6 +1027,30 @@ class MessagePersister {
   isSessionAwaitingInput(agentSlug: string, sessionId: string): boolean {
     const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
     return state?.isAwaitingInput ?? false
+  }
+
+  /**
+   * True while the current turn is compacting; a late-joining client gets it
+   * in the `connected` snapshot. The raw flag is turn-scoped: a stop, a
+   * replaced process and every turn start reset it, while an error result
+   * only ends the turn and leaves it for the next start to clear. So it is
+   * read only while the session is active. The client keeps its own copy
+   * across an input request, so this does not gate on one.
+   */
+  isSessionCompacting(agentSlug: string, sessionId: string): boolean {
+    const state = this.streamingStates.get(sessionKeyOf(agentSlug, sessionId))
+    return !!state && state.isActive && state.isCompacting
+  }
+
+  /**
+   * End a compaction the summary will never close (the turn was stopped or
+   * its process replaced). Connected clients only reset on compact_complete
+   * or a turn boundary, so tell them when no boundary frame follows.
+   */
+  private abandonCompaction(agentSlug: string, sessionId: string, state: StreamingState): void {
+    if (!state.isCompacting) return
+    state.isCompacting = false
+    this.broadcastToSSE(agentSlug, sessionId, { type: 'compact_complete' })
   }
 
   /**
@@ -1540,6 +1566,9 @@ class MessagePersister {
       state.isInterrupted = true
       state.isStreaming = false
       state.isAwaitingInput = false
+      // The stopped turn's compaction died with it; the client clears its own
+      // flag off the idle / waiting-background frame below.
+      state.isCompacting = false
       state.lastResultCleanSuccess = false
       state.currentText = ''
       state.currentToolUse = null
@@ -2670,6 +2699,9 @@ class MessagePersister {
             this.resetSessionCompleteResponse(state)
             state.queuedTurnCount = 0
             state.resetAssistantBeforeNextTurnOutput = false
+            // Turn-scoped, like markSessionActive: the client resets it off
+            // the session_active frame below.
+            state.isCompacting = false
             // Preserve the prior result guard. Some runtimes emit a stray
             // running → idle pair without another result; clearing the guard
             // here would leave isActive stuck until disconnect. The response
@@ -2781,6 +2813,8 @@ class MessagePersister {
           this.containerClients.get(sessionKeyOf(agentSlug, sessionId))?.onFatalResult('oom_sigkill') === 'defer_for_recovery'
         ) {
           this.recordLastFatal(state.agentSlug, 'oom_sigkill')
+          // The dead process's compaction ends here, not when recovery lands.
+          this.abandonCompaction(agentSlug, sessionId, state)
           this.onUnexpectedDeathRequested?.(state.agentSlug)
           break
         }
@@ -2794,11 +2828,16 @@ class MessagePersister {
           // markSessionInterrupted settles the session if the process was in
           // fact replaced, and process_restarted drops the tasks otherwise.
           state.isAwaitingInput = false
+          this.abandonCompaction(agentSlug, sessionId, state)
         } else if (state.stateEventsAuthority || this.openBackgroundWorkCount(state) > 0) {
           this.syncSessionAwaiting(agentSlug, sessionId)
         } else {
           state.isAwaitingInput = false // finalizeIdle below settles the turn
         }
+        // The compact summary always precedes the result, so a compaction
+        // cannot outlive its turn. A summary missed across a container
+        // reattach would otherwise leave the flag set until the next turn.
+        state.isCompacting = false
         state.currentText = ''
         state.lastResultSubtype = typeof content.subtype === 'string' ? content.subtype : null
 
@@ -3346,6 +3385,8 @@ class MessagePersister {
       this.clearBackgroundTask(agentSlug, sessionId, state, taskId)
     }
     state.bgTasksSnapshot = null
+    // A compaction in flight died with the process too.
+    this.abandonCompaction(agentSlug, sessionId, state)
   }
 
   private clearBackgroundTask(agentSlug: string, sessionId: string, state: StreamingState, taskId: string): boolean {

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -2435,8 +2435,9 @@ class MessagePersister {
           state.isCompacting = false
           // Compaction complete — broadcast so frontend transitions from spinner to boundary
           this.broadcastToSSE(agentSlug, sessionId, { type: 'compact_complete' })
-          this.broadcastToSSE(agentSlug, sessionId, { type: 'messages_updated' })
-          break
+          // No early exit: a summary missed across a transport reattach leaves
+          // the flag set, so the frame that clears it can be a tool result that
+          // still has to settle its request below.
         }
         // Tool results come as 'user' type messages. handleToolResults settles
         // each answered request in the registry and recomputes awaiting from
@@ -2828,7 +2829,6 @@ class MessagePersister {
           // markSessionInterrupted settles the session if the process was in
           // fact replaced, and process_restarted drops the tasks otherwise.
           state.isAwaitingInput = false
-          this.abandonCompaction(agentSlug, sessionId, state)
         } else if (state.stateEventsAuthority || this.openBackgroundWorkCount(state) > 0) {
           this.syncSessionAwaiting(agentSlug, sessionId)
         } else {
@@ -2836,8 +2836,10 @@ class MessagePersister {
         }
         // The compact summary always precedes the result, so a compaction
         // cannot outlive its turn. A summary missed across a container
-        // reattach would otherwise leave the flag set until the next turn.
-        state.isCompacting = false
+        // reattach would otherwise leave the flag set until the next turn,
+        // and the result paths with no idle frame after them (a graceful
+        // interrupt, a runtime-authority success) need the broadcast.
+        this.abandonCompaction(agentSlug, sessionId, state)
         state.currentText = ''
         state.lastResultSubtype = typeof content.subtype === 'string' ? content.subtype : null
 

--- a/src/shared/lib/container/mock-container-client.ts
+++ b/src/shared/lib/container/mock-container-client.ts
@@ -538,8 +538,8 @@ export class SlowCompactionScenario implements MockScenario {
 
     // Well clear of the echo above (the persister ends compaction at the first
     // user message that FOLLOWS the compacting status) and of any subscribe
-    // hand-off: compact_start is one-shot, so a client that is not listening
-    // yet never learns compaction began.
+    // hand-off. compact_start is one-shot; a client that opens its stream
+    // later learns the state from the connected snapshot instead.
     setTimeout(() => {
       client.emitStreamMessage(sessionId, {
         type: 'system',


### PR DESCRIPTION
A session stream that opens after compaction has started shows "Working" until the summary lands, and one that misses the finish keeps a spinner until the next turn, because `compact_start` and `compact_complete` are one-shot broadcasts and nothing else told a late-joining client where the session stood. The stream's connected snapshot and keep-alive ping now carry `isCompacting`, the client takes its value from them, and the server keeps that flag honest across the turn's lifecycle instead of only at the next turn start. Found while building the fork-and-compact flow in #1044, which opens a fresh copy and compacts it: the copy's stream connects after the compaction begins.

Closes https://linear.app/datawizz/issue/SUP-822/late-joining-session-streams-do-not-learn-compaction-state
Related to https://linear.app/datawizz/issue/SUP-793/stale-notice-continue-in-a-compacted-fork-fork-compact

Footprint: production +75 / -35 across 4 files, tests +328 / -69 across 5.

```
stream opens
  → connected { isActive, isCompacting, ... }   ← was missing isCompacting
  → every 30s ping { isActive, isCompacting }    ← same
client
  → snapshot value wins. An older host that omits it falls back to the local
    value while the turn runs, and clears it once the turn's output ended
```

- Server: `isSessionCompacting` reads the persister's flag only while the session is active. A stop, a turn result, a replaced process and a runtime-started turn reset it. A transport reattach to the same live turn keeps it. The two paths that end a compaction with no idle frame following (a soft stop that spares background work, a replaced process) broadcast `compact_complete` so open tabs drop their indicator too.
- Client: the ping corrects a missed `compact_start` or `compact_complete` within one interval, and a finished compaction invalidates the transcript so its boundary shows.
- A tool result that follows a summary missed across a reattach still reaches the tool-result handler: the compact-summary branch clears the flag and falls through instead of exiting early.
- The message list's boundary-count safety net is removed. Its baseline started at zero, so a page opened mid-compaction cleared the snapshot's value the moment a transcript with earlier boundaries loaded. The ping covers the missed-frame case it existed for, with fewer lines.

A mock-runtime e2e reloads the page mid-compaction and expects the indicator to read "Compacting" from the snapshot. Live smoke against the staging Platform: reload 0.3s into a real compaction shows "Compacting..." on the fresh stream, then the boundary lands.

No UI change beyond the indicator showing "Compacting..." where it showed "Working".
