### PR TITLE
fix(computer-use): 12 MB Windows daemon, per-arch packaging, loud CI on oversize/R2 failure, working computer_run

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -82,6 +82,24 @@ jobs:
           PLATFORM_AUTH_ISSUER_URL: ${{ secrets.PLATFORM_AUTH_ISSUER_URL }}
         run: npm run dist:mac
 
+      - name: Enforce release artifact size limit
+        shell: bash
+        run: |
+          # Same cap the release workflow enforces: Cloudflare R2 (wrangler)
+          # rejects single objects over 300 MiB. Catch it on the PR.
+          limit=$((280 * 1024 * 1024))
+          bad=0
+          for f in release/*.exe release/*.dmg release/*.zip; do
+            [ -e "$f" ] || continue
+            size=$(wc -c < "$f")
+            printf '%6d MiB  %s\n' "$((size / 1048576))" "$(basename "$f")"
+            if [ "$size" -gt "$limit" ]; then
+              echo "::error file=$f::$(basename "$f") is $((size / 1048576)) MiB, over the 280 MiB release-artifact limit (R2 upload cap is 300 MiB)"
+              bad=1
+            fi
+          done
+          [ "$bad" -eq 0 ] || exit 1
+
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -40,6 +40,24 @@ jobs:
           AZURE_CODE_SIGNING_PUBLISHER: ${{ secrets.AZURE_CODE_SIGNING_PUBLISHER }}
         run: npm run dist:win
 
+      - name: Enforce release artifact size limit
+        shell: bash
+        run: |
+          # Same cap the release workflow enforces: Cloudflare R2 (wrangler)
+          # rejects single objects over 300 MiB. Catch it on the PR.
+          limit=$((280 * 1024 * 1024))
+          bad=0
+          for f in release/*.exe release/*.dmg release/*.zip; do
+            [ -e "$f" ] || continue
+            size=$(wc -c < "$f")
+            printf '%6d MiB  %s\n' "$((size / 1048576))" "$(basename "$f")"
+            if [ "$size" -gt "$limit" ]; then
+              echo "::error file=$f::$(basename "$f") is $((size / 1048576)) MiB, over the 280 MiB release-artifact limit (R2 upload cap is 300 MiB)"
+              bad=1
+            fi
+          done
+          [ "$bad" -eq 0 ] || exit 1
+
       - name: Upload Windows Installer
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,6 +244,25 @@ jobs:
           PLATFORM_AUTH_ISSUER_URL: ${{ secrets.PLATFORM_AUTH_ISSUER_URL }}
         run: npm run dist:mac
 
+      - name: Enforce release artifact size limit
+        shell: bash
+        run: |
+          # Wrangler (Cloudflare R2 feed upload) rejects single objects over
+          # 300 MiB. Fail here, in the build job, rather than discovering it
+          # after the GitHub release is already published.
+          limit=$((280 * 1024 * 1024))
+          bad=0
+          for f in release/*.exe release/*.dmg release/*.zip; do
+            [ -e "$f" ] || continue
+            size=$(wc -c < "$f")
+            printf '%6d MiB  %s\n' "$((size / 1048576))" "$(basename "$f")"
+            if [ "$size" -gt "$limit" ]; then
+              echo "::error file=$f::$(basename "$f") is $((size / 1048576)) MiB, over the 280 MiB release-artifact limit (R2 upload cap is 300 MiB)"
+              bad=1
+            fi
+          done
+          [ "$bad" -eq 0 ] || exit 1
+
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -309,6 +328,25 @@ jobs:
           AZURE_CODE_SIGNING_PUBLISHER: ${{ secrets.AZURE_CODE_SIGNING_PUBLISHER }}
         run: npm run dist:win
 
+      - name: Enforce release artifact size limit
+        shell: bash
+        run: |
+          # Wrangler (Cloudflare R2 feed upload) rejects single objects over
+          # 300 MiB. Fail here, in the build job, rather than discovering it
+          # after the GitHub release is already published.
+          limit=$((280 * 1024 * 1024))
+          bad=0
+          for f in release/*.exe release/*.dmg release/*.zip; do
+            [ -e "$f" ] || continue
+            size=$(wc -c < "$f")
+            printf '%6d MiB  %s\n' "$((size / 1048576))" "$(basename "$f")"
+            if [ "$size" -gt "$limit" ]; then
+              echo "::error file=$f::$(basename "$f") is $((size / 1048576)) MiB, over the 280 MiB release-artifact limit (R2 upload cap is 300 MiB)"
+              bad=1
+            fi
+          done
+          [ "$bad" -eq 0 ] || exit 1
+
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -364,26 +402,56 @@ jobs:
         run: gh release edit "$GITHUB_REF_NAME" --draft=false --repo "$GITHUB_REPOSITORY"
 
       # Dual-publish bridge (SUP-286): populate the owned R2 feed
-      # (updates.gamutagents.com) AFTER the GitHub release is published, so a
-      # transient R2 hiccup can never block the primary (GitHub) feed during the
-      # bridge. continue-on-error keeps a failed upload from failing the release —
-      # generic-feed builds update from R2; pre-generic clients keep updating from
-      # GitHub until the cutover subtask (SUP-287) retires the GitHub feed. Skipped
-      # if the Cloudflare credentials aren't configured. Uses the same
-      # CLOUDFLARE_API_TOKEN as the gamut-releases Worker deploy — no separate R2
-      # S3 keys to manage.
+      # (updates.gamutagents.com) AFTER the GitHub release is published, so an
+      # R2 failure can never block the primary (GitHub) feed during the bridge.
+      # It DOES fail this job: from 0.5.21 to 0.5.22 the Windows installer was
+      # over wrangler's 300 MiB cap, the loop died on its first file, nothing
+      # (not even latest.yml) reached R2, and continue-on-error hid it — the
+      # generic feed silently stopped updating. Binaries go first and the feed
+      # metadata (latest*.yml) last, so R2 never advertises a version whose
+      # binaries are missing. Skipped if the Cloudflare credentials aren't
+      # configured. Uses the same CLOUDFLARE_API_TOKEN as the gamut-releases
+      # Worker deploy — no separate R2 S3 keys to manage.
       - name: Upload release feed to Cloudflare R2
         if: ${{ env.CLOUDFLARE_ACCOUNT_ID != '' }}
-        continue-on-error: true
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           shopt -s nullglob
+          failed=()
+          binaries=()
+          feeds=()
           for f in ./release-artifacts/*; do
             name="$(basename "$f")"
             # builder-debug.yml is electron-builder's debug dump, not a feed file.
             [ "$name" = "builder-debug.yml" ] && continue
-            echo "→ R2: $name"
-            npx --yes wrangler@4 r2 object put "gamut-releases/$name" --file "$f" --remote
+            case "$name" in
+              *.yml|*.yaml) feeds+=("$f") ;;
+              *)            binaries+=("$f") ;;
+            esac
           done
+
+          upload() {
+            local f="$1" name
+            name="$(basename "$f")"
+            echo "→ R2: $name ($(( $(wc -c < "$f") / 1048576 )) MiB)"
+            if ! npx --yes wrangler@4 r2 object put "gamut-releases/$name" --file "$f" --remote; then
+              echo "::error::R2 upload failed for $name"
+              failed+=("$name")
+            fi
+          }
+
+          for f in "${binaries[@]}"; do upload "$f"; done
+
+          if [ "${#failed[@]}" -ne 0 ]; then
+            echo "::error::Not uploading feed metadata: ${#failed[@]} binary upload(s) failed (${failed[*]}). The R2 feed still points at the previous version."
+            exit 1
+          fi
+
+          for f in "${feeds[@]}"; do upload "$f"; done
+
+          if [ "${#failed[@]}" -ne 0 ]; then
+            echo "::error::Feed metadata upload failed (${failed[*]}); clients on the R2 feed will not see this release."
+            exit 1
+          fi

--- a/agent-container/src/computer-use-agent-prompt.md
+++ b/agent-container/src/computer-use-agent-prompt.md
@@ -32,8 +32,9 @@ You are a desktop automation agent. You receive high-level objectives and accomp
   - `computer_run("read", { ref: "@t1" })` — Read an element's value
   - `computer_run("hover", { ref: "@b1" })` — Hover over an element
   - `computer_run("drag", { from: "@b1", to: "@b2" })` — Drag between elements
-  - `computer_run("wait", { ms: 2000 })` — Wait for a duration
-  - `computer_run("clipboard")` — Read clipboard contents
+  - `computer_run("wait", { text: "Done", timeout: 5000 })` — Wait until text appears
+  - `computer_run("clipboard_read")` — Read clipboard contents
+  - `computer_run("clipboard_set", { text: "hello" })` — Set clipboard contents
 
 ## Core Workflow
 1. `computer_grab` and `computer_launch` automatically return an accessibility snapshot — read it to understand the current UI state

--- a/agent-container/src/tools/computer-use.ts
+++ b/agent-container/src/tools/computer-use.ts
@@ -309,11 +309,12 @@ export const computerRunTool = tool(
   `Run an arbitrary agent-computer (ac) command. Use this for advanced operations not covered by the specific tools above. The command is the ac method name and args is a JSON object of parameters.
 
 Examples:
-- method: "read", args: { ref: "@t1" } — read an element's value
-- method: "hover", args: { ref: "@b1" } — hover over an element
-- method: "drag", args: { from: "@b1", to: "@b2" } — drag between elements
-- method: "wait", args: { ms: 2000 } — wait 2 seconds
-- method: "clipboard", args: {} — read clipboard contents`,
+- command: "read", args: { ref: "@t1" } — read an element's value
+- command: "hover", args: { ref: "@b1" } — hover over an element
+- command: "drag", args: { from: "@b1", to: "@b2" } — drag between elements
+- command: "wait", args: { text: "Done", timeout: 5000 } — wait until text appears
+- command: "clipboard_read", args: {} — read clipboard contents
+- command: "clipboard_set", args: { text: "hello" } — set clipboard contents`,
   {
     command: z.string().describe('The ac method name to execute'),
     args: z.record(z.string(), z.unknown()).optional().describe('Arguments to pass to the method'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@hono/node-server": "^1.13.7",
         "@hono/zod-validator": "^0.8.0",
         "@sentry/node": "^10.48.0",
-        "@skillful-agents/agent-computer": "^0.0.12",
+        "@skillful-agents/agent-computer": "^0.0.13",
         "@slack/bolt": "^4.7.0",
         "archiver": "^7.0.1",
         "better-sqlite3": "^12.8.0",
@@ -8535,9 +8535,9 @@
       }
     },
     "node_modules/@skillful-agents/agent-computer": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@skillful-agents/agent-computer/-/agent-computer-0.0.12.tgz",
-      "integrity": "sha512-PGO99lgcc/FS3njpdfB34TmbzEhFJYDa6E2uoN/IrwzKq40U/kl3Dw2LQ1PeOR32NgcuO1Vp+CXhOhripYaRRQ==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@skillful-agents/agent-computer/-/agent-computer-0.0.13.tgz",
+      "integrity": "sha512-vwbl+iLb7HtzRh6+D+mEL5RcqSPIcdjUT5audBrTMj8n6Xe7x1bkJ0CWiTFcBxCFPiRqm19WhLFcig7rSeGUuQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -297,7 +297,10 @@
             ]
           }
         ]
-      }
+      },
+      "files": [
+        "!node_modules/@skillful-agents/agent-computer/bin/ac-core-win32-*"
+      ]
     },
     "win": {
       "target": [
@@ -377,7 +380,11 @@
         "certificateProfileName": "gamut-windows",
         "codeSigningAccountName": "Gamut",
         "publisherName": "Datawizz Inc."
-      }
+      },
+      "files": [
+        "!node_modules/@skillful-agents/agent-computer/bin/ac-core-darwin-*",
+        "!node_modules/@skillful-agents/agent-computer/bin/ac-core-win32-!(${arch}).exe"
+      ]
     },
     "nsis": {
       "oneClick": false,

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@hono/node-server": "^1.13.7",
     "@hono/zod-validator": "^0.8.0",
     "@sentry/node": "^10.48.0",
-    "@skillful-agents/agent-computer": "^0.0.12",
+    "@skillful-agents/agent-computer": "^0.0.13",
     "@slack/bolt": "^4.7.0",
     "archiver": "^7.0.1",
     "better-sqlite3": "^12.8.0",

--- a/src/shared/lib/computer-use/executor.test.ts
+++ b/src/shared/lib/computer-use/executor.test.ts
@@ -27,6 +27,7 @@ const mockAC = {
   dialogAccept: vi.fn(),
   dialogCancel: vi.fn(),
   shutdown: vi.fn(),
+  bridgeSend: vi.fn(),
 }
 
 vi.mock('@skillful-agents/agent-computer', () => ({
@@ -56,6 +57,9 @@ vi.mock('@skillful-agents/agent-computer', () => ({
     dialogAccept = mockAC.dialogAccept
     dialogCancel = mockAC.dialogCancel
     shutdown = mockAC.shutdown
+    // The real AC keeps its JSON-RPC bridge as a private field; the executor
+    // reaches it for methods the SDK has no wrapper for.
+    bridge = { send: mockAC.bridgeSend }
   },
   formatOutput: vi.fn((val: unknown) => JSON.stringify(val)),
 }))
@@ -138,8 +142,38 @@ describe('executeComputerUseCommand', () => {
       await expect(executeComputerUseCommand('click', { ref: '@b1' })).rejects.toThrow('Element not found')
     })
 
-    it('throws for unknown method', async () => {
-      await expect(executeComputerUseCommand('nonexistent', {})).rejects.toThrow('Unknown computer use method')
+    it('rejects a method name that cannot be a daemon method instead of forwarding it', async () => {
+      await expect(executeComputerUseCommand('Not a method!', {})).rejects.toThrow('Unknown computer use method')
+      expect(mockAC.bridgeSend).not.toHaveBeenCalled()
+    })
+
+    it('rejects a computer_run without a command', async () => {
+      await expect(executeComputerUseCommand('run', {})).rejects.toThrow('Unknown computer use method: run')
+      expect(mockAC.bridgeSend).not.toHaveBeenCalled()
+    })
+  })
+
+  // ─── Escape hatch: methods the SDK has no wrapper for ─────────────
+
+  describe('raw daemon methods', () => {
+    it('forwards a method without an SDK wrapper straight to the bridge', async () => {
+      mockAC.bridgeSend.mockResolvedValue({ ok: true, text: 'clip' })
+      const result = await executeComputerUseCommand('clipboard_read', {})
+      expect(mockAC.bridgeSend).toHaveBeenCalledWith('clipboard_read', {})
+      expect(result).toContain('clip')
+    })
+
+    it('unwraps computer_run into the inner command before dispatch', async () => {
+      mockAC.bridgeSend.mockResolvedValue({ ok: true })
+      await executeComputerUseCommand('run', { command: 'drag', args: { from: '@b1', to: '@b2' } })
+      expect(mockAC.bridgeSend).toHaveBeenCalledWith('drag', { from: '@b1', to: '@b2' })
+    })
+
+    it('routes an unwrapped computer_run to the SDK wrapper when one exists', async () => {
+      mockAC.windows.mockResolvedValue({ windows: [] })
+      await executeComputerUseCommand('run', { command: 'windows' })
+      expect(mockAC.windows).toHaveBeenCalled()
+      expect(mockAC.bridgeSend).not.toHaveBeenCalled()
     })
   })
 

--- a/src/shared/lib/computer-use/executor.ts
+++ b/src/shared/lib/computer-use/executor.ts
@@ -6,6 +6,7 @@
  */
 
 import { AC, formatOutput } from '@skillful-agents/agent-computer'
+import { COMPUTER_RUN_METHOD, unwrapComputerRun } from './types'
 import * as fs from 'fs'
 import { createRequire } from 'module'
 import * as path from 'path'
@@ -44,9 +45,25 @@ export async function executeComputerUseCommand(
   method: string,
   params: Record<string, unknown>,
 ): Promise<string> {
+  // Requests are normally unwrapped when they arrive from the container, but
+  // this is the last stop for every path, so be safe here too.
+  ;({ method, params } = unwrapComputerRun(method, params))
   const ac = getAC()
   const result = await dispatchMethod(ac, method, params)
   return formatResult(method, result)
+}
+
+/**
+ * The SDK keeps its JSON-RPC bridge private, but the daemon understands far
+ * more methods than the SDK wraps (clipboard_read, drag, wait, box, children,
+ * ...). The container's `computer_run` escape hatch exists precisely to reach
+ * those, so forward anything without a wrapper straight to the bridge.
+ */
+type RawBridge = { send(method: string, params?: Record<string, unknown>): Promise<unknown> }
+
+function rawBridge(ac: AC): RawBridge | undefined {
+  const bridge = (ac as unknown as { bridge?: unknown }).bridge
+  return bridge && typeof (bridge as RawBridge).send === 'function' ? (bridge as RawBridge) : undefined
 }
 
 /**
@@ -213,8 +230,15 @@ async function dispatchMethod(
       }
     }
 
-    default:
-      throw new Error(`Unknown computer use method: ${method}`)
+    default: {
+      const bridge = rawBridge(ac)
+      // `run` is the escape hatch itself; reaching here means it carried no
+      // usable `command`, and it is never a daemon method.
+      if (!bridge || method === COMPUTER_RUN_METHOD || !/^[a-z][a-z0-9_]*$/.test(method)) {
+        throw new Error(`Unknown computer use method: ${method}`)
+      }
+      return bridge.send(method, params)
+    }
   }
 }
 

--- a/src/shared/lib/computer-use/types.test.ts
+++ b/src/shared/lib/computer-use/types.test.ts
@@ -2,9 +2,49 @@ import { describe, it, expect } from 'vitest'
 import {
   getRequiredPermissionLevel,
   resolveTargetApp,
+  unwrapComputerRun,
   READ_ONLY_METHODS,
   TIMED_GRANT_DURATION_MS,
 } from './types'
+
+describe('unwrapComputerRun', () => {
+  it('passes ordinary methods through untouched', () => {
+    const params = { ref: '@b1' }
+    expect(unwrapComputerRun('click', params)).toEqual({ method: 'click', params })
+  })
+
+  it('unwraps computer_run into the inner command and args', () => {
+    expect(unwrapComputerRun('run', { command: 'clipboard_read', args: {} }))
+      .toEqual({ method: 'clipboard_read', params: {} })
+    expect(unwrapComputerRun('run', { command: 'drag', args: { from: '@b1', to: '@b2' } }))
+      .toEqual({ method: 'drag', params: { from: '@b1', to: '@b2' } })
+  })
+
+  it('defaults missing or malformed args to an empty object', () => {
+    expect(unwrapComputerRun('run', { command: 'clipboard_read' }).params).toEqual({})
+    expect(unwrapComputerRun('run', { command: 'clipboard_read', args: ['x'] }).params).toEqual({})
+    expect(unwrapComputerRun('run', { command: 'clipboard_read', args: 'x' }).params).toEqual({})
+  })
+
+  it('applies the tool-name aliases so run("menu") reaches the SDK wrapper', () => {
+    expect(unwrapComputerRun('run', { command: 'menu', args: { path: 'File > Save' } }).method).toBe('menuClick')
+  })
+
+  it('trims the command', () => {
+    expect(unwrapComputerRun('run', { command: '  windows ' }).method).toBe('windows')
+  })
+
+  it('leaves a run without a usable command alone so the executor can reject it', () => {
+    expect(unwrapComputerRun('run', {})).toEqual({ method: 'run', params: {} })
+    expect(unwrapComputerRun('run', { command: '' })).toEqual({ method: 'run', params: { command: '' } })
+    expect(unwrapComputerRun('run', { command: 42 })).toEqual({ method: 'run', params: { command: 42 } })
+  })
+
+  it('makes the unwrapped method drive the permission level', () => {
+    expect(getRequiredPermissionLevel(unwrapComputerRun('run', { command: 'windows' }).method)).toBe('list_apps_windows')
+    expect(getRequiredPermissionLevel(unwrapComputerRun('run', { command: 'clipboard_set' }).method)).toBe('use_application')
+  })
+})
 
 describe('getRequiredPermissionLevel', () => {
   it('returns list_apps_windows for all read-only methods', () => {

--- a/src/shared/lib/computer-use/types.ts
+++ b/src/shared/lib/computer-use/types.ts
@@ -87,6 +87,31 @@ export function computerUseMethodFromToolName(toolName: string): string {
   return COMPUTER_USE_METHODS[suffix] ?? suffix
 }
 
+/** Method name the container's `computer_run` escape-hatch tool arrives as. */
+export const COMPUTER_RUN_METHOD = 'run'
+
+/**
+ * `computer_run` wraps another daemon method: its input is
+ * `{ command: "<method>", args: { ...params } }`. Unwrap it so permission
+ * checks, the approval card and the executor all see the real method.
+ * Anything else passes through untouched. A `run` without a usable
+ * `command` is left as-is so the executor rejects it with a clear error.
+ */
+export function unwrapComputerRun(
+  method: string,
+  params: Record<string, unknown>,
+): { method: string; params: Record<string, unknown> } {
+  if (method !== COMPUTER_RUN_METHOD) return { method, params }
+  const command = params.command
+  if (typeof command !== 'string' || !command.trim()) return { method, params }
+  const inner = command.trim()
+  const args = params.args
+  const innerParams = args && typeof args === 'object' && !Array.isArray(args)
+    ? (args as Record<string, unknown>)
+    : {}
+  return { method: COMPUTER_USE_METHODS[inner] ?? inner, params: innerParams }
+}
+
 /** Duration of "timed" permission grants in milliseconds (15 minutes) */
 export const TIMED_GRANT_DURATION_MS = 15 * 60 * 1000
 

--- a/src/shared/lib/container/message-persister.test.ts
+++ b/src/shared/lib/container/message-persister.test.ts
@@ -109,6 +109,7 @@ vi.mock('@shared/lib/computer-use/types', () => ({
       : 'use_application'
   )),
   resolveTargetApp: vi.fn(() => undefined),
+  unwrapComputerRun: vi.fn((method: string, params: Record<string, unknown>) => ({ method, params })),
   READ_ONLY_METHODS: new Set(['apps', 'windows', 'status', 'displays', 'permissions']),
   TIMED_GRANT_DURATION_MS: 15 * 60 * 1000,
 }))

--- a/src/shared/lib/container/message-persister.ts
+++ b/src/shared/lib/container/message-persister.ts
@@ -92,7 +92,7 @@ import { sessionCapabilityGrantsResponseSchema } from '@shared/lib/config/capabi
 import { getActiveLlmProvider, getModelContextWindow } from '@shared/lib/llm-provider'
 import { computerUsePermissionManager } from '@shared/lib/computer-use/permission-manager'
 import { resolveAppFromWindowRef } from '@shared/lib/computer-use/executor'
-import { computerUseMethodFromToolName, getRequiredPermissionLevel, resolveTargetApp, type ComputerUsePermissionLevel } from '@shared/lib/computer-use/types'
+import { computerUseMethodFromToolName, getRequiredPermissionLevel, resolveTargetApp, unwrapComputerRun, type ComputerUsePermissionLevel } from '@shared/lib/computer-use/types'
 import { getAgentSessionsDir, getSessionJsonlPath } from '@shared/lib/utils/file-storage'
 import { makeThinkingBlockId } from '@shared/lib/utils/thinking-block-id'
 import { isSyntheticPlaceholderMessage } from '@shared/lib/utils/synthetic-message'
@@ -5724,7 +5724,7 @@ ${continuation}`
   ): Promise<void> {
     try {
       // Extract AC method from tool name: mcp__computer-use__computer_launch -> launch.
-      const method = computerUseMethodFromToolName(toolName)
+      let method = computerUseMethodFromToolName(toolName)
 
       // The toolInput is the raw MCP tool input (e.g., { name: "Calculator" } for computer_launch)
       // Empty input is valid for tools like screenshot, apps, ungrab that take no required params
@@ -5735,6 +5735,10 @@ ${continuation}`
         console.error('[MessagePersister] Failed to parse computer use request:', toolInput)
         return
       }
+
+      // computer_run("clipboard_read", {...}) is really a clipboard_read request:
+      // unwrap it so the permission level, approval card and executor see that.
+      ;({ method, params } = unwrapComputerRun(method, params))
 
       // Check platform support — computer use requires macOS or Windows (skip in E2E mock mode)
       if (process.env.E2E_MOCK !== 'true' && process.platform !== 'darwin' && process.platform !== 'win32') {


### PR DESCRIPTION
## Summary

agent-computer 0.0.12 fixed Windows computer use but shipped two 70 MB daemons. That pushed the Windows installer from 243 MiB to 492 MiB, past wrangler's 300 MiB cap, and the Cloudflare R2 feed (updates.gamutagents.com) has silently received nothing since 0.5.21 because the upload step was `continue-on-error`. This PR fixes the size at the source, ships only the binary each installer can run, makes CI fail loudly on both conditions, and repairs the `computer_run` escape hatch that has never worked.

## Changes

- **Bump `@skillful-agents/agent-computer` to 0.0.13** ([release](https://github.com/SkillfulAgents/agent-computer/releases/tag/v0.0.13)). The Windows daemon no longer references WPF/WinForms: UI Automation goes through the UIAutomationCore COM API behind a thin shim, screens/clipboard/halo overlay are Win32, and the publish is trimmed. 11.8 MB arm64 / 11.3 MB x64 instead of 70 MB each, with a 20 MB budget enforced upstream. It also registers the cross-platform method names (`clipboard_read/set/copy`, `menu_list`, `menu_click`, `dialog_accept/cancel/file`) the Windows daemon had been missing, and can list Windows 11 (WinUI) menus.
- **Per-arch packaging** (`mac.files` / `win.files`): electron-builder applies `files` exclusions to node_modules with `${arch}` expansion, so each Windows installer carries only its own arch's exe and macOS builds carry no Windows exes. Verified with a `--dir` arm64 pack.
- **CI fails loudly**:
  - `build-mac` / `build-win` (release and PR workflows) fail if any installer/dmg/zip exceeds 280 MiB.
  - The R2 feed step no longer continues on error. Binaries upload first; if any fails the feed metadata (`latest*.yml`) is not uploaded, so R2 never advertises a version whose files are missing, and the job fails listing the failures. The GitHub release is already published by then. Dry-run with a stub wrangler for failing-binary, failing-feed and happy paths.
- **`computer_run` works**: the container's catch-all tool arrived at the host as method `run`, which was never dispatched. It is now unwrapped into the inner command on arrival (permission level follows the real method), and the executor forwards methods the SDK has no wrapper for to the daemon over its bridge. Prompt/tool examples now name real daemon methods.

## Verification

- Packaged Gamut on Windows 11 arm64 with the 0.0.13 binary: agent `computer_windows` request approved through `/computer-use`, Gamut spawned the 12 MB daemon (32 MB RSS) and the agent got the window list.
- Daemon CLI against Notepad: launch, windows, grab (halo visible), snapshot, find, click, type, read, screenshot, clipboard set/read, menu list/click, Page Setup dialog detect + cancel, displays. 25 Chrome snapshots: 62 → 66 MB RSS, no leak. x64 exe verified under Windows-on-ARM emulation.
- `npm run typecheck`, `npm run lint` clean (warnings pre-existing). Computer-use unit tests: 144/144. `message-persister.test.ts` and `agents.test.ts` show only failures that exist identically on a clean `main` (script_run and uploads/symlink tests).

## Notes

- The `.npmrc` 7-day `min-release-age` cooldown was overridden for the one install of our own freshly published package; `npm ci` installs from the lockfile without re-resolving.
- Pre-existing, unrelated: `agent-container` `tsc --noEmit` fails locally on missing `mustache` types.

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B78e6gDbuk6m3XFsBN8bUD
